### PR TITLE
fix: 修复批量运行首轮后不继续执行

### DIFF
--- a/background.js
+++ b/background.js
@@ -3454,8 +3454,10 @@ async function autoRunLoop(totalRuns, options = {}) {
         inbucketMailbox: prevState.inbucketMailbox,
         cloudflareDomain: prevState.cloudflareDomain,
         cloudflareDomains: prevState.cloudflareDomains,
+        // 新一轮 fresh attempt 必须丢弃上一轮标签页/URL 运行态，避免沿用旧页面上下文。
+        tabRegistry: {},
+        sourceLastUrls: {},
         ...getAutoRunStatusPayload('running', { currentRun: targetRun, totalRuns, attemptRun: attemptRuns }),
-        ...(forceFreshTabsNextRun ? { tabRegistry: {} } : {}),
       };
       await resetState();
       await setState(keepSettings);

--- a/tests/auto-run-fresh-attempt-reset.test.js
+++ b/tests/auto-run-fresh-attempt-reset.test.js
@@ -1,0 +1,245 @@
+const assert = require('assert');
+const fs = require('fs');
+
+const source = fs.readFileSync('background.js', 'utf8');
+
+function extractFunction(name) {
+  const markers = [`async function ${name}(`, `function ${name}(`];
+  const start = markers
+    .map(marker => source.indexOf(marker))
+    .find(index => index >= 0);
+  if (start < 0) {
+    throw new Error(`missing function ${name}`);
+  }
+
+  let parenDepth = 0;
+  let signatureEnded = false;
+  let braceStart = -1;
+  for (let i = start; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === '(') {
+      parenDepth += 1;
+    } else if (ch === ')') {
+      parenDepth -= 1;
+      if (parenDepth === 0) {
+        signatureEnded = true;
+      }
+    } else if (ch === '{' && signatureEnded) {
+      braceStart = i;
+      break;
+    }
+  }
+  if (braceStart < 0) {
+    throw new Error(`missing body for function ${name}`);
+  }
+
+  let depth = 0;
+  let end = braceStart;
+  for (; end < source.length; end += 1) {
+    const ch = source[end];
+    if (ch === '{') depth += 1;
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        end += 1;
+        break;
+      }
+    }
+  }
+
+  return source.slice(start, end);
+}
+
+const bundle = [
+  extractFunction('clearStopRequest'),
+  extractFunction('throwIfStopped'),
+  extractFunction('isStopError'),
+  extractFunction('isStepDoneStatus'),
+  extractFunction('isRestartCurrentAttemptError'),
+  extractFunction('getFirstUnfinishedStep'),
+  extractFunction('hasSavedProgress'),
+  extractFunction('getRunningSteps'),
+  extractFunction('getAutoRunStatusPayload'),
+  extractFunction('autoRunLoop'),
+].join('\n');
+
+const api = new Function(`
+const STOP_ERROR_MESSAGE = '流程已被用户停止。';
+const DEFAULT_STATE = {
+  stepStatuses: {
+    1: 'pending',
+    2: 'pending',
+    3: 'pending',
+    4: 'pending',
+    5: 'pending',
+    6: 'pending',
+    7: 'pending',
+    8: 'pending',
+    9: 'pending',
+  },
+};
+
+let stopRequested = false;
+let autoRunActive = false;
+let autoRunCurrentRun = 0;
+let autoRunTotalRuns = 1;
+let autoRunAttemptRun = 0;
+let runCalls = 0;
+
+const logs = [];
+const broadcasts = [];
+let currentState = {
+  ...DEFAULT_STATE,
+  stepStatuses: { ...DEFAULT_STATE.stepStatuses },
+  vpsUrl: 'https://example.com/vps',
+  vpsPassword: 'secret',
+  customPassword: '',
+  autoRunSkipFailures: false,
+  autoRunDelayEnabled: false,
+  autoRunDelayMinutes: 30,
+  mailProvider: '163',
+  emailGenerator: 'duck',
+  inbucketHost: '',
+  inbucketMailbox: '',
+  cloudflareDomain: '',
+  cloudflareDomains: [],
+  tabRegistry: {},
+  sourceLastUrls: {},
+};
+
+async function getState() {
+  return {
+    ...currentState,
+    stepStatuses: { ...(currentState.stepStatuses || {}) },
+    tabRegistry: { ...(currentState.tabRegistry || {}) },
+    sourceLastUrls: { ...(currentState.sourceLastUrls || {}) },
+  };
+}
+
+async function setState(updates) {
+  currentState = {
+    ...currentState,
+    ...updates,
+    stepStatuses: updates.stepStatuses
+      ? { ...updates.stepStatuses }
+      : currentState.stepStatuses,
+    tabRegistry: updates.tabRegistry
+      ? { ...updates.tabRegistry }
+      : currentState.tabRegistry,
+    sourceLastUrls: updates.sourceLastUrls
+      ? { ...updates.sourceLastUrls }
+      : currentState.sourceLastUrls,
+  };
+}
+
+async function resetState() {
+  const prev = await getState();
+  currentState = {
+    ...DEFAULT_STATE,
+    stepStatuses: { ...DEFAULT_STATE.stepStatuses },
+    vpsUrl: prev.vpsUrl,
+    vpsPassword: prev.vpsPassword,
+    customPassword: prev.customPassword,
+    autoRunSkipFailures: prev.autoRunSkipFailures,
+    autoRunDelayEnabled: prev.autoRunDelayEnabled,
+    autoRunDelayMinutes: prev.autoRunDelayMinutes,
+    mailProvider: prev.mailProvider,
+    emailGenerator: prev.emailGenerator,
+    inbucketHost: prev.inbucketHost,
+    inbucketMailbox: prev.inbucketMailbox,
+    cloudflareDomain: prev.cloudflareDomain,
+    cloudflareDomains: [...(prev.cloudflareDomains || [])],
+    tabRegistry: { ...(prev.tabRegistry || {}) },
+    sourceLastUrls: { ...(prev.sourceLastUrls || {}) },
+  };
+}
+
+async function addLog(message, level = 'info') {
+  logs.push({ message, level });
+}
+
+async function broadcastAutoRunStatus(phase, payload = {}) {
+  broadcasts.push({ phase, ...payload });
+  await setState({
+    ...getAutoRunStatusPayload(phase, payload),
+  });
+}
+
+async function sleepWithStop() {}
+async function waitForRunningStepsToFinish() {
+  return getState();
+}
+async function broadcastStopToContentScripts() {}
+function cancelPendingCommands() {}
+
+const chrome = {
+  runtime: {
+    sendMessage() {
+      return Promise.resolve();
+    },
+  },
+};
+
+async function runAutoSequenceFromStep() {
+  runCalls += 1;
+  const state = await getState();
+
+  if (runCalls === 2 && (Object.keys(state.tabRegistry || {}).length || Object.keys(state.sourceLastUrls || {}).length)) {
+    throw new Error('fresh auto-run attempt reused stale runtime tab context');
+  }
+
+  currentState = {
+    ...currentState,
+    stepStatuses: {
+      1: 'completed',
+      2: 'completed',
+      3: 'completed',
+      4: 'completed',
+      5: 'completed',
+      6: 'completed',
+      7: 'completed',
+      8: 'completed',
+      9: 'completed',
+    },
+    tabRegistry: {
+      'signup-page': { tabId: 88, ready: true },
+    },
+    sourceLastUrls: {
+      'signup-page': 'https://auth.openai.com/authorize',
+    },
+  };
+}
+
+${bundle}
+
+return {
+  autoRunLoop,
+  snapshot() {
+    return {
+      runCalls,
+      autoRunActive,
+      autoRunCurrentRun,
+      autoRunTotalRuns,
+      autoRunAttemptRun,
+      currentState,
+      logs,
+      broadcasts,
+    };
+  },
+};
+`)();
+
+(async () => {
+  await api.autoRunLoop(2, { autoRunSkipFailures: false, mode: 'restart' });
+
+  const snapshot = api.snapshot();
+  assert.strictEqual(snapshot.runCalls, 2, '自动运行应至少尝试进入第二轮');
+  assert.strictEqual(snapshot.currentState.autoRunPhase, 'complete', '清理上一轮运行态后，两轮自动运行都应完成');
+  assert.strictEqual(snapshot.currentState.autoRunCurrentRun, 2, '完成后应记录到第 2 轮');
+  assert.strictEqual(snapshot.autoRunActive, false, '自动运行结束后应解除活跃标记');
+
+  console.log('auto-run fresh attempt reset tests passed');
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## 变更说明

- 修复批量运行在首轮结束后不继续执行下一轮的问题
- fresh attempt 开始前，主动清理上一轮遗留的 `tabRegistry` 和 `sourceLastUrls`
- 保持用户配置和其他自动运行逻辑不变
- 新增回归测试，覆盖两轮自动运行场景

## 根因

批量运行进入新一轮 fresh attempt 时，仍会继承上一轮的标签页注册信息和最近访问 URL。
这会让下一轮复用旧的页面上下文，导致流程在首轮后无法正常继续。

## 验证

- `node tests/auto-run-fresh-attempt-reset.test.js`
- `node tests/step8-callback-handling.test.js`
- `node tests/step8-debugger-stop.test.js`
- `node tests/step8-state-timeout-retry.test.js`
- `node tests/step8-stop-cleanup.test.js`
- `node tests/step9-cpa-mode.test.js`
- `node tests/verification-stop-propagation.test.js`
- `node tests/hotmail-utils.test.js`
- `node tests/activation-utils.test.js`

## 备注

- 仓库当前仍有一个既有失败用例：`tests/step9-localhost-cleanup-scope.test.js`
- 本 PR 未处理该历史问题