### PR TITLE
fix: 重发验证码后重新聚焦邮箱标签页

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /docs/md
 
 /.github
+
+.spec-workflow

--- a/background.js
+++ b/background.js
@@ -1682,6 +1682,10 @@ function getContentScriptResponseTimeoutMs(message) {
     return 45000;
   }
 
+  if (message.type === 'RESEND_VERIFICATION_CODE') {
+    return 75000;
+  }
+
   return 30000;
 }
 
@@ -4585,6 +4589,33 @@ function getVerificationCodeLabel(step) {
   return step === 4 ? '注册' : '登录';
 }
 
+async function openOrFocusMailTab(mail) {
+  if (!mail || mail.provider === HOTMAIL_PROVIDER) {
+    return null;
+  }
+
+  const alive = await isTabAlive(mail.source);
+  if (alive) {
+    if (mail.navigateOnReuse) {
+      return await reuseOrCreateTab(mail.source, mail.url, {
+        inject: mail.inject,
+        injectSource: mail.injectSource,
+      });
+    }
+
+    const tabId = await getTabId(mail.source);
+    if (Number.isInteger(tabId)) {
+      await chrome.tabs.update(tabId, { active: true });
+      return tabId;
+    }
+  }
+
+  return await reuseOrCreateTab(mail.source, mail.url, {
+    inject: mail.inject,
+    injectSource: mail.injectSource,
+  });
+}
+
 function getVerificationPollPayload(step, state, overrides = {}) {
   if (step === 4) {
     return {
@@ -4670,6 +4701,7 @@ async function pollFreshVerificationCode(step, state, mail, pollOverrides = {}) 
     throwIfStopped();
     if (round > 1) {
       await requestVerificationCodeResend(step);
+      await openOrFocusMailTab(mail);
     }
 
     const payload = getVerificationPollPayload(step, state, {
@@ -4769,6 +4801,7 @@ async function resolveVerificationStep(step, state, mail, options = {}) {
   if (requestFreshCodeFirst) {
     try {
       await requestVerificationCodeResend(step);
+      await openOrFocusMailTab(mail);
       await addLog(`步骤 ${step}：已先请求一封新的${getVerificationCodeLabel(step)}验证码，再开始轮询邮箱。`, 'warn');
     } catch (err) {
       if (isStopError(err) || (step === 7 && isStep7RestartFromStep6Error(err))) {
@@ -4866,25 +4899,7 @@ async function executeStep4(state) {
     await addLog(`步骤 4：正在通过 ${mail.label} 轮询验证码...`);
   } else {
     await addLog(`步骤 4：正在打开${mail.label}...`);
-
-    // For mail tabs, only create if not alive — don't navigate (preserves login session)
-    const alive = await isTabAlive(mail.source);
-    if (alive) {
-      if (mail.navigateOnReuse) {
-        await reuseOrCreateTab(mail.source, mail.url, {
-          inject: mail.inject,
-          injectSource: mail.injectSource,
-        });
-      } else {
-        const tabId = await getTabId(mail.source);
-        await chrome.tabs.update(tabId, { active: true });
-      }
-    } else {
-      await reuseOrCreateTab(mail.source, mail.url, {
-        inject: mail.inject,
-        injectSource: mail.injectSource,
-      });
-    }
+    await openOrFocusMailTab(mail);
   }
 
   await resolveVerificationStep(4, state, mail, {
@@ -4996,24 +5011,7 @@ async function runStep7Attempt(state) {
     await addLog(`步骤 7：正在通过 ${mail.label} 轮询验证码...`);
   } else {
     await addLog(`步骤 7：正在打开${mail.label}...`);
-
-    const alive = await isTabAlive(mail.source);
-    if (alive) {
-      if (mail.navigateOnReuse) {
-        await reuseOrCreateTab(mail.source, mail.url, {
-          inject: mail.inject,
-          injectSource: mail.injectSource,
-        });
-      } else {
-        const tabId = await getTabId(mail.source);
-        await chrome.tabs.update(tabId, { active: true });
-      }
-    } else {
-      await reuseOrCreateTab(mail.source, mail.url, {
-        inject: mail.inject,
-        injectSource: mail.injectSource,
-      });
-    }
+    await openOrFocusMailTab(mail);
   }
 
   await resolveVerificationStep(7, state, mail, {

--- a/content/signup-page.js
+++ b/content/signup-page.js
@@ -271,9 +271,14 @@ async function resendVerificationCode(step, timeout = 45000) {
       await humanPause(350, 900);
       simulateClick(action);
       await sleep(1200);
+      const readyResult = await waitForVerificationPageAfterResend(step);
+      if (readyResult?.restartFromStep6) {
+        return readyResult;
+      }
       return {
         resent: true,
         buttonText: getActionText(action),
+        ...(readyResult?.verificationRequestedAt ? { verificationRequestedAt: readyResult.verificationRequestedAt } : {}),
       };
     }
 
@@ -286,6 +291,47 @@ async function resendVerificationCode(step, timeout = 45000) {
   }
 
   throw new Error('无法点击重新发送验证码按钮。URL: ' + location.href);
+}
+
+async function waitForVerificationPageAfterResend(step, timeout = 15000) {
+  const start = Date.now();
+  let loggedWaiting = false;
+
+  while (Date.now() - start < timeout) {
+    throwIfStopped();
+
+    if (step === 7) {
+      const prepareResult = await prepareLoginCodeFlow(5000);
+      if (prepareResult?.restartFromStep6) {
+        return prepareResult;
+      }
+
+      if (prepareResult?.ready) {
+        log('步骤 7：重新发送后已回到邮箱验证码页面。', 'ok');
+        return prepareResult;
+      }
+    }
+
+    const target = getVerificationCodeTarget();
+    if (target) {
+      log(`步骤 ${step}：重新发送后验证码输入框已就绪。`, 'ok');
+      return { ready: true, mode: target.type };
+    }
+
+    if (isEmailVerificationPage() && isVerificationPageStillVisible()) {
+      log(`步骤 ${step}：重新发送后已回到邮箱验证码页面。`, 'ok');
+      return { ready: true, mode: 'verification_page' };
+    }
+
+    if (!loggedWaiting) {
+      loggedWaiting = true;
+      log(`步骤 ${step}：已点击重新发送，正在等待页面切回邮箱验证码页...`);
+    }
+
+    await sleep(250);
+  }
+
+  throw new Error(`重新发送验证码后，页面未切回邮箱验证码页。URL: ${location.href}`);
 }
 
 // ============================================================

--- a/tests/resend-mail-tab-focus.test.js
+++ b/tests/resend-mail-tab-focus.test.js
@@ -1,0 +1,142 @@
+const assert = require('assert');
+const fs = require('fs');
+const test = require('node:test');
+
+const source = fs.readFileSync('background.js', 'utf8');
+
+function extractFunction(name) {
+  const markers = [`async function ${name}(`, `function ${name}(`];
+  const start = markers.map((marker) => source.indexOf(marker)).find((index) => index >= 0);
+  if (start < 0) {
+    throw new Error(`missing function ${name}`);
+  }
+
+  let parenDepth = 0;
+  let signatureEnded = false;
+  let braceStart = -1;
+  for (let i = start; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === '(') {
+      parenDepth += 1;
+    } else if (ch === ')') {
+      parenDepth -= 1;
+      if (parenDepth === 0) {
+        signatureEnded = true;
+      }
+    } else if (ch === '{' && signatureEnded) {
+      braceStart = i;
+      break;
+    }
+  }
+
+  if (braceStart < 0) {
+    throw new Error(`missing body for function ${name}`);
+  }
+
+  let depth = 0;
+  let end = braceStart;
+  for (; end < source.length; end += 1) {
+    const ch = source[end];
+    if (ch === '{') depth += 1;
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        end += 1;
+        break;
+      }
+    }
+  }
+
+  return source.slice(start, end);
+}
+
+test('resolveVerificationStep refocuses mail tab after requesting a fresh code first', async () => {
+  const bundle = [
+    extractFunction('isStopError'),
+    extractFunction('openOrFocusMailTab'),
+    extractFunction('resolveVerificationStep'),
+  ].join('\n');
+
+  const api = new Function(`
+const HOTMAIL_PROVIDER = 'hotmail-api';
+const calls = [];
+
+function getVerificationCodeStateKey(step) {
+  return step === 4 ? 'lastSignupCode' : 'lastLoginCode';
+}
+function throwIfStopped() {}
+function getHotmailVerificationPollConfig() {
+  return {};
+}
+function getVerificationCodeLabel(step) {
+  return step === 4 ? '注册' : '登录';
+}
+function isStep7RestartFromStep6Error() {
+  return false;
+}
+async function requestVerificationCodeResend(step) {
+  calls.push(['resend', step]);
+}
+async function addLog(message) {
+  calls.push(['log', message]);
+}
+async function pollFreshVerificationCode(step) {
+  calls.push(['poll', step]);
+  return { code: '123456', emailTimestamp: 1000 };
+}
+async function submitVerificationCode() {
+  calls.push(['submit']);
+  return { success: true };
+}
+async function setState(payload) {
+  calls.push(['setState', payload]);
+}
+async function completeStepFromBackground(step, payload) {
+  calls.push(['complete', step, payload]);
+}
+async function isTabAlive(source) {
+  calls.push(['isTabAlive', source]);
+  return true;
+}
+async function getTabId(source) {
+  calls.push(['getTabId', source]);
+  return 66;
+}
+async function reuseOrCreateTab() {
+  throw new Error('should not navigate existing 2925 tab in this test');
+}
+const chrome = {
+  tabs: {
+    async update(tabId, payload) {
+      calls.push(['tabs.update', tabId, payload]);
+      return { id: tabId, ...payload };
+    },
+  },
+};
+
+${bundle}
+
+return {
+  resolveVerificationStep,
+  snapshot() {
+    return calls;
+  },
+};
+`)();
+
+  await api.resolveVerificationStep(
+    4,
+    {},
+    { provider: '2925', source: 'mail-2925', url: 'https://2925.com/#/mailList', label: '2925 邮箱' },
+    { requestFreshCodeFirst: true }
+  );
+
+  const calls = api.snapshot();
+  const resendIndex = calls.findIndex((entry) => entry[0] === 'resend');
+  const focusIndex = calls.findIndex((entry) => entry[0] === 'tabs.update' && entry[1] === 66 && entry[2]?.active === true);
+  const pollIndex = calls.findIndex((entry) => entry[0] === 'poll');
+
+  assert.ok(resendIndex >= 0, '应先请求重发验证码');
+  assert.ok(focusIndex > resendIndex, '重发后应重新激活邮箱页');
+  assert.ok(pollIndex > focusIndex, '激活邮箱页后才开始轮询');
+});

--- a/tests/resend-verification-page-recovery.test.js
+++ b/tests/resend-verification-page-recovery.test.js
@@ -1,0 +1,153 @@
+const assert = require('assert');
+const fs = require('fs');
+const test = require('node:test');
+
+const source = fs.readFileSync('content/signup-page.js', 'utf8');
+
+function extractFunction(name) {
+  const markers = [`async function ${name}(`, `function ${name}(`];
+  const start = markers
+    .map((marker) => source.indexOf(marker))
+    .find((index) => index >= 0);
+  if (start < 0) {
+    throw new Error(`missing function ${name}`);
+  }
+
+  let parenDepth = 0;
+  let signatureEnded = false;
+  let braceStart = -1;
+  for (let i = start; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === '(') {
+      parenDepth += 1;
+    } else if (ch === ')') {
+      parenDepth -= 1;
+      if (parenDepth === 0) {
+        signatureEnded = true;
+      }
+    } else if (ch === '{' && signatureEnded) {
+      braceStart = i;
+      break;
+    }
+  }
+
+  if (braceStart < 0) {
+    throw new Error(`missing body for function ${name}`);
+  }
+
+  let depth = 0;
+  let end = braceStart;
+  for (; end < source.length; end += 1) {
+    const ch = source[end];
+    if (ch === '{') depth += 1;
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        end += 1;
+        break;
+      }
+    }
+  }
+
+  return source.slice(start, end);
+}
+
+test('waitForVerificationPageAfterResend waits until signup verification page becomes visible', async () => {
+  const bundle = [
+    extractFunction('waitForVerificationPageAfterResend'),
+  ].join('\n');
+
+  const api = new Function(`
+let now = 0;
+let verificationVisible = false;
+const logs = [];
+const location = { href: 'https://auth.openai.com/u/create-account/email-verification' };
+
+function throwIfStopped() {}
+async function prepareLoginCodeFlow() {
+  throw new Error('step 4 should not call prepareLoginCodeFlow');
+}
+function getVerificationCodeTarget() {
+  return null;
+}
+function isEmailVerificationPage() {
+  return verificationVisible;
+}
+function isVerificationPageStillVisible() {
+  return verificationVisible;
+}
+function log(message, level = 'info') {
+  logs.push({ message, level });
+}
+async function sleep(ms) {
+  now += ms;
+  if (now >= 250) verificationVisible = true;
+}
+
+Date.now = () => now;
+
+${bundle}
+
+return {
+  waitForVerificationPageAfterResend,
+  snapshot() {
+    return { logs };
+  },
+};
+`)();
+
+  const result = await api.waitForVerificationPageAfterResend(4, 2000);
+  const state = api.snapshot();
+
+  assert.deepStrictEqual(result, { ready: true, mode: 'verification_page' });
+  assert.ok(
+    state.logs.some((entry) => entry.message.includes('正在等待页面切回邮箱验证码页')),
+    '应记录等待页面切换日志'
+  );
+  assert.ok(
+    state.logs.some((entry) => entry.message.includes('已回到邮箱验证码页面')),
+    '应记录页面恢复日志'
+  );
+});
+
+test('waitForVerificationPageAfterResend returns restart signal for step 7', async () => {
+  const bundle = [
+    extractFunction('waitForVerificationPageAfterResend'),
+  ].join('\n');
+
+  const api = new Function(`
+const restartSignal = {
+  restartFromStep6: true,
+  reason: 'login_timeout_error_page',
+  url: 'https://auth.openai.com/u/login',
+};
+const location = { href: restartSignal.url };
+
+function throwIfStopped() {}
+async function prepareLoginCodeFlow() {
+  return restartSignal;
+}
+function getVerificationCodeTarget() {
+  return null;
+}
+function isEmailVerificationPage() {
+  return false;
+}
+function isVerificationPageStillVisible() {
+  return false;
+}
+function log() {}
+async function sleep() {}
+
+${bundle}
+
+return { waitForVerificationPageAfterResend };
+`)();
+
+  const result = await api.waitForVerificationPageAfterResend(7, 2000);
+  assert.deepStrictEqual(result, {
+    restartFromStep6: true,
+    reason: 'login_timeout_error_page',
+    url: 'https://auth.openai.com/u/login',
+  });
+});


### PR DESCRIPTION
**描述**

- 修复 step 4 / step 7 点击“重发验证码”后未立即切回邮箱标签页的问题
- 针对 `2925` 邮箱场景，重发成功后会重新激活 `2925` 收件箱标签页，再开始轮询新验证码
- 抽取统一的邮箱页聚焦逻辑，减少 step 4 / step 7 重复代码
- 为 `RESEND_VERIFICATION_CODE` 增加更长响应超时，避免认证页重发后等待状态切换时被后台过早判超时
- 新增测试覆盖：
  - 重发后认证页恢复等待
  - 重发后邮箱标签页重新聚焦
  - Stop 信号传播不回退

**✅****验证**

- `node --test tests/resend-mail-tab-focus.test.js`
- `node --test tests/resend-verification-page-recovery.test.js`
- `node --test tests/verification-stop-propagation.test.js`