### PR TITLE
修复hotmail跨域导致校验失败并已经跑通注册流程

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Step 1 和 Step 9 都依赖这个地址。
 - 点击 `校验`
 - 校验通过后，可点击 `测试收信`
 - Auto 模式每轮会自动选用一个可用账号
+- 当前版本会优先按 `/Users/yu/Developer/outlookEmail` 的刷新方式兼容导入的 `client_id + refresh_token`
 
 ### `Mailbox`
 

--- a/background.js
+++ b/background.js
@@ -40,8 +40,11 @@ const AUTO_RUN_ALARM_NAME = 'scheduled-auto-run';
 const AUTO_RUN_DELAY_MIN_MINUTES = 1;
 const AUTO_RUN_DELAY_MAX_MINUTES = 1440;
 const DEFAULT_LOCAL_CPA_STEP9_MODE = 'submit';
+const HOTMAIL_TOKEN_HEADER_RULE_ID = 91001;
 
 initializeSessionStorageAccess();
+
+let hotmailTokenHeaderRulePromise = null;
 
 // ============================================================
 // 状态管理（chrome.storage.session + chrome.storage.local）
@@ -750,30 +753,84 @@ function isHotmailAccessTokenUsable(account, now = Date.now()) {
     && Number(account?.expiresAt || 0) > now + 60_000;
 }
 
