### PR TITLE
feat: add 163 VIP webmail provider support

### DIFF
--- a/background.js
+++ b/background.js
@@ -223,6 +223,12 @@ function isSignupPageHost(hostname = '') {
   return ['auth0.openai.com', 'auth.openai.com', 'accounts.openai.com'].includes(hostname);
 }
 
+function is163MailHost(hostname = '') {
+  return hostname === 'mail.163.com'
+    || hostname.endsWith('.mail.163.com')
+    || hostname === 'webmail.vip.163.com';
+}
+
 function buildLocalhostCleanupPrefix(rawUrl) {
   const parsed = parseUrlSafely(rawUrl);
   if (!parsed || parsed.hostname !== 'localhost') return '';
@@ -249,7 +255,7 @@ function matchesSourceUrlFamily(source, candidateUrl, referenceUrl) {
     case 'qq-mail':
       return candidate.hostname === 'mail.qq.com' || candidate.hostname === 'wx.mail.qq.com';
     case 'mail-163':
-      return candidate.hostname === 'mail.163.com' || candidate.hostname.endsWith('.mail.163.com');
+      return is163MailHost(candidate.hostname);
     case 'inbucket-mail':
       return Boolean(reference)
         && candidate.origin === reference.origin
@@ -1763,6 +1769,9 @@ function getMailConfig(state) {
   const provider = state.mailProvider || 'qq';
   if (provider === '163') {
     return { source: 'mail-163', url: 'https://mail.163.com/js6/main.jsp?df=mail163_letter#module=mbox.ListModule%7C%7B%22fid%22%3A1%2C%22order%22%3A%22date%22%2C%22desc%22%3Atrue%7D', label: '163 邮箱' };
+  }
+  if (provider === '163-vip') {
+    return { source: 'mail-163', url: 'https://webmail.vip.163.com/js6/main.jsp?df=mail163_letter#module=mbox.ListModule%7C%7B%22fid%22%3A1%2C%22order%22%3A%22date%22%2C%22desc%22%3Atrue%7D', label: '163 VIP 邮箱' };
   }
   if (provider === 'inbucket') {
     const host = normalizeInbucketOrigin(state.inbucketHost);

--- a/content/utils.js
+++ b/content/utils.js
@@ -3,9 +3,10 @@
 const SCRIPT_SOURCE = (() => {
   if (window.__MULTIPAGE_SOURCE) return window.__MULTIPAGE_SOURCE;
   const url = location.href;
+  const hostname = location.hostname;
   if (url.includes('auth0.openai.com') || url.includes('auth.openai.com') || url.includes('accounts.openai.com')) return 'signup-page';
-  if (url.includes('mail.qq.com')) return 'qq-mail';
-  if (url.includes('mail.163.com')) return 'mail-163';
+  if (hostname === 'mail.qq.com' || hostname === 'wx.mail.qq.com') return 'qq-mail';
+  if (hostname === 'mail.163.com' || hostname.endsWith('.mail.163.com') || hostname === 'webmail.vip.163.com') return 'mail-163';
   if (url.includes('duckduckgo.com/email/settings/autofill')) return 'duck-mail';
   if (url.includes('chatgpt.com')) return 'chatgpt';
   // VPS panel — detected dynamically since URL is configurable

--- a/manifest.json
+++ b/manifest.json
@@ -43,7 +43,8 @@
     {
       "matches": [
         "https://mail.163.com/*",
-        "https://*.mail.163.com/*"
+        "https://*.mail.163.com/*",
+        "https://webmail.vip.163.com/*"
       ],
       "js": ["content/utils.js", "content/mail-163.js"],
       "all_frames": true,

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -56,6 +56,7 @@
         <span class="data-label">邮箱服务</span>
         <select id="select-mail-provider" class="data-select">
           <option value="163">163 邮箱 (mail.163.com)</option>
+          <option value="163-vip">163 VIP 邮箱 (webmail.vip.163.com)</option>
           <option value="qq">QQ 邮箱 (wx.mail.qq.com)</option>
           <option value="inbucket">Inbucket（自定义主机）</option>
         </select>


### PR DESCRIPTION
  ## 背景
  当前扩展仅支持 `mail.163.com` 作为 163 邮箱入口。
  163 VIP 用户通常使用 `webmail.vip.163.com`，需要在侧边栏可直接选择并走验证码流程。

  ## 变更内容
  1. 侧边栏新增邮箱选项：`163 VIP 邮箱 (webmail.vip.163.com)`（`mailProvider=163-vip`）。
  2. `background.js` 新增 `163-vip` provider 配置，复用现有 `mail-163` 内容脚本逻辑。
  3. 扩展 163 邮箱域名匹配逻辑，纳入 `webmail.vip.163.com`，保证标签页复用与冲突清理正确。
  4. `content/utils.js` 新增 VIP 域名识别，映射到 `mail-163` 来源。
  5. `manifest.json` 的 `content_scripts.matches` 新增 `https://webmail.vip.163.com/*`。

  ## 兼容性与影响
  - 默认 provider 仍为 `163`，现有流程不变。
  - QQ / Inbucket 分支未改动。
  - 仅新增域名适配，不引入新权限模型或高风险改动。

  ## 验证
  - `node --check background.js` 通过。
  - `node --check content/utils.js` 通过。
  - `manifest.json` 解析通过。
  - 手动验证：侧边栏可选择 163 VIP；VIP 域名页面可注入并走取码流程。