### PR TITLE
[codex] fix(mail): support 163 mail subdomains

### DIFF
--- a/background.js
+++ b/background.js
@@ -249,7 +249,7 @@ function matchesSourceUrlFamily(source, candidateUrl, referenceUrl) {
     case 'qq-mail':
       return candidate.hostname === 'mail.qq.com' || candidate.hostname === 'wx.mail.qq.com';
     case 'mail-163':
-      return candidate.hostname === 'mail.163.com';
+      return candidate.hostname === 'mail.163.com' || candidate.hostname.endsWith('.mail.163.com');
     case 'inbucket-mail':
       return Boolean(reference)
         && candidate.origin === reference.origin

--- a/manifest.json
+++ b/manifest.json
@@ -42,7 +42,8 @@
     },
     {
       "matches": [
-        "https://mail.163.com/*"
+        "https://mail.163.com/*",
+        "https://*.mail.163.com/*"
       ],
       "js": ["content/utils.js", "content/mail-163.js"],
       "all_frames": true,


### PR DESCRIPTION
## Summary

- support 163 mail subdomains for content script injection
- allow background mail source matching for *.mail.163.com hosts

## Root Cause

163 Mail may redirect authenticated sessions to subdomains such as `hw.mail.163.com`.
The previous implementation only matched `mail.163.com`, so `content/mail-163.js` was not injected on the redirected page and the background worker never received `CONTENT_SCRIPT_READY`.

## Validation

- manually verified the 163 mail flow after reloading the extension
- `node -e "JSON.parse(require(""fs"").readFileSync(""manifest.json"",""utf8"")); console.log(""manifest ok"")"`
- `git diff --check`