-async function refreshHotmailAccessToken(account) {
-  if (!account?.email) {
-    throw new Error('Hotmail 账号缺少邮箱地址。');
-  }
-  if (!account?.clientId) {
-    throw new Error(`Hotmail 账号 ${account.email || account.id} 缺少客户端 ID。`);
-  }
-  if (!account?.refreshToken) {
-    throw new Error(`Hotmail 账号 ${account.email || account.id} 缺少刷新令牌（refresh token）。`);
+async function installHotmailTokenHeaderRule() {
+  if (!chrome.declarativeNetRequest?.updateSessionRules) {
+    return false;
   }
 
-  const { timeoutMs, scopes, tokenUrl } = getHotmailGraphRequestConfig();
+  const tabIdNone = Number.isInteger(chrome.tabs?.TAB_ID_NONE)
+    ? chrome.tabs.TAB_ID_NONE
+    : -1;
+  const rule = {
+    id: HOTMAIL_TOKEN_HEADER_RULE_ID,
+    priority: 1,
+    action: {
+      type: 'modifyHeaders',
+      requestHeaders: [
+        {
+          header: 'origin',
+          operation: 'remove',
+        },
+      ],
+    },
+    condition: {
+      urlFilter: '||login.microsoftonline.com/',
+      requestMethods: ['post'],
+      resourceTypes: ['xmlhttprequest', 'other'],
+      tabIds: [tabIdNone],
+    },
+  };
+
+  try {
+    await chrome.declarativeNetRequest.updateSessionRules({
+      removeRuleIds: [HOTMAIL_TOKEN_HEADER_RULE_ID],
+      addRules: [rule],
+    });
+    return true;
+  } catch (error) {
+    console.warn(LOG_PREFIX, `Failed to install Hotmail token header rule: ${error?.message || error}`);
+    hotmailTokenHeaderRulePromise = null;
+    return false;
+  }
+}
+
+function ensureHotmailTokenHeaderRule() {
+  if (!hotmailTokenHeaderRulePromise) {
+    hotmailTokenHeaderRulePromise = installHotmailTokenHeaderRule();
+  }
+  return hotmailTokenHeaderRulePromise;
+}
+
+function isHotmailCrossOriginTokenError(rawErrorText) {
+  return typeof rawErrorText === 'string' && /AADSTS90023\d*/i.test(rawErrorText);
+}
+
+function extractHotmailTokenErrorText(payload, fallbackText) {
+  return payload?.error_description
+    || payload?.error?.message
+    || payload?.error
+    || payload?.message
+    || fallbackText;
+}
+
+async function requestHotmailTokenRefreshAttempt(account, attemptConfig, timeoutMs) {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(new Error('timeout')), timeoutMs);
   const formData = new URLSearchParams();
+
   formData.set('client_id', account.clientId);
   formData.set('grant_type', 'refresh_token');
   formData.set('refresh_token', account.refreshToken);
-  formData.set('scope', scopes.join(' '));
-  formData.set('redirect_uri', 'https://login.microsoftonline.com/common/oauth2/nativeclient');
+  if (attemptConfig.scope) {
+    formData.set('scope', attemptConfig.scope);
+  }
+  if (attemptConfig.redirectUri) {
+    formData.set('redirect_uri', attemptConfig.redirectUri);
+  }
 
   let response;
   try {
-    response = await fetch(tokenUrl, {
+    response = await fetch(attemptConfig.tokenUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
@@ -781,14 +838,6 @@ async function refreshHotmailAccessToken(account) {
       body: formData.toString(),
       signal: controller.signal,
     });
-  } catch (err) {
-    const error = new Error(
-      err?.name === 'AbortError'
-        ? `Hotmail 令牌刷新超时（>${Math.round(timeoutMs / 1000)} 秒）`
-        : `Hotmail 令牌刷新失败：${err.message}`
-    );
-    error.code = 'HOTMAIL_TOKEN_REFRESH_FAILED';
-    throw error;
   } finally {
     clearTimeout(timeoutId);
   }
@@ -801,27 +850,111 @@ async function refreshHotmailAccessToken(account) {
     payload = { raw: text };
   }
 
-  if (!response.ok || !payload?.access_token) {
-    const rawErrorText = payload?.error_description || payload?.error?.message || payload?.error || payload?.message || text || `HTTP ${response.status}`;
-    const isCrossOriginError = typeof rawErrorText === 'string' && rawErrorText.includes('AADSTS90023');
-    const errorText = isCrossOriginError
-      ? `Azure AD 拒绝了跨域令牌请求（AADSTS90023）。请在 Azure AD 应用注册中将应用平台改为"单页应用程序（SPA）"，并将重定向 URI 设置为 https://login.microsoftonline.com/common/oauth2/nativeclient，或将应用类型改为"移动和桌面应用程序（Native）"。`
-      : rawErrorText;
-    const error = new Error(`Hotmail 令牌刷新失败：${errorText}`);
+  return {
+    ok: response.ok && Boolean(payload?.access_token),
+    status: response.status,
+    payload,
+    text,
+  };
+}
+
+function buildHotmailRefreshFailureError(attemptFailures, timeoutMs) {
+  const crossOriginFailure = attemptFailures.find((failure) => isHotmailCrossOriginTokenError(failure.errorText));
+  if (crossOriginFailure) {
+    const error = new Error(
+      'Hotmail 令牌刷新失败：Azure AD 拒绝了浏览器发起的跨域令牌请求（AADSTS90023）。'
+      + ' 扩展已自动尝试兼容 `outlookEmail` 项目的刷新方式，但当前 client ID 仍未放行。'
+      + ' 请优先确认 Azure 应用注册已开启 SPA 或公共客户端能力；如果你刚更新了扩展，请重新加载扩展后再校验。'
+    );
     error.code = 'HOTMAIL_TOKEN_REFRESH_FAILED';
-    throw error;
+    return error;
   }
 
-  const expiresInSeconds = Math.max(60, Number(payload.expires_in || payload.expiresIn || 0) || 3600);
-  return normalizeHotmailAccount({
-    ...account,
-    accessToken: String(payload.access_token || ''),
-    refreshToken: String(payload.refresh_token || '').trim() || account.refreshToken,
-    expiresAt: Date.now() + expiresInSeconds * 1000,
-    status: 'authorized',
-    lastAuthAt: Date.now(),
-    lastError: '',
-  });
+  const summary = attemptFailures
+    .map((failure) => {
+      const label = failure.attemptLabel || failure.attemptId || 'unknown';
+      const errorText = String(failure.errorText || '').trim();
+      return errorText
+        ? `${label}: ${errorText}`
+        : `${label}: HTTP ${failure.status || 'unknown'}`;
+    })
+    .filter(Boolean)
+    .join('；');
+
+  const error = new Error(
+    summary
+      ? `Hotmail 令牌刷新失败：${summary}`
+      : `Hotmail 令牌刷新失败：请求未成功返回（超时阈值 ${Math.round(timeoutMs / 1000)} 秒）`
+  );
+  error.code = 'HOTMAIL_TOKEN_REFRESH_FAILED';
+  return error;
+}
+
+async function refreshHotmailAccessToken(account) {
+  if (!account?.email) {
+    throw new Error('Hotmail 账号缺少邮箱地址。');
+  }
+  if (!account?.clientId) {
+    throw new Error(`Hotmail 账号 ${account.email || account.id} 缺少客户端 ID。`);
+  }
+  if (!account?.refreshToken) {
+    throw new Error(`Hotmail 账号 ${account.email || account.id} 缺少刷新令牌（refresh token）。`);
+  }
+
+  const { timeoutMs, scopes, tokenUrl, tokenRefreshStrategies = [] } = getHotmailGraphRequestConfig();
+  const attempts = tokenRefreshStrategies.length
+    ? tokenRefreshStrategies
+    : [{
+      id: 'graph-legacy-consumers',
+      label: 'Graph delegated/consumers + native redirect',
+      tokenUrl,
+      scope: scopes.join(' '),
+      redirectUri: 'https://login.microsoftonline.com/common/oauth2/nativeclient',
+    }];
+  const failures = [];
+
+  try {
+    await ensureHotmailTokenHeaderRule();
+  } catch (err) {
+    console.warn(LOG_PREFIX, `Failed to prepare Hotmail token header rule: ${err?.message || err}`);
+  }
+
+  for (const attempt of attempts) {
+    try {
+      const result = await requestHotmailTokenRefreshAttempt(account, attempt, timeoutMs);
+      if (result.ok) {
+        const payload = result.payload || {};
+        const expiresInSeconds = Math.max(60, Number(payload.expires_in || payload.expiresIn || 0) || 3600);
+        return normalizeHotmailAccount({
+          ...account,
+          accessToken: String(payload.access_token || ''),
+          refreshToken: String(payload.refresh_token || '').trim() || account.refreshToken,
+          expiresAt: Date.now() + expiresInSeconds * 1000,
+          status: 'authorized',
+          lastAuthAt: Date.now(),
+          lastError: '',
+        });
+      }
+
+      failures.push({
+        attemptId: attempt.id,
+        attemptLabel: attempt.label,
+        status: result.status,
+        errorText: extractHotmailTokenErrorText(result.payload, result.text || `HTTP ${result.status}`),
+      });
+    } catch (err) {
+      failures.push({
+        attemptId: attempt.id,
+        attemptLabel: attempt.label,
+        status: 0,
+        errorText: err?.name === 'AbortError'
+          ? `请求超时（>${Math.round(timeoutMs / 1000)} 秒）`
+          : String(err?.message || err),
+      });
+    }
+  }
+
+  throw buildHotmailRefreshFailureError(failures, timeoutMs);
 }
 
 async function requestHotmailGraphMessages(account, mailbox = 'INBOX') {

--- a/hotmail-utils.js
+++ b/hotmail-utils.js
@@ -6,9 +6,12 @@
 
   root.HotmailUtils = factory();
 })(typeof self !== 'undefined' ? self : globalThis, function createHotmailUtils() {
-  const HOTMAIL_MICROSOFT_TOKEN_URL = 'https://login.microsoftonline.com/consumers/oauth2/v2.0/token';
+  const HOTMAIL_MICROSOFT_COMMON_TOKEN_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/token';
+  const HOTMAIL_MICROSOFT_CONSUMERS_TOKEN_URL = 'https://login.microsoftonline.com/consumers/oauth2/v2.0/token';
+  const HOTMAIL_MICROSOFT_NATIVE_REDIRECT_URI = 'https://login.microsoftonline.com/common/oauth2/nativeclient';
   const HOTMAIL_GRAPH_API_ORIGIN = 'https://graph.microsoft.com';
   const HOTMAIL_GRAPH_PAGE_SIZE = 10;
+  const HOTMAIL_GRAPH_DEFAULT_SCOPE = 'https://graph.microsoft.com/.default';
   const HOTMAIL_GRAPH_MESSAGE_FIELDS = [
     'id',
     'internetMessageId',
@@ -349,11 +352,42 @@
   }
 
   function getHotmailGraphRequestConfig() {
+    const delegatedScope = HOTMAIL_GRAPH_SCOPES.join(' ');
     return {
       timeoutMs: 15000,
       pageSize: HOTMAIL_GRAPH_PAGE_SIZE,
       scopes: HOTMAIL_GRAPH_SCOPES.slice(),
-      tokenUrl: HOTMAIL_MICROSOFT_TOKEN_URL,
+      tokenUrl: HOTMAIL_MICROSOFT_COMMON_TOKEN_URL,
+      tokenRefreshStrategies: [
+        {
+          id: 'graph-common-default',
+          label: 'Graph .default/common',
+          tokenUrl: HOTMAIL_MICROSOFT_COMMON_TOKEN_URL,
+          scope: HOTMAIL_GRAPH_DEFAULT_SCOPE,
+          redirectUri: '',
+        },
+        {
+          id: 'graph-common-delegated',
+          label: 'Graph delegated/common',
+          tokenUrl: HOTMAIL_MICROSOFT_COMMON_TOKEN_URL,
+          scope: delegatedScope,
+          redirectUri: '',
+        },
+        {
+          id: 'graph-consumers-delegated',
+          label: 'Graph delegated/consumers',
+          tokenUrl: HOTMAIL_MICROSOFT_CONSUMERS_TOKEN_URL,
+          scope: delegatedScope,
+          redirectUri: '',
+        },
+        {
+          id: 'graph-consumers-native-redirect',
+          label: 'Graph delegated/consumers + native redirect',
+          tokenUrl: HOTMAIL_MICROSOFT_CONSUMERS_TOKEN_URL,
+          scope: delegatedScope,
+          redirectUri: HOTMAIL_MICROSOFT_NATIVE_REDIRECT_URI,
+        },
+      ],
       messageFields: HOTMAIL_GRAPH_MESSAGE_FIELDS.slice(),
     };
   }

--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,7 @@
     "tabs",
     "webNavigation",
     "debugger",
+    "declarativeNetRequestWithHostAccess",
     "storage",
     "scripting",
     "activeTab"

--- a/tests/hotmail-utils.test.js
+++ b/tests/hotmail-utils.test.js
@@ -449,7 +449,37 @@ test('getHotmailGraphRequestConfig defines Microsoft Graph request defaults', ()
       'https://graph.microsoft.com/Mail.Read',
       'https://graph.microsoft.com/User.Read',
     ],
-    tokenUrl: 'https://login.microsoftonline.com/consumers/oauth2/v2.0/token',
+    tokenUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+    tokenRefreshStrategies: [
+      {
+        id: 'graph-common-default',
+        label: 'Graph .default/common',
+        tokenUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+        scope: 'https://graph.microsoft.com/.default',
+        redirectUri: '',
+      },
+      {
+        id: 'graph-common-delegated',
+        label: 'Graph delegated/common',
+        tokenUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+        scope: 'offline_access https://graph.microsoft.com/Mail.Read https://graph.microsoft.com/User.Read',
+        redirectUri: '',
+      },
+      {
+        id: 'graph-consumers-delegated',
+        label: 'Graph delegated/consumers',
+        tokenUrl: 'https://login.microsoftonline.com/consumers/oauth2/v2.0/token',
+        scope: 'offline_access https://graph.microsoft.com/Mail.Read https://graph.microsoft.com/User.Read',
+        redirectUri: '',
+      },
+      {
+        id: 'graph-consumers-native-redirect',
+        label: 'Graph delegated/consumers + native redirect',
+        tokenUrl: 'https://login.microsoftonline.com/consumers/oauth2/v2.0/token',
+        scope: 'offline_access https://graph.microsoft.com/Mail.Read https://graph.microsoft.com/User.Read',
+        redirectUri: 'https://login.microsoftonline.com/common/oauth2/nativeclient',
+      },
+    ],
     messageFields: [
       'id',
       'internetMessageId',


### PR DESCRIPTION
用codex修复了hotmail校验失败问题并已经跑通注册流程，原文如下
当前扩展原来是在浏览器扩展环境里直接 fetch，Azure AD 会把它识别成浏览器跨域令牌兑换，所以你的 client_id 只要不是放行为 SPA/公共客户端，就容易报 AADSTS90023。我把修复落在了 background.js (line 756) 和 hotmail-utils.js (line 354)：

先按 outlookEmail 的方式优先尝试 common 端点 + https://graph.microsoft.com/.default
如果不行，再回退到当前扩展原来的 consumers + delegated scopes + native redirect
给扩展加了一个仅针对后台 token 请求的 DNR 会话规则，尝试移除 Origin 头，让请求形态更接近服务端实现，权限在 manifest.json (line 6)