### PR TITLE
fix: #56 2925发送邮件后到2925tab页等待

### DIFF
--- a/background.js
+++ b/background.js
@@ -4640,6 +4640,15 @@ async function requestVerificationCodeResend(step) {
     throw new Error(result.error);
   }
 
+  const currentState = await getState();
+  if (currentState.mailProvider === '2925') {
+    const mailTabId = await getTabId('mail-2925');
+    if (mailTabId) {
+      await chrome.tabs.update(mailTabId, { active: true });
+      await addLog(`步骤 ${step}：已切换到 2925 邮箱标签页等待新邮件。`, 'info');
+    }
+  }
+
   return Date.now();
 }
 


### PR DESCRIPTION
遵循最小改动原则，修复 #56  2925发邮件后跳到邮箱tab页等待新邮件