### PR TITLE
修复：在第 5 步中，优先使用可见的年龄输入框，而非隐藏的生日字段

### DIFF
--- a/content/signup-page.js
+++ b/content/signup-page.js
@@ -1013,19 +1013,50 @@ async function step5_fillNameBirthday(payload) {
 
   let birthdayMode = false;
   let ageInput = null;
+  let yearSpinner = null;
+  let monthSpinner = null;
+  let daySpinner = null;
+  let hiddenBirthday = null;
+  let yearReactSelect = null;
+  let monthReactSelect = null;
+  let dayReactSelect = null;
+  let visibleAgeInput = false;
+  let visibleBirthdaySpinners = false;
+  let visibleBirthdaySelects = false;
 
   for (let i = 0; i < 100; i++) {
-    const yearSpinner = document.querySelector('[role="spinbutton"][data-type="year"]');
-    const monthSpinner = document.querySelector('[role="spinbutton"][data-type="month"]');
-    const daySpinner = document.querySelector('[role="spinbutton"][data-type="day"]');
-    const hiddenBirthday = document.querySelector('input[name="birthday"]');
+    yearSpinner = document.querySelector('[role="spinbutton"][data-type="year"]');
+    monthSpinner = document.querySelector('[role="spinbutton"][data-type="month"]');
+    daySpinner = document.querySelector('[role="spinbutton"][data-type="day"]');
+    hiddenBirthday = document.querySelector('input[name="birthday"]');
     ageInput = document.querySelector('input[name="age"]');
+    yearReactSelect = findBirthdayReactAriaSelect('年');
+    monthReactSelect = findBirthdayReactAriaSelect('月');
+    dayReactSelect = findBirthdayReactAriaSelect('天');
 
-    if ((yearSpinner && monthSpinner && daySpinner) || hiddenBirthday) {
+    visibleAgeInput = Boolean(ageInput && isVisibleElement(ageInput));
+    visibleBirthdaySpinners = Boolean(
+      yearSpinner
+      && monthSpinner
+      && daySpinner
+      && isVisibleElement(yearSpinner)
+      && isVisibleElement(monthSpinner)
+      && isVisibleElement(daySpinner)
+    );
+    visibleBirthdaySelects = Boolean(
+      yearReactSelect?.button
+      && monthReactSelect?.button
+      && dayReactSelect?.button
+      && isVisibleElement(yearReactSelect.button)
+      && isVisibleElement(monthReactSelect.button)
+      && isVisibleElement(dayReactSelect.button)
+    );
+
+    if (visibleAgeInput) break;
+    if (visibleBirthdaySpinners || visibleBirthdaySelects) {
       birthdayMode = true;
       break;
     }
-    if (ageInput) break;
     await sleep(100);
   }
 


### PR DESCRIPTION
  ## Summary
  - fix Step 5 field detection to prefer visible `input[name="age"]`
  - stop treating hidden `input[name="birthday"]` as a birthday-mode signal
  - preserve birthday-mode handling for visible birthday controls

  ## Problem
  On some pages, a visible age input and a hidden birthday input coexist.

  The previous logic treated the hidden `input[name="birthday"]` as evidence of birthday mode, which caused Step 5 to
  fill birthday instead of age.

  ## Verification
  - reproduced on a page where `input[name="age"]` is visible
  - confirmed `input[name="birthday"]` exists but is hidden
  - verified Step 5 now enters the age branch and fills the age input correctly