### PR TITLE
Fix: 修复 Step 9 本地回调成功状态的多语言识别，以及 log 的乱码问题

### DIFF
--- a/background.js
+++ b/background.js
@@ -7905,7 +7905,7 @@ async function executeCpaStep9(state) {
     inject: injectFiles,
     timeoutMs: 45000,
     retryDelayMs: 900,
-    logMessage: '姝ラ 9锛欳PA 闈㈡澘浠嶅湪鍔犺浇锛屾鍦ㄩ噸璇曡繛鎺ュ唴瀹硅剼鏈?..',
+    logMessage: '步骤 9：CPA 面板仍在加载，正在重试连接...',
   });
 
   await addLog('步骤 9：正在填写回调地址...');

--- a/content/vps-panel.js
+++ b/content/vps-panel.js
@@ -222,13 +222,32 @@ function summarizeStatusBadgeEntries(entries) {
     .join(' | ');
 }
 
+const STEP9_SUCCESS_STATUSES = new Set([
+  'Authentication successful!',
+  'Аутентификация успешна!',
+  '认证成功！',
+]);
+
+function normalizeStep9StatusText(statusText) {
+  return String(statusText || '').replace(/\s+/g, ' ').trim();
+}
+
+function isStep9SuccessStatus(statusText) {
+  return STEP9_SUCCESS_STATUSES.has(normalizeStep9StatusText(statusText));
+}
+
+function isStep9SuccessLikeStatus(statusText) {
+  const text = normalizeStep9StatusText(statusText);
+  return /authentication successful|аутентификац.*успеш|认证成功/i.test(text);
+}
+
 function getStatusBadgeDiagnostics() {
   const entries = getStatusBadgeEntries();
   const visibleEntries = entries.filter((entry) => entry.visible);
   const selectedEntry = visibleEntries[0] || null;
   const selectedText = selectedEntry?.text || '';
-  const successLikeEntries = visibleEntries.filter((entry) => /认证成功/.test(entry.text || ''));
-  const exactSuccessEntries = visibleEntries.filter((entry) => entry.text === '认证成功！');
+  const successLikeEntries = visibleEntries.filter((entry) => isStep9SuccessLikeStatus(entry.text));
+  const exactSuccessEntries = visibleEntries.filter((entry) => isStep9SuccessStatus(entry.text));
   const visibleSummary = summarizeStatusBadgeEntries(visibleEntries);
   const pageSnippet = getPageTextSnippet();
 
@@ -312,7 +331,7 @@ async function waitForExactSuccessBadge(timeout = STEP9_SUCCESS_BADGE_TIMEOUT_MS
     if (typeof isRecoverableStep9AuthFailure === 'function' && isRecoverableStep9AuthFailure(statusText)) {
       throw new Error(`STEP9_OAUTH_RETRY::${statusText}`);
     }
-    if (statusText === '认证成功！') {
+    if (isStep9SuccessStatus(statusText)) {
       return statusText;
     }
     await sleep(200);
@@ -328,8 +347,8 @@ async function waitForExactSuccessBadge(timeout = STEP9_SUCCESS_BADGE_TIMEOUT_MS
     throw new Error(`STEP9_OAUTH_RETRY::${finalText}${diagnosticsSuffix}`);
   }
   throw new Error(finalText
-    ? `CPA 面板状态不是“认证成功！”，当前为“${finalText}”。${diagnosticsSuffix}`
-    : `CPA 面板长时间未出现“认证成功！”状态徽标。${diagnosticsSuffix}`);
+    ? `CPA 面板状态未进入成功状态，当前为“${finalText}”。${diagnosticsSuffix}`
+    : `CPA 面板长时间未出现成功状态徽标。${diagnosticsSuffix}`);
 }
 
 function findManagementKeyInput() {


### PR DESCRIPTION
## Summary
- 将 Step 9 的成功状态识别从仅支持中文改为支持中文、英文、俄文三种文案
- 使用明确白名单匹配成功状态，避免本地回调成功后因界面语言不同而误判失败
- 将超时后的报错文案调整为中性描述，减少误导
- background 有一个乱码的 log 顺手修正了

## Test plan
- [x] node --check content/vps-panel.js
- [ ] 在中文界面的 CPA 面板手动验证 Step 9
- [ ] 在英文界面的 CPA 面板手动验证 Step 9
- [ ] 在俄文界面的 CPA 面板手动验证 Step 9
