### PR TITLE
fix(auth): 修复邮箱轮询与认证重试恢复

### DIFF
--- a/background.js
+++ b/background.js
@@ -43,6 +43,9 @@ const AUTO_STEP_RANDOM_DELAY_MIN_ALLOWED_SECONDS = 0;
 const AUTO_STEP_RANDOM_DELAY_MAX_ALLOWED_SECONDS = 600;
 const AUTO_STEP_RANDOM_DELAY_DEFAULT_MIN_SECONDS = 12;
 const AUTO_STEP_RANDOM_DELAY_DEFAULT_MAX_SECONDS = 18;
+const EMAIL_POLL_MAX_ATTEMPTS_MIN = 1;
+const EMAIL_POLL_MAX_ATTEMPTS_MAX = 20;
+const EMAIL_POLL_MAX_ATTEMPTS_DEFAULT = 7;
 const DEFAULT_LOCAL_CPA_STEP9_MODE = 'submit';
 
 initializeSessionStorageAccess();
@@ -66,6 +69,7 @@ const PERSISTED_SETTING_DEFAULTS = {
   autoRunDelayMinutes: 30, // 自动运行倒计时分钟数。
   autoStepRandomDelayMinSeconds: AUTO_STEP_RANDOM_DELAY_DEFAULT_MIN_SECONDS, // 自动运行每一步执行前的最小随机等待秒数。
   autoStepRandomDelayMaxSeconds: AUTO_STEP_RANDOM_DELAY_DEFAULT_MAX_SECONDS, // 自动运行每一步执行前的最大随机等待秒数。
+  emailPollMaxAttempts: EMAIL_POLL_MAX_ATTEMPTS_DEFAULT, // 邮件验证码轮询次数（每一轮/每次发信后）。
   mailProvider: '163', // 验证码邮箱来源（163 / 163-vip / qq / inbucket）。
   emailGenerator: 'duck', // 注册邮箱生成方式：duck / cloudflare。
   inbucketHost: '', // 仅当 mailProvider 为 inbucket 时填写 Inbucket 地址，其他情况保持为空。
@@ -149,6 +153,18 @@ function normalizeAutoStepRandomDelayRange(settings = {}) {
     )
   );
   return { minSeconds, maxSeconds };
+}
+
+function normalizeEmailPollMaxAttempts(value, fallback = EMAIL_POLL_MAX_ATTEMPTS_DEFAULT) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return fallback;
+  }
+
+  return Math.min(
+    EMAIL_POLL_MAX_ATTEMPTS_MAX,
+    Math.max(EMAIL_POLL_MAX_ATTEMPTS_MIN, Math.floor(numeric))
+  );
 }
 
 function normalizeRunCount(value) {
@@ -257,6 +273,11 @@ function normalizePersistentSettingValue(key, value) {
       return normalizeAutoStepRandomDelaySeconds(
         value,
         PERSISTED_SETTING_DEFAULTS.autoStepRandomDelayMaxSeconds
+      );
+    case 'emailPollMaxAttempts':
+      return normalizeEmailPollMaxAttempts(
+        value,
+        PERSISTED_SETTING_DEFAULTS.emailPollMaxAttempts
       );
     case 'mailProvider':
       return normalizeMailProvider(value);
@@ -451,6 +472,7 @@ async function resetState() {
   const [prev, persistedSettings] = await Promise.all([
     chrome.storage.session.get([
       'seenCodes',
+      'seen163MailSignatures',
       'seenInbucketMailIds',
       'accounts',
       'tabRegistry',
@@ -463,6 +485,7 @@ async function resetState() {
     ...DEFAULT_STATE,
     ...persistedSettings,
     seenCodes: prev.seenCodes || [],
+    seen163MailSignatures: prev.seen163MailSignatures || [],
     seenInbucketMailIds: prev.seenInbucketMailIds || [],
     accounts: prev.accounts || [],
     tabRegistry: prev.tabRegistry || {},
@@ -1960,6 +1983,10 @@ function getErrorMessage(error) {
   return String(typeof error === 'string' ? error : error?.message || '');
 }
 
+function isDuckEmailFatalError(error) {
+  return Boolean(error?.duckFatal);
+}
+
 function isVerificationMailPollingError(error) {
   const message = getErrorMessage(error);
   return /未在 .*邮箱中找到新的匹配邮件|未在 Hotmail 收件箱中找到新的匹配验证码|邮箱轮询结束，但未获取到验证码|无法获取新的(?:注册|登录)验证码|页面未能重新就绪|页面通信异常|did not respond in \d+s/i.test(message);
@@ -3187,7 +3214,11 @@ async function fetchDuckEmail(options = {}) {
   });
 
   if (result?.error) {
-    throw new Error(result.error);
+    const error = new Error(result.error);
+    if (result.fatal) {
+      error.duckFatal = true;
+    }
+    throw error;
   }
   if (!result?.email) {
     throw new Error('未返回 Duck 邮箱地址。');
@@ -3281,6 +3312,12 @@ async function ensureAutoEmailReady(targetRun, totalRuns, attemptRuns) {
     } catch (err) {
       lastError = err;
       await addLog(`${generatorLabel}自动获取失败（${attempt}/${EMAIL_FETCH_MAX_ATTEMPTS}）：${err.message}`, 'warn');
+      if (generator === 'duck' && isDuckEmailFatalError(err)) {
+        await requestStop({
+          logMessage: `Duck 邮箱生成失败，已立即停止自动流程：${err.message}`,
+        });
+        throw new Error(STOP_ERROR_MESSAGE);
+      }
       if (generator === 'cloudflare' && /域名/.test(String(err.message || ''))) {
         break;
       }
@@ -3862,13 +3899,17 @@ function getVerificationCodeLabel(step) {
 }
 
 function getVerificationPollPayload(step, state, overrides = {}) {
+  const emailPollMaxAttempts = normalizeEmailPollMaxAttempts(
+    state?.emailPollMaxAttempts,
+    PERSISTED_SETTING_DEFAULTS.emailPollMaxAttempts
+  );
   if (step === 4) {
     return {
       filterAfterTimestamp: getHotmailVerificationRequestTimestamp(4, state),
-      senderFilters: ['openai', 'noreply', 'verify', 'auth', 'duckduckgo', 'forward'],
-      subjectFilters: ['verify', 'verification', 'code', '楠岃瘉', 'confirm'],
+      senderFilters: ['openai', 'noreply', 'otp', 'verify', 'auth', 'duckduckgo', 'forward'],
+      subjectFilters: ['verify', 'verification', 'code', 'otp', 'openai', 'chatgpt', '楠岃瘉', 'confirm'],
       targetEmail: state.email,
-      maxAttempts: 5,
+      maxAttempts: emailPollMaxAttempts,
       intervalMs: 3000,
       ...overrides,
     };
@@ -3876,10 +3917,10 @@ function getVerificationPollPayload(step, state, overrides = {}) {
 
   return {
     filterAfterTimestamp: getHotmailVerificationRequestTimestamp(7, state),
-    senderFilters: ['openai', 'noreply', 'verify', 'auth', 'chatgpt', 'duckduckgo', 'forward'],
-    subjectFilters: ['verify', 'verification', 'code', '楠岃瘉', 'confirm', 'login'],
+    senderFilters: ['openai', 'noreply', 'otp', 'verify', 'auth', 'chatgpt', 'duckduckgo', 'forward'],
+    subjectFilters: ['verify', 'verification', 'code', 'otp', 'openai', 'chatgpt', '楠岃瘉', 'confirm', 'login'],
     targetEmail: state.email,
-    maxAttempts: 5,
+    maxAttempts: emailPollMaxAttempts,
     intervalMs: 3000,
     ...overrides,
   };
@@ -3925,6 +3966,10 @@ async function pollFreshVerificationCode(step, state, mail, pollOverrides = {}) 
     return pollHotmailVerificationCode(step, state, {
       ...getVerificationPollPayload(step, state),
       ...hotmailPollConfig,
+      maxAttempts: normalizeEmailPollMaxAttempts(
+        state?.emailPollMaxAttempts,
+        hotmailPollConfig.maxAttempts
+      ),
       ...pollOverrides,
     });
   }

--- a/content/duck-mail.js
+++ b/content/duck-mail.js
@@ -14,7 +14,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       sendResponse({ stopped: true, error: err.message });
       return;
     }
-    sendResponse({ error: err.message });
+    sendResponse({ error: err.message, fatal: Boolean(err?.fatal) });
   });
 
   return true;
@@ -75,6 +75,12 @@ async function fetchDuckEmail(payload = {}) {
     throw new Error('等待 Duck 地址出现超时。');
   };
 
+  const createDuckGenerationError = (message) => {
+    const error = new Error(message);
+    error.fatal = true;
+    return error;
+  };
+
   const currentEmail = readEmail();
   if (currentEmail && !generateNew) {
     log(`Duck 邮箱：已发现现有地址 ${currentEmail}`);
@@ -84,7 +90,7 @@ async function fetchDuckEmail(payload = {}) {
   const generatorButton = getGeneratorButton();
   if (!generatorButton) {
     if (generateNew) {
-      throw new Error('未找到“生成新 Duck 地址”按钮（可能是页面文案/语言变化、未登录或页面结构更新）。');
+      throw createDuckGenerationError('未找到“生成新 Duck 地址”按钮（可能是页面文案/语言变化、未登录或页面结构更新）。');
     }
     if (currentEmail) {
       log(`Duck 邮箱：未找到生成按钮，复用现有地址 ${currentEmail}`, 'warn');
@@ -93,6 +99,8 @@ async function fetchDuckEmail(payload = {}) {
     throw new Error('未找到“生成 Duck 私有地址”按钮。');
   }
 
+  // Duck 页面偶发首次点击后不刷新地址，允许页面内再试一次；
+  // 两次后仍拿不到不同于旧值的新地址，则视为 fatal，直接交给 background 停止自动流程。
   for (let attempt = 1; attempt <= 2; attempt++) {
     await humanPause(500, 1300);
     if (typeof simulateClick === 'function') {
@@ -108,12 +116,10 @@ async function fetchDuckEmail(payload = {}) {
       return { email: nextEmail, generated: true };
     } catch (err) {
       if (attempt >= 2) {
-        throw err;
+        throw createDuckGenerationError(`点击 ${attempt} 次后仍未获得新的 Duck 地址：${err.message}`);
       }
       log('Duck 邮箱：首次生成后地址未变化，准备重试一次...', 'warn');
       await sleep(800);
     }
   }
-
-  throw new Error('Duck 地址生成失败。');
 }

--- a/content/mail-163.js
+++ b/content/mail-163.js
@@ -9,6 +9,20 @@
 
 const MAIL163_PREFIX = '[MultiPage:mail-163]';
 const isTopFrame = window === window.top;
+const SEEN_MAIL_SIGNATURES_KEY = 'seen163MailSignatures';
+const SEEN_MAIL_SIGNATURE_LIMIT = 200;
+
+const {
+  buildMail163SelectionPlan,
+  collectMail163CleanupEntries,
+  createMail163Snapshot,
+  normalizeMail163Entry,
+  normalizeMail163PollAttempts,
+  normalizeMinuteTimestamp,
+  parseMail163Timestamp,
+  pickMail163VerificationEntry,
+  updateRecentMail163Signatures,
+} = self.Mail163Utils;
 
 console.log(MAIL163_PREFIX, 'Content script loaded on', location.href, 'frame:', isTopFrame ? 'top' : 'child');
 
@@ -17,30 +31,43 @@ if (!isTopFrame) {
   console.log(MAIL163_PREFIX, 'Skipping child frame');
 } else {
 
-// Track codes we've already seen — persisted in chrome.storage.session to survive script re-injection
-let seenCodes = new Set();
+let seenMailSignatures = [];
+let seenMailSignatureSet = new Set();
 
-async function loadSeenCodes() {
+async function loadSeenMailSignatures() {
   try {
-    const data = await chrome.storage.session.get('seenCodes');
-    if (data.seenCodes && Array.isArray(data.seenCodes)) {
-      seenCodes = new Set(data.seenCodes);
-      console.log(MAIL163_PREFIX, `Loaded ${seenCodes.size} previously seen codes`);
+    const data = await chrome.storage.session.get(SEEN_MAIL_SIGNATURES_KEY);
+    if (Array.isArray(data[SEEN_MAIL_SIGNATURES_KEY])) {
+      seenMailSignatures = data[SEEN_MAIL_SIGNATURES_KEY].filter(Boolean).slice(0, SEEN_MAIL_SIGNATURE_LIMIT);
+      seenMailSignatureSet = new Set(seenMailSignatures);
+      console.log(MAIL163_PREFIX, `Loaded ${seenMailSignatureSet.size} previously seen mail signatures`);
     }
   } catch (err) {
-    console.warn(MAIL163_PREFIX, 'Session storage unavailable, using in-memory seen codes:', err?.message || err);
+    console.warn(MAIL163_PREFIX, 'Session storage unavailable, using in-memory seen mail signatures:', err?.message || err);
   }
 }
 
-// Load previously seen codes on startup
-loadSeenCodes();
+const seenMailSignaturesReady = loadSeenMailSignatures();
 
-async function persistSeenCodes() {
+async function persistSeenMailSignatures() {
   try {
-    await chrome.storage.session.set({ seenCodes: [...seenCodes] });
+    await chrome.storage.session.set({
+      [SEEN_MAIL_SIGNATURES_KEY]: seenMailSignatures,
+    });
   } catch (err) {
-    console.warn(MAIL163_PREFIX, 'Could not persist seen codes, continuing in-memory only:', err?.message || err);
+    console.warn(MAIL163_PREFIX, 'Could not persist seen mail signatures, continuing in-memory only:', err?.message || err);
   }
+}
+
+async function rememberSeenMailSignature(signature) {
+  if (!signature) return;
+  seenMailSignatures = updateRecentMail163Signatures(
+    seenMailSignatures,
+    signature,
+    SEEN_MAIL_SIGNATURE_LIMIT
+  );
+  seenMailSignatureSet = new Set(seenMailSignatures);
+  await persistSeenMailSignatures();
 }
 
 // ============================================================
@@ -73,58 +100,6 @@ function findMailItems() {
   return document.querySelectorAll('div[sign="letter"]');
 }
 
-function getCurrentMailIds() {
-  const ids = new Set();
-  findMailItems().forEach(item => {
-    const id = item.getAttribute('id') || '';
-    if (id) ids.add(id);
-  });
-  return ids;
-}
-
-function normalizeMinuteTimestamp(timestamp) {
-  if (!Number.isFinite(timestamp) || timestamp <= 0) return 0;
-  const date = new Date(timestamp);
-  date.setSeconds(0, 0);
-  return date.getTime();
-}
-
-function parseMail163Timestamp(rawText) {
-  const text = (rawText || '').replace(/\s+/g, ' ').trim();
-  if (!text) return null;
-
-  let match = text.match(/(\d{4})年(\d{1,2})月(\d{1,2})日\s+(\d{1,2}):(\d{2})/);
-  if (match) {
-    const [, year, month, day, hour, minute] = match;
-    return new Date(
-      Number(year),
-      Number(month) - 1,
-      Number(day),
-      Number(hour),
-      Number(minute),
-      0,
-      0
-    ).getTime();
-  }
-
-  match = text.match(/\b(\d{1,2}):(\d{2})\b/);
-  if (match) {
-    const [, hour, minute] = match;
-    const now = new Date();
-    return new Date(
-      now.getFullYear(),
-      now.getMonth(),
-      now.getDate(),
-      Number(hour),
-      Number(minute),
-      0,
-      0
-    ).getTime();
-  }
-
-  return null;
-}
-
 function getMailTimestamp(item) {
   const candidates = [];
   const timeCell = item.querySelector('.e00[title], [title*="年"][title*=":"]');
@@ -145,9 +120,41 @@ function getMailTimestamp(item) {
   return null;
 }
 
-function scheduleEmailCleanup(item, step) {
+function parseMailItem(item, index = 0) {
+  const sender = item.querySelector('.nui-user')?.textContent || '';
+  const subject = item.querySelector('span.da0')?.textContent || '';
+
+  return {
+    item,
+    index,
+    id: item.getAttribute('id') || '',
+    sender,
+    subject,
+    ariaLabel: item.getAttribute('aria-label') || '',
+    timestamp: getMailTimestamp(item),
+  };
+}
+
+function getCurrentMailSnapshot() {
+  return createMail163Snapshot(Array.from(findMailItems()).map(parseMailItem));
+}
+
+function getCurrentMailEntries() {
+  return Array.from(findMailItems()).map((item, index) => {
+    const checkbox = findMailCheckbox(item);
+    const entry = normalizeMail163Entry(parseMailItem(item, index), index);
+    return {
+      ...entry,
+      item,
+      checkbox,
+      selected: isMailCheckboxChecked(checkbox),
+    };
+  });
+}
+
+function scheduleEmailCleanup(cleanupContext, step) {
   setTimeout(() => {
-    Promise.resolve(deleteEmail(item, step)).catch(() => {
+    Promise.resolve(deleteEmail(cleanupContext, step)).catch(() => {
       // Cleanup is best effort only and must never affect the main verification flow.
     });
   }, 0);
@@ -158,11 +165,20 @@ function scheduleEmailCleanup(item, step) {
 // ============================================================
 
 async function handlePollEmail(step, payload) {
-  const { senderFilters, subjectFilters, maxAttempts, intervalMs, excludeCodes = [], filterAfterTimestamp = 0 } = payload;
-  const excludedCodeSet = new Set(excludeCodes.filter(Boolean));
+  await seenMailSignaturesReady;
+
+  const {
+    senderFilters = [],
+    subjectFilters = [],
+    maxAttempts,
+    intervalMs = 3000,
+    excludeCodes = [],
+    filterAfterTimestamp = 0,
+  } = payload || {};
+  const effectiveMaxAttempts = normalizeMail163PollAttempts(maxAttempts);
   const filterAfterMinute = normalizeMinuteTimestamp(Number(filterAfterTimestamp) || 0);
 
-  log(`步骤 ${step}：开始轮询 163 邮箱（最多 ${maxAttempts} 次）`);
+  log(`步骤 ${step}：开始轮询 163 邮箱（最多 ${effectiveMaxAttempts} 次）`);
   if (filterAfterMinute) {
     log(`步骤 ${step}：仅尝试 ${new Date(filterAfterMinute).toLocaleString('zh-CN', { hour12: false })} 及之后时间的邮件。`);
   }
@@ -198,79 +214,70 @@ async function handlePollEmail(step, payload) {
 
   log(`步骤 ${step}：邮件列表已加载，共 ${items.length} 封邮件`);
 
-  // Snapshot existing mail IDs
-  const existingMailIds = getCurrentMailIds();
-  log(`步骤 ${step}：已记录当前 ${existingMailIds.size} 封旧邮件快照`);
+  const existingMailSnapshot = getCurrentMailSnapshot();
+  log(`步骤 ${step}：已记录当前 ${existingMailSnapshot.signatures.size} 封旧邮件快照`);
 
   const FALLBACK_AFTER = 3;
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    log(`步骤 ${step}：正在轮询 163 邮箱，第 ${attempt}/${maxAttempts} 次`);
+  for (let attempt = 1; attempt <= effectiveMaxAttempts; attempt++) {
+    log(`步骤 ${step}：正在轮询 163 邮箱，第 ${attempt}/${effectiveMaxAttempts} 次`);
 
     if (attempt > 1) {
       await refreshInbox();
       await sleep(1000);
     }
 
-    const allItems = findMailItems();
+    const allItems = Array.from(findMailItems()).map(parseMailItem);
     const useFallback = attempt > FALLBACK_AFTER;
 
-    for (const item of allItems) {
-      const id = item.getAttribute('id') || '';
-      const mailTimestamp = getMailTimestamp(item);
-      const mailMinute = normalizeMinuteTimestamp(mailTimestamp || 0);
-      const passesTimeFilter = !filterAfterMinute || (mailMinute && mailMinute >= filterAfterMinute);
-      const shouldBypassOldSnapshot = Boolean(filterAfterMinute && passesTimeFilter && mailMinute > 0);
+    const selection = pickMail163VerificationEntry(allItems, {
+      afterTimestamp: filterAfterTimestamp,
+      allowSnapshotFallback: useFallback,
+      allowTimeFallback: useFallback,
+      excludeCodes,
+      seenSignatures: [...seenMailSignatureSet],
+      senderFilters,
+      snapshot: existingMailSnapshot,
+      subjectFilters,
+    });
 
-      if (!passesTimeFilter) {
-        continue;
-      }
+    if (selection?.match) {
+      const matchedMail = selection.match;
+      await rememberSeenMailSignature(matchedMail.signature);
+      const source = selection.usedTimeFallback
+        ? '延迟回退匹配邮件'
+        : (selection.usedSnapshotFallback ? '回退匹配邮件' : '新邮件');
+      const timeLabel = matchedMail.timestamp
+        ? `，时间：${new Date(matchedMail.timestamp).toLocaleString('zh-CN', { hour12: false })}`
+        : '';
+      const extraLabel = selection.usedTimeFallback ? '，已忽略时间窗口' : '';
+      log(`步骤 ${step}：已找到验证码：${matchedMail.code}（来源：${source}${extraLabel}${timeLabel}，主题：${matchedMail.subject.slice(0, 40)}）`, 'ok');
 
-      if (!useFallback && !shouldBypassOldSnapshot && existingMailIds.has(id)) continue;
+      scheduleEmailCleanup({
+        matchedMail,
+        senderFilters,
+        subjectFilters,
+      }, step);
 
-      const senderEl = item.querySelector('.nui-user');
-      const sender = senderEl ? senderEl.textContent.toLowerCase() : '';
-
-      const subjectEl = item.querySelector('span.da0');
-      const subject = subjectEl ? subjectEl.textContent : '';
-
-      const ariaLabel = (item.getAttribute('aria-label') || '').toLowerCase();
-
-      const senderMatch = senderFilters.some(f => sender.includes(f.toLowerCase()) || ariaLabel.includes(f.toLowerCase()));
-      const subjectMatch = subjectFilters.some(f => subject.toLowerCase().includes(f.toLowerCase()) || ariaLabel.includes(f.toLowerCase()));
-
-      if (senderMatch || subjectMatch) {
-        const code = extractVerificationCode(subject + ' ' + ariaLabel);
-        if (code && excludedCodeSet.has(code)) {
-          log(`步骤 ${step}：跳过排除的验证码：${code}`, 'info');
-        } else if (code && !seenCodes.has(code)) {
-          seenCodes.add(code);
-          persistSeenCodes();
-          const source = useFallback && existingMailIds.has(id) ? '回退匹配邮件' : '新邮件';
-          const timeLabel = mailTimestamp ? `，时间：${new Date(mailTimestamp).toLocaleString('zh-CN', { hour12: false })}` : '';
-          log(`步骤 ${step}：已找到验证码：${code}（来源：${source}${timeLabel}，主题：${subject.slice(0, 40)}）`, 'ok');
-
-          // Trigger cleanup only as a best-effort side effect.
-          scheduleEmailCleanup(item, step);
-
-          return { ok: true, code, emailTimestamp: Date.now(), mailId: id };
-        } else if (code && seenCodes.has(code)) {
-          log(`步骤 ${step}：跳过已处理过的验证码：${code}`, 'info');
-        }
-      }
+      return {
+        ok: true,
+        code: matchedMail.code,
+        emailTimestamp: matchedMail.timestamp || Date.now(),
+        mailId: matchedMail.id || matchedMail.signature,
+      };
     }
 
     if (attempt === FALLBACK_AFTER + 1) {
-      log(`步骤 ${step}：连续 ${FALLBACK_AFTER} 次未发现新邮件，开始回退到首封匹配邮件`, 'warn');
+      log(`步骤 ${step}：连续 ${FALLBACK_AFTER} 次未发现新邮件，开始回退到匹配邮件，并在必要时放宽时间窗口。`, 'warn');
     }
 
-    if (attempt < maxAttempts) {
+    if (attempt < effectiveMaxAttempts) {
       await sleep(intervalMs);
     }
   }
 
   throw new Error(
-    `${(maxAttempts * intervalMs / 1000).toFixed(0)} 秒后仍未在 163 邮箱中找到新的匹配邮件。` +
+    `${(effectiveMaxAttempts * intervalMs / 1000).toFixed(0)} 秒后仍未在 163 邮箱中找到新的匹配邮件。` +
     '请手动检查收件箱。'
   );
 }
@@ -279,7 +286,104 @@ async function handlePollEmail(step, payload) {
 // Delete Email via Hover Trash / Toolbar Fallback
 // ============================================================
 
-async function deleteEmail(item, step) {
+function clickElement(element) {
+  if (!element) return;
+  if (typeof simulateClick === 'function') {
+    simulateClick(element);
+    return;
+  }
+  element.click();
+}
+
+function findMailCheckbox(item) {
+  return item?.querySelector('[sign="checkbox"], .nui-chk, input[type="checkbox"]') || null;
+}
+
+function isMailCheckboxChecked(checkbox) {
+  if (!checkbox) return false;
+
+  const nodes = [checkbox, ...checkbox.querySelectorAll?.('*') || []];
+  for (const node of nodes) {
+    if (!node) continue;
+    if (node instanceof HTMLInputElement && node.type === 'checkbox' && node.checked) {
+      return true;
+    }
+
+    const ariaChecked = node.getAttribute?.('aria-checked');
+    if (ariaChecked === 'true') {
+      return true;
+    }
+
+    const checkedAttr = node.getAttribute?.('checked');
+    if (checkedAttr !== null && checkedAttr !== 'false') {
+      return true;
+    }
+
+    const className = typeof node.className === 'string' ? node.className : '';
+    if (/\bnui-(?:chk|ico)-checked\b|\bis-checked\b|\bchecked\b/.test(className)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function clickToolbarDelete(step, selectedCount) {
+  const toolbarBtns = document.querySelectorAll('.nui-btn .nui-btn-text');
+  for (const btn of toolbarBtns) {
+    if (btn.textContent.replace(/\s/g, '').includes('删除')) {
+      clickElement(btn.closest('.nui-btn'));
+      log(`步骤 ${step}：已批量删除 ${selectedCount} 封匹配邮件`, 'ok');
+      await sleep(1500);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function toggleMailCheckbox(entry, shouldBeChecked) {
+  if (!entry?.checkbox) return false;
+  const initiallyChecked = isMailCheckboxChecked(entry.checkbox);
+  if (initiallyChecked === shouldBeChecked) {
+    return true;
+  }
+
+  entry.item?.scrollIntoView?.({ block: 'center' });
+  clickElement(entry.checkbox);
+  await sleep(150);
+  return isMailCheckboxChecked(entry.checkbox) === shouldBeChecked;
+}
+
+async function syncMailSelection(targetEntries, step) {
+  const initialEntries = getCurrentMailEntries();
+  const initialPlan = buildMail163SelectionPlan(initialEntries, targetEntries);
+
+  let clearedCount = 0;
+  for (const entry of initialPlan.toUnselect) {
+    if (await toggleMailCheckbox(entry, false)) {
+      clearedCount += 1;
+    }
+  }
+
+  for (const entry of initialPlan.toSelect) {
+    await toggleMailCheckbox(entry, true);
+  }
+
+  const finalPlan = buildMail163SelectionPlan(getCurrentMailEntries(), targetEntries);
+  if (clearedCount > 0) {
+    log(`步骤 ${step}：已清除 ${clearedCount} 封与本次删除无关的已选邮件。`, 'info');
+  }
+
+  return {
+    clearedCount,
+    selectedCount: finalPlan.selectedTargetCount,
+    targetCount: finalPlan.targetCount,
+    unexpectedSelectedCount: finalPlan.toUnselect.length,
+  };
+}
+
+async function deleteSingleEmail(item, step) {
   try {
     log(`步骤 ${step}：正在删除邮件...`);
 
@@ -292,7 +396,7 @@ async function deleteEmail(item, step) {
 
     const trashIcon = item.querySelector('[sign="trash"], .nui-ico-delete, [title="删除邮件"]');
     if (trashIcon) {
-      trashIcon.click();
+      clickElement(trashIcon);
       log(`步骤 ${step}：已点击删除图标`, 'ok');
       await sleep(1500);
 
@@ -308,24 +412,63 @@ async function deleteEmail(item, step) {
 
     // Strategy 2: Select checkbox then click toolbar delete button
     log(`步骤 ${step}：未找到删除图标，尝试使用复选框加工具栏删除...`);
-    const checkbox = item.querySelector('[sign="checkbox"], .nui-chk');
+    const checkbox = findMailCheckbox(item);
     if (checkbox) {
-      checkbox.click();
-      await sleep(300);
+      const selection = await syncMailSelection([
+        {
+          ...normalizeMail163Entry(parseMailItem(item)),
+          item,
+        },
+      ], step);
 
-      // Click toolbar delete button
-      const toolbarBtns = document.querySelectorAll('.nui-btn .nui-btn-text');
-      for (const btn of toolbarBtns) {
-        if (btn.textContent.replace(/\s/g, '').includes('删除')) {
-          btn.closest('.nui-btn').click();
-          log(`步骤 ${step}：已点击工具栏删除`, 'ok');
-          await sleep(1500);
-          return;
-        }
+      if (selection.unexpectedSelectedCount > 0) {
+        log(`步骤 ${step}：仍存在 ${selection.unexpectedSelectedCount} 封无关已选邮件，已跳过工具栏删除以避免误删。`, 'warn');
+        return;
+      }
+
+      if (selection.selectedCount > 0 && await clickToolbarDelete(step, selection.selectedCount)) {
+        return;
       }
     }
 
     log(`步骤 ${step}：无法删除邮件（未找到删除按钮）`, 'warn');
+  } catch (err) {
+    log(`步骤 ${step}：删除邮件失败：${err.message}`, 'warn');
+  }
+}
+
+async function deleteEmail(cleanupContext, step) {
+  const { matchedMail = null, senderFilters = [], subjectFilters = [] } = cleanupContext || {};
+
+  try {
+    const candidates = collectMail163CleanupEntries(
+      Array.from(findMailItems()).map(parseMailItem),
+      { senderFilters, subjectFilters }
+    );
+
+    if (!candidates.length) {
+      if (matchedMail?.item) {
+        await deleteSingleEmail(matchedMail.item, step);
+        return;
+      }
+      log(`步骤 ${step}：未找到可批量删除的匹配邮件`, 'warn');
+      return;
+    }
+
+    const selection = await syncMailSelection(candidates, step);
+    if (selection.unexpectedSelectedCount > 0) {
+      log(`步骤 ${step}：仍存在 ${selection.unexpectedSelectedCount} 封无关已选邮件，已放弃批量删除以避免误删。`, 'warn');
+    } else if (selection.selectedCount > 0 && await clickToolbarDelete(step, selection.selectedCount)) {
+      return;
+    }
+
+    if (matchedMail?.item) {
+      log(`步骤 ${step}：批量删除不可用，回退为单封删除`, 'warn');
+      await deleteSingleEmail(matchedMail.item, step);
+      return;
+    }
+
+    log(`步骤 ${step}：无法删除邮件（未找到可用的复选框或删除按钮）`, 'warn');
   } catch (err) {
     log(`步骤 ${step}：删除邮件失败：${err.message}`, 'warn');
   }
@@ -359,23 +502,6 @@ async function refreshInbox() {
   }
 
   console.log(MAIL163_PREFIX, 'Could not find refresh button');
-}
-
-// ============================================================
-// Verification Code Extraction
-// ============================================================
-
-function extractVerificationCode(text) {
-  const matchCn = text.match(/(?:代码为|验证码[^0-9]*?)[\s：:]*(\d{6})/);
-  if (matchCn) return matchCn[1];
-
-  const matchEn = text.match(/code[:\s]+is[:\s]+(\d{6})|code[:\s]+(\d{6})/i);
-  if (matchEn) return matchEn[1] || matchEn[2];
-
-  const match6 = text.match(/\b(\d{6})\b/);
-  if (match6) return match6[1];
-
-  return null;
 }
 
 } // end of isTopFrame else block

--- a/content/signup-page.js
+++ b/content/signup-page.js
@@ -401,7 +401,7 @@ const OAUTH_CONSENT_FORM_SELECTOR = 'form[action*="/sign-in-with-chatgpt/" i][ac
 const CONTINUE_ACTION_PATTERN = /继续|continue/i;
 const ADD_PHONE_PAGE_PATTERN = /add[\s-]*phone|添加手机号|手机号码|手机号|phone\s+number|telephone/i;
 const STEP5_SUBMIT_ERROR_PATTERN = /无法根据该信息创建帐户|请重试|unable\s+to\s+create\s+(?:your\s+)?account|couldn'?t\s+create\s+(?:your\s+)?account|something\s+went\s+wrong|invalid\s+(?:birthday|birth|date)|生日|出生日期/i;
-const AUTH_TIMEOUT_ERROR_TITLE_PATTERN = /糟糕，出错了|something\s+went\s+wrong|oops/i;
+const AUTH_TIMEOUT_ERROR_TITLE_PATTERN = /糟糕，出错了|something\s+went\s+wrong|oops|(?:an\s+)?error\s+occurred/i;
 const AUTH_TIMEOUT_ERROR_DETAIL_PATTERN = /operation\s+timed\s+out|timed\s+out|请求超时|操作超时/i;
 const SIGNUP_EMAIL_EXISTS_PATTERN = /与此电子邮件地址相关联的帐户已存在|account\s+associated\s+with\s+this\s+email\s+address\s+already\s+exists|email\s+address.*already\s+exists/i;
 

--- a/mail-163-utils.js
+++ b/mail-163-utils.js
@@ -1,0 +1,372 @@
+(function mail163UtilsModule(root, factory) {
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = factory();
+    return;
+  }
+
+  root.Mail163Utils = factory();
+})(typeof self !== 'undefined' ? self : globalThis, function createMail163Utils() {
+  const DEFAULT_SIGNATURE_HISTORY_LIMIT = 200;
+
+  function normalizeText(value) {
+    return String(value || '')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .toLowerCase();
+  }
+
+  function normalizeTimestamp(value) {
+    if (!value) return 0;
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value > 0 ? value : 0;
+    }
+
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  function normalizeMinuteTimestamp(value) {
+    const timestamp = normalizeTimestamp(value);
+    if (!timestamp) return 0;
+
+    const date = new Date(timestamp);
+    date.setSeconds(0, 0);
+    return date.getTime();
+  }
+
+  function parseMail163Timestamp(rawText, nowValue = new Date()) {
+    const text = String(rawText || '').replace(/\s+/g, ' ').trim();
+    if (!text) return null;
+
+    let match = text.match(/(\d{4})年(\d{1,2})月(\d{1,2})日\s+(\d{1,2}):(\d{2})/);
+    if (match) {
+      const [, year, month, day, hour, minute] = match;
+      return new Date(
+        Number(year),
+        Number(month) - 1,
+        Number(day),
+        Number(hour),
+        Number(minute),
+        0,
+        0
+      ).getTime();
+    }
+
+    match = text.match(/\b(\d{1,2}):(\d{2})\b/);
+    if (match) {
+      const [, hour, minute] = match;
+      const nowTimestamp = normalizeTimestamp(nowValue) || Date.now();
+      const now = new Date(nowTimestamp);
+      return new Date(
+        now.getFullYear(),
+        now.getMonth(),
+        now.getDate(),
+        Number(hour),
+        Number(minute),
+        0,
+        0
+      ).getTime();
+    }
+
+    return null;
+  }
+
+  function extractVerificationCode(text) {
+    const source = String(text || '');
+    const matchCn = source.match(/(?:代码为|验证码[^0-9]*?)[\s：:]*(\d{6})/i);
+    if (matchCn) return matchCn[1];
+
+    const matchEn = source.match(/code(?:\s+is|[\s:])+(\d{6})/i);
+    if (matchEn) return matchEn[1];
+
+    const matchStandalone = source.match(/\b(\d{6})\b/);
+    return matchStandalone ? matchStandalone[1] : null;
+  }
+
+  function buildMail163EntrySignature(entry = {}) {
+    const code = entry.code || extractVerificationCode(
+      [entry.subject, entry.ariaLabel, entry.sender].filter(Boolean).join(' ')
+    );
+    const signatureParts = [
+      entry.id ? `id=${String(entry.id).trim()}` : '',
+      normalizeText(entry.sender),
+      normalizeText(entry.subject),
+      normalizeText(entry.ariaLabel),
+      String(normalizeMinuteTimestamp(entry.timestamp) || 0),
+      code || '',
+    ];
+    return signatureParts.join('|');
+  }
+
+  function normalizeMail163Entry(entry = {}, index = 0) {
+    const timestamp = normalizeTimestamp(entry.timestamp);
+    const code = entry.code || extractVerificationCode(
+      [entry.subject, entry.ariaLabel, entry.sender].filter(Boolean).join(' ')
+    );
+    const normalizedEntry = {
+      ...entry,
+      index: Number.isFinite(entry.index) ? entry.index : index,
+      id: String(entry.id || '').trim(),
+      sender: String(entry.sender || '').trim(),
+      subject: String(entry.subject || '').trim(),
+      ariaLabel: String(entry.ariaLabel || '').trim(),
+      timestamp,
+      minuteTimestamp: normalizeMinuteTimestamp(timestamp),
+      code,
+    };
+    normalizedEntry.signature = buildMail163EntrySignature(normalizedEntry);
+    return normalizedEntry;
+  }
+
+  function createMail163Snapshot(entries = []) {
+    const idsToSignatures = new Map();
+    const signatures = new Set();
+
+    (Array.isArray(entries) ? entries : []).forEach((entry, index) => {
+      const normalizedEntry = normalizeMail163Entry(entry, index);
+      signatures.add(normalizedEntry.signature);
+      if (normalizedEntry.id) {
+        idsToSignatures.set(normalizedEntry.id, normalizedEntry.signature);
+      }
+    });
+
+    return { idsToSignatures, signatures };
+  }
+
+  function snapshotHasMail163Entry(snapshot, entry) {
+    if (!snapshot) return false;
+
+    const normalizedEntry = normalizeMail163Entry(entry);
+    if (normalizedEntry.id && snapshot.idsToSignatures instanceof Map && snapshot.idsToSignatures.has(normalizedEntry.id)) {
+      return snapshot.idsToSignatures.get(normalizedEntry.id) === normalizedEntry.signature;
+    }
+
+    return snapshot.signatures instanceof Set
+      ? snapshot.signatures.has(normalizedEntry.signature)
+      : false;
+  }
+
+  function messageMatchesFilters(entry, filters = {}) {
+    const senderFilters = (filters.senderFilters || []).map(normalizeText).filter(Boolean);
+    const subjectFilters = (filters.subjectFilters || []).map(normalizeText).filter(Boolean);
+    const sender = normalizeText(entry.sender);
+    const subject = normalizeText(entry.subject);
+    const combined = normalizeText([entry.subject, entry.sender, entry.ariaLabel].filter(Boolean).join(' '));
+
+    const senderMatch = senderFilters.length === 0
+      ? false
+      : senderFilters.some((value) => sender.includes(value) || combined.includes(value));
+    const subjectMatch = subjectFilters.length === 0
+      ? false
+      : subjectFilters.some((value) => subject.includes(value) || combined.includes(value));
+    const matched = (senderFilters.length === 0 && subjectFilters.length === 0)
+      ? true
+      : (senderMatch || subjectMatch);
+
+    return {
+      matched: Boolean(matched && entry.code),
+      senderMatch,
+      subjectMatch,
+      code: entry.code || null,
+    };
+  }
+
+  function compareMail163Candidates(left, right) {
+    if (left.existsInSnapshot !== right.existsInSnapshot) {
+      return left.existsInSnapshot ? 1 : -1;
+    }
+
+    if (left.minuteTimestamp !== right.minuteTimestamp) {
+      return right.minuteTimestamp - left.minuteTimestamp;
+    }
+
+    if (left.timestamp !== right.timestamp) {
+      return right.timestamp - left.timestamp;
+    }
+
+    return left.index - right.index;
+  }
+
+  function compareMail163EntriesByFreshness(left, right) {
+    if (left.minuteTimestamp !== right.minuteTimestamp) {
+      return right.minuteTimestamp - left.minuteTimestamp;
+    }
+
+    if (left.timestamp !== right.timestamp) {
+      return right.timestamp - left.timestamp;
+    }
+
+    return left.index - right.index;
+  }
+
+  function collectMail163CleanupEntries(entries, filters = {}) {
+    return (Array.isArray(entries) ? entries : [])
+      .map((entry, index) => normalizeMail163Entry(entry, index))
+      .map((entry) => ({
+        ...entry,
+        ...messageMatchesFilters(entry, filters),
+      }))
+      .filter((entry) => entry.matched)
+      .filter((entry) => Boolean(entry.code))
+      .sort(compareMail163EntriesByFreshness);
+  }
+
+  function buildMail163SelectionPlan(entries, targetEntries = []) {
+    const normalizedEntries = (Array.isArray(entries) ? entries : [])
+      .map((entry, index) => normalizeMail163Entry(entry, index))
+      .map((entry) => ({
+        ...entry,
+        selected: Boolean(entry.selected),
+      }));
+    const targetSignatures = new Set(
+      (Array.isArray(targetEntries) ? targetEntries : [])
+        .map((entry, index) => normalizeMail163Entry(entry, index).signature)
+        .filter(Boolean)
+    );
+
+    const toSelect = [];
+    const toUnselect = [];
+    let selectedTargetCount = 0;
+
+    normalizedEntries.forEach((entry) => {
+      const isTarget = targetSignatures.has(entry.signature);
+      if (isTarget && entry.selected) {
+        selectedTargetCount += 1;
+      }
+      if (isTarget && !entry.selected) {
+        toSelect.push(entry);
+      }
+      if (!isTarget && entry.selected) {
+        toUnselect.push(entry);
+      }
+    });
+
+    return {
+      targetCount: targetSignatures.size,
+      selectedTargetCount,
+      expectedSelectedCount: selectedTargetCount + toSelect.length,
+      toSelect,
+      toUnselect,
+    };
+  }
+
+  function normalizeMail163PollAttempts(value, fallback = 7) {
+    const normalizedFallback = Number.isFinite(Number(fallback))
+      ? Math.max(1, Math.floor(Number(fallback)))
+      : 7;
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+      return normalizedFallback;
+    }
+
+    return Math.max(1, Math.floor(numeric));
+  }
+
+  function pickMail163VerificationEntry(entries, options = {}) {
+    const excludedCodes = new Set((options.excludeCodes || []).filter(Boolean));
+    const seenSignatures = new Set((options.seenSignatures || []).filter(Boolean));
+    const snapshot = options.snapshot || createMail163Snapshot([]);
+    const afterMinute = normalizeMinuteTimestamp(options.afterTimestamp);
+    const allowSnapshotFallback = Boolean(options.allowSnapshotFallback);
+    const allowTimeFallback = Boolean(options.allowTimeFallback);
+
+    const candidates = (Array.isArray(entries) ? entries : [])
+      .map((entry, index) => normalizeMail163Entry(entry, index))
+      .map((entry) => {
+        const filterResult = messageMatchesFilters(entry, options);
+        return {
+          ...entry,
+          ...filterResult,
+          existsInSnapshot: snapshotHasMail163Entry(snapshot, entry),
+        };
+      })
+      .filter((entry) => entry.matched)
+      .filter((entry) => Boolean(entry.code))
+      .filter((entry) => !excludedCodes.has(entry.code))
+      .filter((entry) => !seenSignatures.has(entry.signature));
+
+    const strictMatches = candidates
+      .filter((entry) => {
+        if (!allowSnapshotFallback && entry.existsInSnapshot) {
+          return false;
+        }
+
+        if (!afterMinute) {
+          return true;
+        }
+
+        if (entry.minuteTimestamp) {
+          return entry.minuteTimestamp >= afterMinute;
+        }
+
+        return !entry.existsInSnapshot;
+      })
+      .sort(compareMail163Candidates);
+
+    if (strictMatches[0]) {
+      return {
+        match: strictMatches[0],
+        usedSnapshotFallback: Boolean(strictMatches[0].existsInSnapshot),
+        usedTimeFallback: false,
+      };
+    }
+
+    if (!allowTimeFallback) {
+      return {
+        match: null,
+        usedSnapshotFallback: false,
+        usedTimeFallback: false,
+      };
+    }
+
+    const relaxedMatches = candidates
+      .filter((entry) => allowSnapshotFallback || !entry.existsInSnapshot)
+      .sort(compareMail163Candidates);
+
+    if (!relaxedMatches[0]) {
+      return {
+        match: null,
+        usedSnapshotFallback: false,
+        usedTimeFallback: false,
+      };
+    }
+
+    return {
+      match: relaxedMatches[0],
+      usedSnapshotFallback: Boolean(relaxedMatches[0].existsInSnapshot),
+      usedTimeFallback: true,
+    };
+  }
+
+  function updateRecentMail163Signatures(signatures, nextSignature, limit = DEFAULT_SIGNATURE_HISTORY_LIMIT) {
+    const nextLimit = Number.isFinite(Number(limit))
+      ? Math.max(1, Math.floor(Number(limit)))
+      : DEFAULT_SIGNATURE_HISTORY_LIMIT;
+    const nextList = Array.isArray(signatures) ? signatures.filter(Boolean) : [];
+
+    if (!nextSignature) {
+      return nextList.slice(0, nextLimit);
+    }
+
+    return [nextSignature, ...nextList.filter((signature) => signature !== nextSignature)]
+      .slice(0, nextLimit);
+  }
+
+  return {
+    buildMail163SelectionPlan,
+    buildMail163EntrySignature,
+    collectMail163CleanupEntries,
+    createMail163Snapshot,
+    extractVerificationCode,
+    messageMatchesFilters,
+    normalizeMail163Entry,
+    normalizeMail163PollAttempts,
+    normalizeMinuteTimestamp,
+    normalizeText,
+    normalizeTimestamp,
+    parseMail163Timestamp,
+    pickMail163VerificationEntry,
+    snapshotHasMail163Entry,
+    updateRecentMail163Signatures,
+  };
+});

--- a/manifest.json
+++ b/manifest.json
@@ -58,6 +58,7 @@
       "js": [
         "content/activation-utils.js",
         "content/utils.js",
+        "mail-163-utils.js",
         "content/mail-163.js"
       ],
       "all_frames": true,

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -140,6 +140,16 @@
           <button id="btn-mail-login" class="btn btn-outline btn-sm" type="button" disabled>登录</button>
         </div>
       </div>
+      <div class="data-row">
+        <span class="data-label">邮件轮询</span>
+        <div class="data-inline auto-delay-inline">
+          <div class="auto-delay-controls">
+            <input type="number" id="input-email-poll-max-attempts" class="data-input auto-delay-input" value="7" min="1"
+              max="20" step="1" title="每轮验证码轮询的最大尝试次数" />
+            <span class="data-unit">次/轮</span>
+          </div>
+        </div>
+      </div>
       <div class="data-row" id="row-email-generator">
         <span class="data-label">邮箱生成</span>
         <select id="select-email-generator" class="data-select">

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -57,6 +57,7 @@ const inputSub2ApiPassword = document.getElementById('input-sub2api-password');
 const rowSub2ApiGroup = document.getElementById('row-sub2api-group');
 const inputSub2ApiGroup = document.getElementById('input-sub2api-group');
 const selectMailProvider = document.getElementById('select-mail-provider');
+const inputEmailPollMaxAttempts = document.getElementById('input-email-poll-max-attempts');
 const btnMailLogin = document.getElementById('btn-mail-login');
 const rowEmailGenerator = document.getElementById('row-email-generator');
 const selectEmailGenerator = document.getElementById('select-email-generator');
@@ -114,6 +115,9 @@ const AUTO_STEP_DELAY_MIN_SECONDS = 0;
 const AUTO_STEP_DELAY_MAX_SECONDS = 600;
 const AUTO_STEP_DELAY_DEFAULT_MIN_SECONDS = 12;
 const AUTO_STEP_DELAY_DEFAULT_MAX_SECONDS = 18;
+const EMAIL_POLL_MAX_ATTEMPTS_MIN = 1;
+const EMAIL_POLL_MAX_ATTEMPTS_MAX = 20;
+const EMAIL_POLL_MAX_ATTEMPTS_DEFAULT = 7;
 const DEFAULT_LOCAL_CPA_STEP9_MODE = 'submit';
 
 let latestState = null;
@@ -636,6 +640,7 @@ function collectSettingsPayload() {
     sub2apiGroupName: inputSub2ApiGroup.value.trim(),
     customPassword: inputPassword.value,
     mailProvider: selectMailProvider.value,
+    emailPollMaxAttempts: normalizeEmailPollMaxAttempts(inputEmailPollMaxAttempts.value),
     emailGenerator: selectEmailGenerator.value,
     inbucketHost: inputInbucketHost.value.trim(),
     inbucketMailbox: inputInbucketMailbox.value.trim(),
@@ -647,6 +652,18 @@ function collectSettingsPayload() {
     autoStepRandomDelayMinSeconds: autoStepDelayRange.minSeconds,
     autoStepRandomDelayMaxSeconds: autoStepDelayRange.maxSeconds,
   };
+}
+
+function normalizeEmailPollMaxAttempts(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return EMAIL_POLL_MAX_ATTEMPTS_DEFAULT;
+  }
+
+  return Math.min(
+    EMAIL_POLL_MAX_ATTEMPTS_MAX,
+    Math.max(EMAIL_POLL_MAX_ATTEMPTS_MIN, Math.floor(numeric))
+  );
 }
 
 function normalizeLocalCpaStep9Mode(value = '') {
@@ -879,6 +896,7 @@ function applySettingsState(state) {
   inputSub2ApiPassword.value = state?.sub2apiPassword || '';
   inputSub2ApiGroup.value = state?.sub2apiGroupName || '';
   selectMailProvider.value = state?.mailProvider || '163';
+  inputEmailPollMaxAttempts.value = String(normalizeEmailPollMaxAttempts(state?.emailPollMaxAttempts));
   selectEmailGenerator.value = state?.emailGenerator || 'duck';
   inputInbucketHost.value = state?.inbucketHost || '';
   inputInbucketMailbox.value = state?.inbucketMailbox || '';
@@ -2287,6 +2305,15 @@ inputPassword.addEventListener('blur', () => {
   saveSettings({ silent: true }).catch(() => { });
 });
 
+inputEmailPollMaxAttempts.addEventListener('input', () => {
+  markSettingsDirty(true);
+  scheduleSettingsAutoSave();
+});
+inputEmailPollMaxAttempts.addEventListener('blur', () => {
+  inputEmailPollMaxAttempts.value = String(normalizeEmailPollMaxAttempts(inputEmailPollMaxAttempts.value));
+  saveSettings({ silent: true }).catch(() => { });
+});
+
 selectMailProvider.addEventListener('change', async () => {
   const previousProvider = latestState?.mailProvider || '';
   const nextProvider = selectMailProvider.value;
@@ -2546,6 +2573,9 @@ chrome.runtime.onMessage.addListener((message) => {
         );
         inputAutoStepDelayMinSeconds.value = String(autoStepDelayRange.minSeconds);
         inputAutoStepDelayMaxSeconds.value = String(autoStepDelayRange.maxSeconds);
+      }
+      if (message.payload.emailPollMaxAttempts !== undefined) {
+        inputEmailPollMaxAttempts.value = String(normalizeEmailPollMaxAttempts(message.payload.emailPollMaxAttempts));
       }
       break;
     }

--- a/tests/duck-mail-generation.test.js
+++ b/tests/duck-mail-generation.test.js
@@ -1,0 +1,228 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+const duckSource = fs.readFileSync('content/duck-mail.js', 'utf8');
+const backgroundSource = fs.readFileSync('background.js', 'utf8');
+
+function extractFunction(source, name) {
+  const markers = [`async function ${name}(`, `function ${name}(`];
+  const start = markers
+    .map((marker) => source.indexOf(marker))
+    .find((index) => index >= 0);
+  if (start < 0) {
+    throw new Error(`missing function ${name}`);
+  }
+
+  let parenDepth = 0;
+  let signatureEnded = false;
+  let braceStart = -1;
+  for (let i = start; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === '(') {
+      parenDepth += 1;
+    } else if (ch === ')') {
+      parenDepth -= 1;
+      if (parenDepth === 0) {
+        signatureEnded = true;
+      }
+    } else if (ch === '{' && signatureEnded) {
+      braceStart = i;
+      break;
+    }
+  }
+  if (braceStart < 0) {
+    throw new Error(`missing body for function ${name}`);
+  }
+
+  let depth = 0;
+  let end = braceStart;
+  for (; end < source.length; end += 1) {
+    const ch = source[end];
+    if (ch === '{') depth += 1;
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        end += 1;
+        break;
+      }
+    }
+  }
+
+  return source.slice(start, end);
+}
+
+test('fetchDuckEmail retries once and accepts a new address on the second click', async () => {
+  const api = new Function(`
+let currentEmail = 'old@duck.com';
+let clickCount = 0;
+const logs = [];
+const input = {
+  get value() {
+    return currentEmail;
+  },
+  set value(nextValue) {
+    currentEmail = nextValue;
+  },
+};
+const button = {
+  click() {
+    clickCount += 1;
+    if (clickCount === 2) {
+      currentEmail = 'new@duck.com';
+    }
+  },
+};
+const document = {
+  querySelector(selector) {
+    if (selector === 'input.AutofillSettingsPanel__PrivateDuckAddressValue') return input;
+    if (selector === 'button.AutofillSettingsPanel__GeneratorButton') return button;
+    return null;
+  },
+  querySelectorAll() {
+    return [];
+  },
+};
+async function waitForElement() { return button; }
+async function sleep() {}
+async function humanPause() {}
+function log(message, type) {
+  logs.push({ message, type: type || 'info' });
+}
+${extractFunction(duckSource, 'fetchDuckEmail')}
+return {
+  fetchDuckEmail,
+  snapshot() {
+    return { currentEmail, clickCount, logs };
+  },
+};
+`)();
+
+  const result = await api.fetchDuckEmail({ generateNew: true });
+  const snapshot = api.snapshot();
+
+  assert.deepEqual(result, { email: 'new@duck.com', generated: true });
+  assert.equal(snapshot.clickCount, 2);
+  assert.ok(
+    snapshot.logs.some((entry) => entry.message.includes('首次生成后地址未变化，准备重试一次')),
+    '第一次点击未拿到新地址时应记录一次重试日志'
+  );
+});
+
+test('fetchDuckEmail marks the error as fatal after two unchanged generation attempts', async () => {
+  const api = new Function(`
+let currentEmail = 'old@duck.com';
+let clickCount = 0;
+const input = {
+  get value() {
+    return currentEmail;
+  },
+};
+const button = {
+  click() {
+    clickCount += 1;
+  },
+};
+const document = {
+  querySelector(selector) {
+    if (selector === 'input.AutofillSettingsPanel__PrivateDuckAddressValue') return input;
+    if (selector === 'button.AutofillSettingsPanel__GeneratorButton') return button;
+    return null;
+  },
+  querySelectorAll() {
+    return [];
+  },
+};
+async function waitForElement() { return button; }
+async function sleep() {}
+async function humanPause() {}
+function log() {}
+${extractFunction(duckSource, 'fetchDuckEmail')}
+return {
+  fetchDuckEmail,
+  snapshot() {
+    return { clickCount };
+  },
+};
+`)();
+
+  let thrown = null;
+  try {
+    await api.fetchDuckEmail({ generateNew: true });
+  } catch (error) {
+    thrown = error;
+  }
+
+  assert.ok(thrown instanceof Error, '两次点击后仍未拿到新地址时应抛错');
+  assert.equal(thrown?.fatal, true);
+  assert.match(thrown?.message || '', /点击 2 次后仍未获得新的 Duck 地址/);
+  assert.equal(api.snapshot().clickCount, 2);
+});
+
+test('ensureAutoEmailReady stops the auto flow immediately when duck generation reports fatal', async () => {
+  const api = new Function(`
+let fetchAttempts = 0;
+let waitedForResume = false;
+const requestStopCalls = [];
+const logMessages = [];
+async function getState() {
+  return { email: '', emailGenerator: 'duck' };
+}
+function isHotmailProvider() {
+  return false;
+}
+function normalizeEmailGenerator(value) {
+  return value || 'duck';
+}
+function getEmailGeneratorLabel() {
+  return 'Duck 邮箱';
+}
+async function fetchGeneratedEmail() {
+  fetchAttempts += 1;
+  const error = new Error('duck fatal');
+  error.duckFatal = true;
+  throw error;
+}
+async function addLog(message, type) {
+  logMessages.push({ message, type });
+}
+function isDuckEmailFatalError(error) {
+  return Boolean(error?.duckFatal);
+}
+async function requestStop(options = {}) {
+  requestStopCalls.push(options);
+}
+async function broadcastAutoRunStatus() {
+  throw new Error('duck fatal should not fall through to waiting_email');
+}
+async function waitForResume() {
+  waitedForResume = true;
+}
+async function ensureHotmailAccountForFlow() {
+  throw new Error('should not allocate hotmail account');
+}
+const STOP_ERROR_MESSAGE = '流程已被用户停止。';
+const EMAIL_FETCH_MAX_ATTEMPTS = 5;
+${extractFunction(backgroundSource, 'ensureAutoEmailReady')}
+return {
+  ensureAutoEmailReady,
+  snapshot() {
+    return { fetchAttempts, waitedForResume, requestStopCalls, logMessages };
+  },
+};
+`)();
+
+  await assert.rejects(
+    () => api.ensureAutoEmailReady(2, 5, 3),
+    /流程已被用户停止。/
+  );
+
+  const snapshot = api.snapshot();
+  assert.equal(snapshot.fetchAttempts, 1);
+  assert.equal(snapshot.waitedForResume, false);
+  assert.equal(snapshot.requestStopCalls.length, 1);
+  assert.match(
+    snapshot.requestStopCalls[0]?.logMessage || '',
+    /Duck 邮箱生成失败，已立即停止自动流程/
+  );
+});

--- a/tests/email-poll-settings.test.js
+++ b/tests/email-poll-settings.test.js
@@ -1,0 +1,92 @@
+const assert = require('assert');
+const fs = require('fs');
+
+const source = fs.readFileSync('background.js', 'utf8');
+
+function extractFunction(name) {
+  const start = source.indexOf(`function ${name}(`);
+  if (start < 0) {
+    throw new Error(`missing function ${name}`);
+  }
+
+  const paramsStart = source.indexOf('(', start);
+  let paramsDepth = 0;
+  let paramsEnd = paramsStart;
+  for (; paramsEnd < source.length; paramsEnd += 1) {
+    const ch = source[paramsEnd];
+    if (ch === '(') paramsDepth += 1;
+    if (ch === ')') {
+      paramsDepth -= 1;
+      if (paramsDepth === 0) {
+        break;
+      }
+    }
+  }
+
+  const braceStart = source.indexOf('{', paramsEnd);
+  let depth = 0;
+  let end = braceStart;
+  for (; end < source.length; end += 1) {
+    const ch = source[end];
+    if (ch === '{') depth += 1;
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        end += 1;
+        break;
+      }
+    }
+  }
+
+  return source.slice(start, end);
+}
+
+const bundle = [
+  'const HOTMAIL_PROVIDER = "hotmail-api";',
+  'const EMAIL_POLL_MAX_ATTEMPTS_MIN = 1;',
+  'const EMAIL_POLL_MAX_ATTEMPTS_MAX = 20;',
+  'const EMAIL_POLL_MAX_ATTEMPTS_DEFAULT = 7;',
+  'const PERSISTED_SETTING_DEFAULTS = { emailPollMaxAttempts: 7 };',
+  'function getHotmailVerificationRequestTimestamp() { return 1234567890; }',
+  extractFunction('normalizeEmailPollMaxAttempts'),
+  extractFunction('getVerificationPollPayload'),
+].join('\n');
+
+const api = new Function(`${bundle}; return { normalizeEmailPollMaxAttempts, getVerificationPollPayload };`)();
+
+assert.strictEqual(
+  api.normalizeEmailPollMaxAttempts(undefined),
+  7,
+  'missing poll attempts should fall back to the default value'
+);
+assert.strictEqual(
+  api.normalizeEmailPollMaxAttempts(0),
+  1,
+  'poll attempts should clamp to the minimum value'
+);
+assert.strictEqual(
+  api.normalizeEmailPollMaxAttempts(99),
+  20,
+  'poll attempts should clamp to the maximum value'
+);
+
+const signupPayload = api.getVerificationPollPayload(4, {
+  email: 'demo@example.com',
+  emailPollMaxAttempts: 9,
+});
+assert.strictEqual(signupPayload.maxAttempts, 9, 'configured poll attempts should be used for step 4');
+assert.ok(signupPayload.senderFilters.includes('otp'), 'step 4 sender filters should include otp variants');
+assert.ok(signupPayload.senderFilters.includes('openai'), 'step 4 sender filters should include openai variants');
+assert.ok(signupPayload.subjectFilters.includes('chatgpt'), 'step 4 subject filters should include ChatGPT variants');
+assert.ok(signupPayload.subjectFilters.includes('openai'), 'step 4 subject filters should include OpenAI variants');
+
+const loginPayload = api.getVerificationPollPayload(7, {
+  email: 'demo@example.com',
+  emailPollMaxAttempts: 11,
+});
+assert.strictEqual(loginPayload.maxAttempts, 11, 'configured poll attempts should be used for step 7');
+assert.ok(loginPayload.senderFilters.includes('otp'), 'step 7 sender filters should include otp variants');
+assert.ok(loginPayload.subjectFilters.includes('chatgpt'), 'step 7 subject filters should include ChatGPT variants');
+assert.ok(loginPayload.subjectFilters.includes('openai'), 'step 7 subject filters should include OpenAI variants');
+
+console.log('email poll settings tests passed');

--- a/tests/mail-163-utils.test.js
+++ b/tests/mail-163-utils.test.js
@@ -1,0 +1,195 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildMail163SelectionPlan,
+  buildMail163EntrySignature,
+  collectMail163CleanupEntries,
+  createMail163Snapshot,
+  normalizeMail163PollAttempts,
+  normalizeMinuteTimestamp,
+  parseMail163Timestamp,
+  pickMail163VerificationEntry,
+  updateRecentMail163Signatures,
+} = require('../mail-163-utils.js');
+
+test('parseMail163Timestamp parses full date and same-day time labels', () => {
+  assert.equal(
+    parseMail163Timestamp('2026年4月10日 18:05'),
+    new Date(2026, 3, 10, 18, 5, 0, 0).getTime()
+  );
+
+  const now = new Date(2026, 3, 10, 23, 59, 0, 0);
+  assert.equal(
+    parseMail163Timestamp('09:41', now),
+    new Date(2026, 3, 10, 9, 41, 0, 0).getTime()
+  );
+});
+
+test('pickMail163VerificationEntry treats changed content on the same row id as a new mail', () => {
+  const before = {
+    id: 'row-1',
+    sender: 'OpenAI',
+    subject: 'ChatGPT verification code 111111',
+    ariaLabel: 'OpenAI verification 111111',
+    timestamp: Date.UTC(2026, 3, 10, 10, 0, 0),
+  };
+  const after = {
+    id: 'row-1',
+    sender: 'OpenAI',
+    subject: 'ChatGPT verification code 222222',
+    ariaLabel: 'OpenAI verification 222222',
+    timestamp: Date.UTC(2026, 3, 10, 10, 2, 0),
+  };
+
+  const result = pickMail163VerificationEntry([after], {
+    afterTimestamp: Date.UTC(2026, 3, 10, 10, 1, 0),
+    senderFilters: ['openai'],
+    subjectFilters: ['verification'],
+    snapshot: createMail163Snapshot([before]),
+  });
+
+  assert.equal(result.match.id, 'row-1');
+  assert.equal(result.match.code, '222222');
+  assert.equal(result.usedSnapshotFallback, false);
+  assert.equal(result.usedTimeFallback, false);
+});
+
+test('pickMail163VerificationEntry can recover delayed new mail by ignoring the time window after fallback', () => {
+  const delayedMail = {
+    id: 'row-delayed',
+    sender: 'OpenAI',
+    subject: 'ChatGPT verification code 141735',
+    ariaLabel: 'OpenAI verification 141735',
+    timestamp: Date.UTC(2026, 3, 10, 10, 0, 0),
+  };
+
+  const result = pickMail163VerificationEntry([delayedMail], {
+    afterTimestamp: Date.UTC(2026, 3, 10, 10, 5, 0),
+    allowTimeFallback: true,
+    senderFilters: ['openai'],
+    subjectFilters: ['verification'],
+    snapshot: createMail163Snapshot([]),
+  });
+
+  assert.equal(result.match.id, 'row-delayed');
+  assert.equal(result.match.code, '141735');
+  assert.equal(result.usedSnapshotFallback, false);
+  assert.equal(result.usedTimeFallback, true);
+});
+
+test('pickMail163VerificationEntry tracks processed mails by signature instead of only by code', () => {
+  const oldMail = {
+    id: 'row-old',
+    sender: 'OpenAI',
+    subject: 'ChatGPT verification code 333333',
+    ariaLabel: 'OpenAI verification 333333',
+    timestamp: Date.UTC(2026, 3, 10, 10, 0, 0),
+  };
+  const newMail = {
+    id: 'row-new',
+    sender: 'OpenAI',
+    subject: 'ChatGPT verification code 333333',
+    ariaLabel: 'OpenAI verification 333333 latest',
+    timestamp: Date.UTC(2026, 3, 10, 10, 8, 0),
+  };
+
+  const result = pickMail163VerificationEntry([newMail], {
+    afterTimestamp: normalizeMinuteTimestamp(Date.UTC(2026, 3, 10, 10, 5, 0)),
+    seenSignatures: [buildMail163EntrySignature(oldMail)],
+    senderFilters: ['openai'],
+    subjectFilters: ['verification'],
+    snapshot: createMail163Snapshot([]),
+  });
+
+  assert.equal(result.match.id, 'row-new');
+  assert.equal(result.match.code, '333333');
+});
+
+test('collectMail163CleanupEntries returns all matched mails including older ones for bulk deletion', () => {
+  const entries = [
+    {
+      id: 'old-mail',
+      sender: 'noreply_at_tm.openai.com_nimbly-army-cloak@duck.com',
+      subject: 'Your ChatGPT code is 111111',
+      ariaLabel: 'OpenAI old verification 111111',
+      timestamp: Date.UTC(2026, 3, 10, 10, 0, 0),
+    },
+    {
+      id: 'new-mail',
+      sender: 'otp_at_tm1.openai.com_crib-embark-tiara@duck.com',
+      subject: 'Your OpenAI code is 222222',
+      ariaLabel: 'OpenAI latest verification 222222',
+      timestamp: Date.UTC(2026, 3, 10, 10, 8, 0),
+    },
+    {
+      id: 'ignore-mail',
+      sender: 'alerts@example.com',
+      subject: 'Welcome message',
+      ariaLabel: 'welcome',
+      timestamp: Date.UTC(2026, 3, 10, 10, 9, 0),
+    },
+  ];
+
+  const result = collectMail163CleanupEntries(entries, {
+    senderFilters: ['openai', 'noreply', 'otp'],
+    subjectFilters: ['chatgpt', 'openai', 'code', 'otp'],
+  });
+
+  assert.deepEqual(result.map((item) => item.id), ['new-mail', 'old-mail']);
+});
+
+test('buildMail163SelectionPlan clears unrelated selected mails before selecting current cleanup candidates', () => {
+  const entries = [
+    {
+      id: 'stale-selected',
+      sender: 'alerts@example.com',
+      subject: 'Welcome message',
+      ariaLabel: 'welcome',
+      timestamp: Date.UTC(2026, 3, 10, 10, 9, 0),
+      selected: true,
+    },
+    {
+      id: 'cleanup-target-a',
+      sender: 'noreply_at_tm.openai.com_nimbly-army-cloak@duck.com',
+      subject: 'Your ChatGPT code is 111111',
+      ariaLabel: 'OpenAI old verification 111111',
+      timestamp: Date.UTC(2026, 3, 10, 10, 0, 0),
+      selected: false,
+    },
+    {
+      id: 'cleanup-target-b',
+      sender: 'otp_at_tm1.openai.com_crib-embark-tiara@duck.com',
+      subject: 'Your OpenAI code is 222222',
+      ariaLabel: 'OpenAI latest verification 222222',
+      timestamp: Date.UTC(2026, 3, 10, 10, 8, 0),
+      selected: true,
+    },
+  ];
+
+  const candidates = collectMail163CleanupEntries(entries, {
+    senderFilters: ['openai', 'noreply', 'otp'],
+    subjectFilters: ['chatgpt', 'openai', 'code', 'otp'],
+  });
+  const selectionPlan = buildMail163SelectionPlan(entries, candidates);
+
+  assert.equal(selectionPlan.targetCount, 2);
+  assert.equal(selectionPlan.selectedTargetCount, 1);
+  assert.equal(selectionPlan.expectedSelectedCount, 2);
+  assert.deepEqual(selectionPlan.toUnselect.map((item) => item.id), ['stale-selected']);
+  assert.deepEqual(selectionPlan.toSelect.map((item) => item.id), ['cleanup-target-a']);
+});
+
+test('normalizeMail163PollAttempts honors configured values below seven', () => {
+  assert.equal(normalizeMail163PollAttempts(undefined), 7);
+  assert.equal(normalizeMail163PollAttempts(3), 3);
+  assert.equal(normalizeMail163PollAttempts(0), 1);
+});
+
+test('updateRecentMail163Signatures dedupes history and enforces the limit', () => {
+  const result = updateRecentMail163Signatures(['sig-a', 'sig-b', 'sig-a'], 'sig-c', 3);
+  assert.deepEqual(result, ['sig-c', 'sig-a', 'sig-b']);
+
+  const replaced = updateRecentMail163Signatures(result, 'sig-b', 2);
+  assert.deepEqual(replaced, ['sig-b', 'sig-c']);
+});

--- a/tests/signup-page-auth-retry.test.js
+++ b/tests/signup-page-auth-retry.test.js
@@ -1,0 +1,154 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+const source = fs.readFileSync('content/signup-page.js', 'utf8');
+
+function extractConst(name) {
+  const start = source.indexOf(`const ${name} = `);
+  if (start < 0) {
+    throw new Error(`missing const ${name}`);
+  }
+
+  const semicolon = source.indexOf(';', start);
+  if (semicolon < 0) {
+    throw new Error(`missing semicolon for const ${name}`);
+  }
+
+  return source.slice(start, semicolon + 1);
+}
+
+function extractFunction(name) {
+  const markers = [`async function ${name}(`, `function ${name}(`];
+  const start = markers
+    .map((marker) => source.indexOf(marker))
+    .find((index) => index >= 0);
+  if (start < 0) {
+    throw new Error(`missing function ${name}`);
+  }
+
+  let parenDepth = 0;
+  let signatureEnded = false;
+  let braceStart = -1;
+  for (let i = start; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === '(') {
+      parenDepth += 1;
+    } else if (ch === ')') {
+      parenDepth -= 1;
+      if (parenDepth === 0) {
+        signatureEnded = true;
+      }
+    } else if (ch === '{' && signatureEnded) {
+      braceStart = i;
+      break;
+    }
+  }
+  if (braceStart < 0) {
+    throw new Error(`missing body for function ${name}`);
+  }
+
+  let depth = 0;
+  let end = braceStart;
+  for (; end < source.length; end += 1) {
+    const ch = source[end];
+    if (ch === '{') depth += 1;
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        end += 1;
+        break;
+      }
+    }
+  }
+
+  return source.slice(start, end);
+}
+
+test('matchesAuthTimeoutErrorPage recognizes error occurred when Try again is visible', () => {
+  const api = new Function(`
+${extractConst('AUTH_TIMEOUT_ERROR_TITLE_PATTERN')}
+${extractConst('AUTH_TIMEOUT_ERROR_DETAIL_PATTERN')}
+${extractFunction('getAuthRetryButton')}
+${extractFunction('matchesAuthTimeoutErrorPage')}
+
+let pageText = '';
+let titleText = '';
+let pathname = '/log-in';
+let retryButton = null;
+
+const location = {
+  get pathname() {
+    return pathname;
+  },
+};
+const document = {
+  querySelector(selector) {
+    if (selector === 'button[data-dd-action-name="Try again"]') {
+      return retryButton;
+    }
+    return null;
+  },
+  querySelectorAll() {
+    return retryButton ? [retryButton] : [];
+  },
+  get title() {
+    return titleText;
+  },
+};
+
+function isVisibleElement() {
+  return true;
+}
+
+function isActionEnabled(element) {
+  return element?.getAttribute?.('aria-disabled') !== 'true';
+}
+
+function getActionText(element) {
+  return [
+    element?.textContent,
+    element?.getAttribute?.('aria-label'),
+    element?.getAttribute?.('title'),
+    element?.getAttribute?.('data-dd-action-name'),
+  ].filter(Boolean).join(' ').trim();
+}
+
+function getPageTextSnapshot() {
+  return pageText;
+}
+
+return {
+  matchesAuthTimeoutErrorPage,
+  setState(nextState = {}) {
+    pageText = nextState.pageText ?? pageText;
+    titleText = nextState.titleText ?? titleText;
+    pathname = nextState.pathname ?? pathname;
+    retryButton = nextState.retryButton ?? retryButton;
+  },
+};
+`)();
+
+  const button = {
+    textContent: 'Try again',
+    getAttribute(name) {
+      const attrs = {
+        'aria-disabled': 'false',
+        'data-dd-action-name': 'Try again',
+      };
+      return attrs[name] ?? null;
+    },
+  };
+
+  api.setState({
+    retryButton: button,
+    pageText: 'Oops, an error occurred! Please try again.',
+    titleText: 'An error occurred',
+    pathname: '/log-in',
+  });
+
+  assert.equal(
+    api.matchesAuthTimeoutErrorPage(/\/log-in(?:[/?#]|$)/i),
+    true
+  );
+});


### PR DESCRIPTION
- 为侧边栏补充邮件轮询次数配置，并让 163 严格遵守配置值
- 在 163 批量删除前清空无关勾选，避免工具栏删除误删历史选中项
- 恢复 Duck 生成页内重试并保留二次失败后的 fatal stop
- 为 OpenAI 认证异常页补充 error occurred 识别与回归测试