### PR TITLE
优化 ChatGPT OAuth 官网注册与登录流程

### DIFF
--- a/background.js
+++ b/background.js
@@ -84,6 +84,11 @@ const {
 } = self.MultiPageActivationUtils;
 
 const LOG_PREFIX = '[MultiPage:bg]';
+const CHATGPT_HOME_URL = 'https://chatgpt.com/';
+const CHATGPT_PAGE_SOURCE = 'chatgpt-page';
+const SIGNUP_PAGE_INJECT_FILES = ['content/activation-utils.js', 'content/utils.js', 'content/signup-page.js'];
+const FIRST_AUTOMATION_STEP = 2;
+const LAST_AUTOMATION_STEP = 10;
 const DUCK_AUTOFILL_URL = 'https://duckduckgo.com/email/settings/autofill';
 const ICLOUD_SETUP_URLS = [
   'https://setup.icloud.com.cn/setup/ws/1',
@@ -231,7 +236,7 @@ const DEFAULT_STATE = {
   currentStep: 0, // 当前流程执行到的步骤编号。
   stepStatuses: {
     1: 'pending', 2: 'pending', 3: 'pending', 4: 'pending', 5: 'pending', // 运行时步骤状态映射，不要手动预填。
-    6: 'pending', 7: 'pending', 8: 'pending', 9: 'pending',
+    6: 'pending', 7: 'pending', 8: 'pending', 9: 'pending', 10: 'pending',
   },
   oauthUrl: null, // 运行时抓取到的 OAuth 地址，不要手动预填。
   email: null, // 运行时邮箱，由程序自动获取并写入，不能手动预填。
@@ -1880,7 +1885,8 @@ function isGeneratedAliasProvider(stateOrProvider, mail2925Mode = undefined) {
   const provider = typeof stateOrProvider === 'string'
     ? stateOrProvider
     : stateOrProvider?.mailProvider;
-  if (provider === GMAIL_PROVIDER) {
+  const gmailProvider = typeof GMAIL_PROVIDER !== 'undefined' ? GMAIL_PROVIDER : 'gmail';
+  if (provider === gmailProvider) {
     return true;
   }
   const resolvedMail2925Mode = mail2925Mode !== undefined
@@ -3217,6 +3223,10 @@ function isSignupPasswordPageUrl(rawUrl) {
     && /\/create-account\/password(?:[/?#]|$)/i.test(parsed.pathname || '');
 }
 
+function isChatGptPageHost(hostname = '') {
+  return ['chatgpt.com', 'www.chatgpt.com'].includes(hostname);
+}
+
 function is163MailHost(hostname = '') {
   return hostname === 'mail.163.com'
     || hostname.endsWith('.mail.163.com')
@@ -3262,6 +3272,8 @@ function matchesSourceUrlFamily(source, candidateUrl, referenceUrl) {
   switch (source) {
     case 'signup-page':
       return isSignupPageHost(candidate.hostname);
+    case 'chatgpt-page':
+      return isChatGptPageHost(candidate.hostname);
     case 'duck-mail':
       return candidate.hostname === 'duckduckgo.com' && candidate.pathname.startsWith('/email/');
     case 'qq-mail':
@@ -3998,6 +4010,7 @@ function getSourceLabel(source) {
     'gmail-mail': 'Gmail 邮箱',
     'sidepanel': '侧边栏',
     'signup-page': '认证页',
+    'chatgpt-page': 'ChatGPT 页面',
     'vps-panel': 'CPA 面板',
     'sub2api-panel': 'SUB2API 后台',
     'qq-mail': 'QQ 邮箱',
@@ -4087,7 +4100,15 @@ function isStepDoneStatus(status) {
 }
 
 function getFirstUnfinishedStep(statuses = {}) {
-  for (let step = 1; step <= 9; step++) {
+  const firstStep = typeof FIRST_AUTOMATION_STEP !== 'undefined' ? FIRST_AUTOMATION_STEP : 2;
+  const fallbackLastStep = Math.max(
+    9,
+    ...Object.keys((typeof DEFAULT_STATE !== 'undefined' ? DEFAULT_STATE.stepStatuses : statuses) || {})
+      .map(Number)
+      .filter(Number.isFinite)
+  );
+  const lastStep = typeof LAST_AUTOMATION_STEP !== 'undefined' ? LAST_AUTOMATION_STEP : fallbackLastStep;
+  for (let step = firstStep; step <= lastStep; step++) {
     if (!isStepDoneStatus(statuses[step] || 'pending')) {
       return step;
     }
@@ -4096,7 +4117,26 @@ function getFirstUnfinishedStep(statuses = {}) {
 }
 
 function hasSavedProgress(statuses = {}) {
-  return Object.values({ ...DEFAULT_STATE.stepStatuses, ...statuses }).some((status) => status !== 'pending');
+  const mergedStatuses = { ...DEFAULT_STATE.stepStatuses, ...statuses };
+  const firstStep = typeof FIRST_AUTOMATION_STEP !== 'undefined' ? FIRST_AUTOMATION_STEP : 2;
+  const fallbackLastStep = Math.max(
+    9,
+    ...Object.keys(mergedStatuses || {})
+      .map(Number)
+      .filter(Number.isFinite)
+  );
+  const lastStep = typeof LAST_AUTOMATION_STEP !== 'undefined' ? LAST_AUTOMATION_STEP : fallbackLastStep;
+  for (let step = firstStep; step <= lastStep; step++) {
+    if (mergedStatuses[step] !== 'pending') {
+      return true;
+    }
+  }
+  return false;
+}
+
+function getPreviousAutomationStep(step) {
+  const firstStep = typeof FIRST_AUTOMATION_STEP !== 'undefined' ? FIRST_AUTOMATION_STEP : 2;
+  return step > firstStep ? step - 1 : null;
 }
 
 function getDownstreamStateResets(step) {
@@ -4119,6 +4159,11 @@ function getDownstreamStateResets(step) {
   }
   if (step === 2) {
     return {
+      oauthUrl: null,
+      sub2apiSessionId: null,
+      sub2apiOAuthState: null,
+      sub2apiGroupId: null,
+      sub2apiDraftName: null,
       password: null,
       lastEmailTimestamp: null,
       signupVerificationRequestedAt: null,
@@ -4159,7 +4204,8 @@ async function invalidateDownstreamAfterStepRestart(step, options = {}) {
   const statuses = { ...(state.stepStatuses || {}) };
   const changedSteps = [];
 
-  for (let downstream = step + 1; downstream <= 9; downstream++) {
+  const lastStep = typeof LAST_AUTOMATION_STEP !== 'undefined' ? LAST_AUTOMATION_STEP : 10;
+  for (let downstream = step + 1; downstream <= lastStep; downstream++) {
     if (statuses[downstream] !== 'pending') {
       statuses[downstream] = 'pending';
       changedSteps.push(downstream);
@@ -4189,10 +4235,22 @@ function clearStopRequest() {
 }
 
 function getRunningSteps(statuses = {}) {
-  return Object.entries({ ...DEFAULT_STATE.stepStatuses, ...statuses })
-    .filter(([, status]) => status === 'running')
-    .map(([step]) => Number(step))
-    .sort((a, b) => a - b);
+  const mergedStatuses = { ...DEFAULT_STATE.stepStatuses, ...statuses };
+  const firstStep = typeof FIRST_AUTOMATION_STEP !== 'undefined' ? FIRST_AUTOMATION_STEP : 2;
+  const fallbackLastStep = Math.max(
+    9,
+    ...Object.keys(mergedStatuses || {})
+      .map(Number)
+      .filter(Number.isFinite)
+  );
+  const lastStep = typeof LAST_AUTOMATION_STEP !== 'undefined' ? LAST_AUTOMATION_STEP : fallbackLastStep;
+  const runningSteps = [];
+  for (let step = firstStep; step <= lastStep; step++) {
+    if (mergedStatuses[step] === 'running') {
+      runningSteps.push(step);
+    }
+  }
+  return runningSteps;
 }
 
 function getAutoRunStatusPayload(phase, payload = {}) {
@@ -4605,10 +4663,11 @@ async function skipStep(step) {
     throw new Error(`步骤 ${step} 已完成，无需再跳过。`);
   }
 
-  if (step > 1) {
-    const prevStatus = statuses[step - 1];
+  const prevStep = getPreviousAutomationStep(step);
+  if (prevStep) {
+    const prevStatus = statuses[prevStep];
     if (!isStepDoneStatus(prevStatus)) {
-      throw new Error(`请先完成步骤 ${step - 1}，再跳过步骤 ${step}。`);
+      throw new Error(`请先完成步骤 ${prevStep}，再跳过步骤 ${step}。`);
     }
   }
 
@@ -4646,13 +4705,14 @@ async function humanStepDelay(min = HUMAN_STEP_DELAY_MIN, max = HUMAN_STEP_DELAY
   await sleepWithStop(duration);
 }
 
-async function clickWithDebugger(tabId, rect) {
+async function clickWithDebugger(tabId, rect, options = {}) {
+  const label = options.label || '调试器兜底点击';
   throwIfStopped();
   if (!tabId) {
-    throw new Error('未找到用于调试点击的认证页面标签页。');
+    throw new Error(`未找到用于${label}的标签页。`);
   }
   if (!rect || !Number.isFinite(rect.centerX) || !Number.isFinite(rect.centerY)) {
-    throw new Error('步骤 8 的调试器兜底点击需要有效的按钮坐标。');
+    throw new Error(`${label}需要有效的按钮坐标。`);
   }
 
   const target = { tabId };
@@ -4660,7 +4720,7 @@ async function clickWithDebugger(tabId, rect) {
     await chrome.debugger.attach(target, '1.3');
   } catch (err) {
     throw new Error(
-      `步骤 8 的调试器兜底点击附加失败：${err.message}。` +
+      `${label}附加失败：${err.message}。` +
       '如果认证页标签已打开 DevTools，请先关闭后重试。'
     );
   }
@@ -4751,6 +4811,14 @@ async function handleMessage(message, sender) {
     case 'LOG': {
       const { message: msg, level } = message.payload;
       await addLog(`[${getSourceLabel(message.source)}] ${msg}`, level);
+      return { ok: true };
+    }
+
+    case 'DEBUGGER_CLICK': {
+      const tabId = sender.tab?.id;
+      await clickWithDebugger(tabId, message.payload?.rect, {
+        label: message.payload?.label || '调试器兜底点击',
+      });
       return { ok: true };
     }
 
@@ -5195,7 +5263,7 @@ async function handleStepData(step, payload) {
 const stepWaiters = new Map();
 let resumeWaiter = null;
 const AUTO_RUN_SIGNAL_COMPLETION_TIMEOUT_MS = 120000;
-const AUTO_RUN_BACKGROUND_COMPLETED_STEPS = new Set([1, 2, 4, 6, 7, 8]);
+const AUTO_RUN_BACKGROUND_COMPLETED_STEPS = new Set([1, 2, 4, 6, 7, 8, 10]);
 const STEP_COMPLETION_SIGNAL_STEPS = new Set([3, 5, 9]);
 
 function waitForStepComplete(step, timeoutMs = 120000) {
@@ -5339,9 +5407,14 @@ async function markRunningStepsStopped() {
 async function requestStop(options = {}) {
   const { logMessage = '已收到停止请求，正在取消当前操作...' } = options;
   const state = await getState();
-  const timerPlan = getPendingAutoRunTimerPlan(state);
+  const timerPlan = typeof getPendingAutoRunTimerPlan === 'function'
+    ? getPendingAutoRunTimerPlan(state)
+    : null;
+  const scheduledStartKind = typeof AUTO_RUN_TIMER_KIND_SCHEDULED_START !== 'undefined'
+    ? AUTO_RUN_TIMER_KIND_SCHEDULED_START
+    : 'scheduled_start';
 
-  if (timerPlan?.kind === AUTO_RUN_TIMER_KIND_SCHEDULED_START && !autoRunActive) {
+  if (timerPlan?.kind === scheduledStartKind && !autoRunActive) {
     await cancelScheduledAutoRun({
       logMessage: options.logMessage === false
         ? false
@@ -5418,8 +5491,9 @@ async function executeStep(step, options = {}) {
 
   const state = await getState();
 
-  // Set flow start time on first step
-  if (step === 1 && !state.flowStartTime) {
+  // Set flow start time on the visible first step; step 1 may still run internally later.
+  const firstStep = typeof FIRST_AUTOMATION_STEP !== 'undefined' ? FIRST_AUTOMATION_STEP : 2;
+  if ((step === firstStep || step === 1) && !state.flowStartTime) {
     await setState({ flowStartTime: Date.now() });
   }
 
@@ -5434,6 +5508,7 @@ async function executeStep(step, options = {}) {
       case 7: await executeStep7(state); break;
       case 8: await executeStep8(state); break;
       case 9: await executeStep9(state); break;
+      case 10: await executeStep10(state); break;
       default:
         throw new Error(`未知步骤：${step}`);
     }
@@ -5706,6 +5781,7 @@ const AUTO_STEP_DELAYS = {
   7: 2000,
   8: 2000,
   9: 1000,
+  10: 500,
 };
 
 async function resumeAutoRunIfWaitingForEmail(options = {}) {
@@ -5862,7 +5938,8 @@ async function runAutoSequenceFromStep(startStep, context = {}) {
   }
 
   let step = Math.max(startStep, 4);
-  while (step <= 9) {
+  const lastStep = typeof LAST_AUTOMATION_STEP !== 'undefined' ? LAST_AUTOMATION_STEP : 10;
+  while (step <= lastStep) {
     try {
       await executeStepAndWait(step, AUTO_STEP_DELAYS[step]);
       const latestState = await getState();
@@ -6190,7 +6267,7 @@ async function autoRunLoop(totalRuns, options = {}) {
       autoRunCurrentRun = targetRun;
       autoRunAttemptRun = attemptRun;
       roundSummary.attempts = attemptRun;
-      let startStep = 1;
+      let startStep = typeof FIRST_AUTOMATION_STEP !== 'undefined' ? FIRST_AUTOMATION_STEP : 2;
       let useExistingProgress = false;
 
       if (reuseExistingProgress) {
@@ -6207,7 +6284,7 @@ async function autoRunLoop(totalRuns, options = {}) {
           startStep = resumeStep;
           useExistingProgress = true;
         } else if (hasSavedProgress(currentState.stepStatuses)) {
-          await addLog('检测到当前流程已处理完成，本轮将改为从步骤 1 重新开始。', 'info');
+          await addLog('检测到当前流程已处理完成，本轮将改为从步骤 2 重新开始。', 'info');
         }
       }
 
@@ -6498,7 +6575,6 @@ async function resumeAutoRun() {
 // ============================================================
 
 const SIGNUP_ENTRY_URL = 'https://chatgpt.com/';
-const SIGNUP_PAGE_INJECT_FILES = ['content/utils.js', 'content/signup-page.js'];
 
 async function requestOAuthUrlFromPanel(state, options = {}) {
   if (getPanelMode(state) === 'sub2api') {
@@ -6808,11 +6884,49 @@ async function executeStep3(state) {
   await addLog(
     `步骤 3：正在填写密码，邮箱为 ${resolvedEmail}，密码为${state.customPassword ? '自定义' : '自动生成'}（${password.length} 位）`
   );
-  await sendToContentScript('signup-page', {
+
+  const chatGptTabId = await getTabId(CHATGPT_PAGE_SOURCE);
+  if (chatGptTabId) {
+    let chatGptTab = null;
+    try {
+      chatGptTab = await chrome.tabs.get(chatGptTabId);
+    } catch {
+      chatGptTab = null;
+    }
+
+    if (chatGptTab && matchesSourceUrlFamily(CHATGPT_PAGE_SOURCE, chatGptTab.url, CHATGPT_HOME_URL)) {
+      try {
+        await ensureContentScriptReadyOnTab(CHATGPT_PAGE_SOURCE, chatGptTabId, {
+          inject: SIGNUP_PAGE_INJECT_FILES,
+          injectSource: CHATGPT_PAGE_SOURCE,
+          timeoutMs: 12000,
+          retryDelayMs: 500,
+          logMessage: '步骤 3：正在等待 ChatGPT 弹窗脚本就绪，准备填写邮箱...',
+        });
+
+        await sendTabMessageWithTimeout(chatGptTabId, CHATGPT_PAGE_SOURCE, {
+          type: 'EXECUTE_STEP',
+          step: 3,
+          source: 'background',
+          payload: { email: resolvedEmail, password, phase: 'email' },
+        }, 25000);
+
+        await addLog('步骤 3：已在 ChatGPT 弹窗提交邮箱，正在等待密码页...');
+      } catch (err) {
+        await addLog(`步骤 3：ChatGPT 弹窗邮箱提交未完成，继续等待认证页处理：${getErrorMessage(err)}`, 'warn');
+      }
+    }
+  }
+
+  await sendToContentScriptResilient('signup-page', {
     type: 'EXECUTE_STEP',
     step: 3,
     source: 'background',
     payload: { email: resolvedEmail, password },
+  }, {
+    timeoutMs: 60000,
+    retryDelayMs: 700,
+    logMessage: '步骤 3：认证页仍在从 ChatGPT 跳转，正在等待邮箱输入页就绪...',
   });
 }
 
@@ -7433,18 +7547,165 @@ async function executeStep4(state) {
 // Step 5: Fill Name & Birthday (via signup-page.js)
 // ============================================================
 
+function isChatGptPageUrl(rawUrl) {
+  const parsed = parseUrlSafely(rawUrl);
+  return Boolean(parsed && isChatGptPageHost(parsed.hostname));
+}
+
+async function handleChatGptOnboardingOnTab(tabId) {
+  if (!Number.isInteger(tabId)) return null;
+
+  try {
+    const [injectionResult] = await chrome.scripting.executeScript({
+      target: { tabId },
+      func: () => {
+        const normalize = (value) => String(value || '').replace(/\s+/g, ' ').trim();
+        const isVisible = (el) => {
+          if (!el) return false;
+          const style = window.getComputedStyle(el);
+          if (style.visibility === 'hidden' || style.display === 'none' || Number(style.opacity) === 0) return false;
+          const rect = el.getBoundingClientRect();
+          return rect.width > 0 && rect.height > 0;
+        };
+        const actionText = (el) => normalize([
+          el?.textContent,
+          el?.value,
+          el?.getAttribute?.('aria-label'),
+          el?.getAttribute?.('title'),
+        ].filter(Boolean).join(' '));
+        const candidates = Array.from(document.querySelectorAll(
+          'button, [role="button"], a, [role="link"], input[type="button"], input[type="submit"]'
+        )).filter(isVisible);
+        const pageText = normalize(document.body?.innerText || document.body?.textContent || '');
+        const isOnboarding = /what\s+brings\s+you\s+to\s+chatgpt|we[’']ll\s+use\s+this\s+information/i.test(pageText)
+          || /school\s+work\s+personal\s+tasks\s+fun\s+and\s+entertainment/i.test(pageText);
+        const isHome = /where\s+should\s+we\s+begin/i.test(pageText)
+          || Boolean(document.querySelector('textarea, [contenteditable="true"]'));
+
+        const click = (el) => {
+          el.scrollIntoView?.({ block: 'center', inline: 'center' });
+          el.focus?.();
+          el.click?.();
+        };
+
+        if (isOnboarding) {
+          const skip = candidates.find((el) => /^(skip|跳过)$/i.test(actionText(el)));
+          if (skip) {
+            click(skip);
+            return { state: 'onboarding', action: 'skip', buttonText: actionText(skip), url: location.href };
+          }
+
+          const option = candidates.find((el) => /personal\s+tasks|work|other|school|个人|工作|其他|学校/i.test(actionText(el)));
+          if (option) {
+            click(option);
+            const next = candidates.find((el) => /^(next|continue|下一步|继续)$/i.test(actionText(el)));
+            if (next) click(next);
+            return { state: 'onboarding', action: next ? 'select_and_next' : 'select', buttonText: actionText(option), url: location.href };
+          }
+
+          return { state: 'onboarding', action: 'none', url: location.href };
+        }
+
+        if (isHome) {
+          return { state: 'home', action: 'none', url: location.href };
+        }
+
+        return { state: 'chatgpt', action: 'none', url: location.href };
+      },
+    });
+
+    return injectionResult?.result || null;
+  } catch (err) {
+    return { state: 'error', error: getErrorMessage(err) };
+  }
+}
+
+async function waitForStep5ChatGptPostSubmit(timeoutMs = 45000) {
+  const start = Date.now();
+  let logged = false;
+
+  while (Date.now() - start < timeoutMs) {
+    throwIfStopped();
+
+    const candidateTabIds = [
+      await getTabId('signup-page'),
+      await getTabId(CHATGPT_PAGE_SOURCE),
+    ].filter((value, index, array) => Number.isInteger(value) && array.indexOf(value) === index);
+
+    for (const tabId of candidateTabIds) {
+      let tab = null;
+      try {
+        tab = await chrome.tabs.get(tabId);
+      } catch {
+        continue;
+      }
+
+      if (!isChatGptPageUrl(tab?.url)) {
+        continue;
+      }
+
+      if (!logged) {
+        await addLog('步骤 5：检测到资料提交后进入 ChatGPT 页面，正在处理入门问卷...', 'info');
+        logged = true;
+      }
+
+      const onboardingState = await handleChatGptOnboardingOnTab(tabId);
+      if (onboardingState?.state === 'onboarding') {
+        if (onboardingState.action === 'skip') {
+          await addLog('步骤 5：已自动点击 ChatGPT 入门页 Skip。', 'ok');
+        } else if (onboardingState.action === 'select_and_next') {
+          await addLog('步骤 5：已自动选择 ChatGPT 入门页选项并点击 Next。', 'ok');
+        } else if (onboardingState.action === 'select') {
+          await addLog('步骤 5：已自动选择 ChatGPT 入门页选项。', 'ok');
+        }
+        return { success: true, chatGptOnboarding: true, onboardingAction: onboardingState.action };
+      }
+
+      if (onboardingState?.state === 'home') {
+        await addLog('步骤 5：ChatGPT 页面已就绪，资料提交视为完成。', 'ok');
+        return { success: true, chatGptPage: true };
+      }
+    }
+
+    await sleepWithStop(500);
+  }
+
+  return null;
+}
+
 async function executeStep5(state) {
   const { firstName, lastName } = generateRandomName();
   const { year, month, day } = generateRandomBirthday();
 
   await addLog(`步骤 5：已生成姓名 ${firstName} ${lastName}，生日 ${year}-${month}-${day}`);
 
-  await sendToContentScript('signup-page', {
-    type: 'EXECUTE_STEP',
-    step: 5,
-    source: 'background',
-    payload: { firstName, lastName, year, month, day },
-  });
+  const existingPostSubmit = await waitForStep5ChatGptPostSubmit(1500);
+  if (existingPostSubmit?.success) {
+    await completeStepFromBackground(5, existingPostSubmit);
+    return;
+  }
+
+  try {
+    await sendToContentScript('signup-page', {
+      type: 'EXECUTE_STEP',
+      step: 5,
+      source: 'background',
+      payload: { firstName, lastName, year, month, day },
+    });
+  } catch (err) {
+    if (!isRetryableContentScriptTransportError(err)) {
+      throw err;
+    }
+
+    await addLog(`步骤 5：资料提交后认证页正在跳转，后台继续确认结果：${getErrorMessage(err)}`, 'warn');
+    const postSubmit = await waitForStep5ChatGptPostSubmit(45000);
+    if (postSubmit?.success) {
+      await completeStepFromBackground(5, postSubmit);
+      return;
+    }
+
+    throw new Error(`步骤 5：资料提交后未能确认 ChatGPT 入门页或主页。原始原因：${getErrorMessage(err)}`);
+  }
 }
 
 // ============================================================
@@ -8284,7 +8545,7 @@ async function executeSub2ApiStep9(state) {
     throw new Error('缺少 localhost 回调地址，请先完成步骤 8。');
   }
   if (!state.sub2apiSessionId) {
-    throw new Error('缺少 SUB2API 会话信息，请重新执行步骤 1。');
+    throw new Error('缺少 SUB2API 会话信息，请重新执行当前自动流程。');
   }
   if (!state.sub2apiEmail) {
     throw new Error('尚未配置 SUB2API 登录邮箱，请先在侧边栏填写。');
@@ -8341,6 +8602,193 @@ async function executeSub2ApiStep9(state) {
   if (result?.error) {
     throw new Error(result.error);
   }
+}
+
+// ============================================================
+// Step 10: 清理 ChatGPT 登录残留
+// ============================================================
+
+const CHATGPT_CLEANUP_ORIGINS = [
+  'https://chatgpt.com',
+  'https://www.chatgpt.com',
+  'https://chat.openai.com',
+  'https://auth.openai.com',
+  'https://auth0.openai.com',
+  'https://accounts.openai.com',
+  'https://openai.com',
+];
+
+function isChatGptCleanupUrl(rawUrl) {
+  const parsed = parseUrlSafely(rawUrl);
+  if (!parsed) return false;
+
+  return [
+    'chatgpt.com',
+    'www.chatgpt.com',
+    'chat.openai.com',
+    'auth.openai.com',
+    'auth0.openai.com',
+    'accounts.openai.com',
+    'openai.com',
+  ].includes(parsed.hostname);
+}
+
+async function clearChatGptClientStorageOnOpenTabs() {
+  const tabs = await chrome.tabs.query({});
+  const targetTabs = tabs.filter((tab) => isChatGptCleanupUrl(tab.url || tab.pendingUrl));
+  let clearedTabs = 0;
+
+  for (const tab of targetTabs) {
+    if (!Number.isInteger(tab.id)) continue;
+
+    try {
+      await chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        func: async () => {
+          try { localStorage.clear(); } catch { }
+          try { sessionStorage.clear(); } catch { }
+
+          try {
+            if (self.caches?.keys) {
+              const cacheNames = await caches.keys();
+              await Promise.all(cacheNames.map((name) => caches.delete(name)));
+            }
+          } catch { }
+
+          try {
+            if (navigator.serviceWorker?.getRegistrations) {
+              const registrations = await navigator.serviceWorker.getRegistrations();
+              await Promise.all(registrations.map((registration) => registration.unregister()));
+            }
+          } catch { }
+
+          try {
+            if (indexedDB.databases) {
+              const databases = await indexedDB.databases();
+              await Promise.all(databases
+                .map((database) => database?.name)
+                .filter(Boolean)
+                .map((name) => new Promise((resolve) => {
+                  const request = indexedDB.deleteDatabase(name);
+                  request.onsuccess = () => resolve();
+                  request.onerror = () => resolve();
+                  request.onblocked = () => resolve();
+                })));
+            }
+          } catch { }
+
+          return true;
+        },
+      });
+      clearedTabs += 1;
+    } catch (err) {
+      await addLog(`步骤 10：清理标签页 ${tab.id} 的前端缓存失败：${getErrorMessage(err)}`, 'warn');
+    }
+  }
+
+  return clearedTabs;
+}
+
+async function removeChatGptBrowsingData() {
+  if (!chrome.browsingData?.remove) {
+    await addLog('步骤 10：当前扩展环境没有 browsingData 权限，已跳过浏览器级 Cookie 清理。', 'warn');
+    return false;
+  }
+
+  await new Promise((resolve, reject) => {
+    chrome.browsingData.remove(
+      { origins: CHATGPT_CLEANUP_ORIGINS },
+      {
+        cookies: true,
+        localStorage: true,
+        indexedDB: true,
+        cacheStorage: true,
+        serviceWorkers: true,
+      },
+      () => {
+        const error = chrome.runtime.lastError;
+        if (error) {
+          reject(new Error(error.message));
+        } else {
+          resolve();
+        }
+      }
+    );
+  });
+
+  return true;
+}
+
+async function closeChatGptCleanupTabs() {
+  const tabs = await chrome.tabs.query({});
+  const tabIds = tabs
+    .filter((tab) => Number.isInteger(tab.id) && isChatGptCleanupUrl(tab.url || tab.pendingUrl))
+    .map((tab) => tab.id);
+
+  if (tabIds.length) {
+    await chrome.tabs.remove(tabIds).catch((err) => {
+      throw new Error(`关闭 ChatGPT 残留标签页失败：${getErrorMessage(err)}`);
+    });
+  }
+
+  const state = await getState();
+  const registry = { ...(state.tabRegistry || {}) };
+  const sourceLastUrls = { ...(state.sourceLastUrls || {}) };
+
+  for (const source of [CHATGPT_PAGE_SOURCE, 'signup-page']) {
+    registry[source] = null;
+    delete sourceLastUrls[source];
+  }
+
+  await setState({ tabRegistry: registry, sourceLastUrls });
+  return tabIds.length;
+}
+
+async function cleanupChatGptResidualSession(options = {}) {
+  const {
+    stepLabel = '步骤 10',
+    throwOnBrowsingDataError = true,
+    logSummary = true,
+  } = options;
+
+  const frontendTabs = await clearChatGptClientStorageOnOpenTabs();
+  let browsingDataRemoved = false;
+  let browsingDataError = null;
+
+  try {
+    browsingDataRemoved = await removeChatGptBrowsingData();
+  } catch (err) {
+    browsingDataError = err;
+    await addLog(`${stepLabel}：浏览器级 ChatGPT 数据清理失败：${getErrorMessage(err)}`, 'warn');
+    if (throwOnBrowsingDataError) {
+      throw err;
+    }
+  }
+
+  const closedTabs = await closeChatGptCleanupTabs();
+  const result = {
+    frontendTabs,
+    closedTabs,
+    browsingDataRemoved,
+    browsingDataError: browsingDataError ? getErrorMessage(browsingDataError) : '',
+    origins: CHATGPT_CLEANUP_ORIGINS,
+  };
+
+  if (logSummary) {
+    await addLog(
+      `${stepLabel}：ChatGPT 登录残留已清理（前端缓存标签页 ${frontendTabs} 个，关闭标签页 ${closedTabs} 个，浏览器数据${browsingDataRemoved ? '已清理' : '未清理'}）。`,
+      'ok'
+    );
+  }
+
+  return result;
+}
+
+async function executeStep10() {
+  await addLog('步骤 10：正在清理 ChatGPT 登录残留...');
+
+  const result = await cleanupChatGptResidualSession();
+  await completeStepFromBackground(10, result);
 }
 
 // ============================================================

--- a/content/signup-page.js
+++ b/content/signup-page.js
@@ -195,6 +195,185 @@ function isEmailVerificationPage() {
   return /\/email-verification(?:[/?#]|$)/i.test(location.pathname || '');
 }
 
+function isChatGptPage() {
+  return /(^|\.)chatgpt\.com$/i.test(location.hostname || '');
+}
+
+function getElementHref(el) {
+  const rawHref = el?.href || el?.getAttribute?.('href') || '';
+  if (!rawHref) return '';
+
+  try {
+    return new URL(rawHref, location.href).toString();
+  } catch {
+    return rawHref;
+  }
+}
+
+function scoreChatGptSignupCandidate(el) {
+  if (!isVisibleElement(el) || !isActionEnabled(el)) return 0;
+
+  const text = getActionText(el);
+  const href = getElementHref(el);
+  const combined = `${text} ${href}`.replace(/\s+/g, ' ').trim();
+  if (!combined) return 0;
+
+  const loginOnly = /(^|\b)(log\s*in|sign\s*in|登录|登入|登陆)(\b|$)/i.test(text)
+    && !/sign\s*up|signup|register|注册/i.test(combined);
+  if (loginOnly) return 0;
+
+  if (/\/auth\/signup|[?&]signup=(?:true|1)\b|\/signup(?:[/?#]|$)|register/i.test(href)) {
+    return 100;
+  }
+  if (/sign\s*up(?:\s*for\s*free)?|signup|register|create\s*(?:account|free account)|注册|免费注册|创建(?:账号|账户|帐户)/i.test(text)) {
+    return 90;
+  }
+  if (/log\s*in\s*or\s*sign\s*up|sign\s*up\s*or\s*log\s*in|登录或注册|注册或登录/i.test(text)) {
+    return 80;
+  }
+  if (/get\s*started|start\s*now|try\s*(?:chatgpt|it)?\s*first|开始使用|立即开始|先试用/i.test(text)) {
+    return 50;
+  }
+
+  return 0;
+}
+
+function findChatGptSignupTrigger() {
+  const candidates = Array.from(document.querySelectorAll(
+    'a, button, [role="button"], [role="link"], input[type="button"], input[type="submit"]'
+  ));
+
+  return candidates
+    .map((el) => ({ el, score: scoreChatGptSignupCandidate(el) }))
+    .filter((item) => item.score > 0)
+    .sort((a, b) => b.score - a.score)[0]?.el || null;
+}
+
+async function waitForChatGptSignupTrigger(timeout = 15000) {
+  const start = Date.now();
+  let loggedWaiting = false;
+
+  while (Date.now() - start < timeout) {
+    throwIfStopped();
+    const trigger = findChatGptSignupTrigger();
+    if (trigger) return trigger;
+
+    if (!loggedWaiting) {
+      log('步骤 2：正在等待 ChatGPT 注册入口出现...');
+      loggedWaiting = true;
+    }
+    await sleep(300);
+  }
+
+  throw new Error('未找到 ChatGPT 注册入口。URL: ' + location.href);
+}
+
+function dispatchPointerClick(el) {
+  const rect = el.getBoundingClientRect();
+  const eventInit = {
+    bubbles: true,
+    cancelable: true,
+    view: window,
+    clientX: rect.left + rect.width / 2,
+    clientY: rect.top + rect.height / 2,
+  };
+
+  for (const type of ['pointerdown', 'mousedown', 'pointerup', 'mouseup', 'click']) {
+    const EventCtor = type.startsWith('pointer') && typeof PointerEvent === 'function'
+      ? PointerEvent
+      : MouseEvent;
+    el.dispatchEvent(new EventCtor(type, eventInit));
+  }
+}
+
+function getElementClickRect(el) {
+  const rect = el?.getBoundingClientRect?.();
+  if (!rect || !rect.width || !rect.height) {
+    throw new Error('目标按钮没有可点击尺寸。URL: ' + location.href);
+  }
+
+  return {
+    left: rect.left,
+    top: rect.top,
+    width: rect.width,
+    height: rect.height,
+    centerX: rect.left + (rect.width / 2),
+    centerY: rect.top + (rect.height / 2),
+  };
+}
+
+async function requestDebuggerClick(el, label = '调试器兜底点击') {
+  const response = await chrome.runtime.sendMessage({
+    type: 'DEBUGGER_CLICK',
+    source: SCRIPT_SOURCE,
+    payload: {
+      label,
+      rect: getElementClickRect(el),
+    },
+  });
+
+  if (response?.error) {
+    throw new Error(response.error);
+  }
+}
+
+function findChatGptSignupEmailInput() {
+  const input = document.querySelector(
+    'input[type="email"], input[name="email"], input[autocomplete="email"], input[placeholder*="Email" i], input[placeholder*="邮箱" i]'
+  );
+  return input && isVisibleElement(input) ? input : null;
+}
+
+async function waitForChatGptSignupDialog(timeout = 8000) {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    throwIfStopped();
+
+    const emailInput = findChatGptSignupEmailInput();
+    if (emailInput) {
+      return emailInput;
+    }
+
+    await sleep(250);
+  }
+
+  throw new Error('已点击 ChatGPT 注册入口，但未看到邮箱输入框。URL: ' + location.href);
+}
+
+async function triggerChatGptSignup(registerBtn) {
+  registerBtn.scrollIntoView?.({ block: 'center', inline: 'center' });
+  registerBtn.focus?.();
+  await humanPause(100, 250);
+
+  try {
+    dispatchPointerClick(registerBtn);
+  } catch (err) {
+    log(`步骤 2：指针事件点击失败：${err.message}`, 'warn');
+  }
+
+  try {
+    simulateClick(registerBtn);
+  } catch (err) {
+    log(`步骤 2：常规点击失败：${err.message}`, 'warn');
+  }
+
+  try {
+    await waitForChatGptSignupDialog(6000);
+  } catch (firstErr) {
+    log(`步骤 2：普通点击后未看到邮箱框，尝试调试器真实点击：${firstErr.message}`, 'warn');
+
+    const latestRegisterBtn = document.contains(registerBtn)
+      ? registerBtn
+      : await waitForChatGptSignupTrigger(5000);
+
+    await requestDebuggerClick(latestRegisterBtn, '步骤 2 ChatGPT 注册按钮真实点击');
+    await waitForChatGptSignupDialog(15000);
+  }
+
+  log('步骤 2：已点击 ChatGPT 注册入口，并看到邮箱输入框');
+  await reportComplete(2);
+}
+
 async function resendVerificationCode(step, timeout = 45000) {
   if (step === 7) {
     await waitForLoginVerificationPageReady();
@@ -235,7 +414,15 @@ async function resendVerificationCode(step, timeout = 45000) {
 // ============================================================
 
 const SIGNUP_ENTRY_TRIGGER_PATTERN = /免费注册|立即注册|注册|sign\s*up|register|create\s*account|create\s+account/i;
-const SIGNUP_EMAIL_INPUT_SELECTOR = 'input[type="email"], input[name="email"], input[name="username"], input[id*="email"], input[placeholder*="email" i]';
+const SIGNUP_EMAIL_INPUT_SELECTOR = [
+  'input[type="email"]',
+  'input[name="email"]',
+  'input[name="username"]',
+  'input[id*="email" i]',
+  'input[autocomplete="email"]',
+  'input[placeholder*="email" i]',
+  'input[placeholder*="邮箱"]',
+].join(', ');
 
 function getSignupEmailInput() {
   const input = document.querySelector(SIGNUP_EMAIL_INPUT_SELECTOR);
@@ -440,6 +627,208 @@ async function step2_clickRegister(payload = {}) {
 // Step 3: Fill Password
 // ============================================================
 
+const SIGNUP_ACTION_SELECTOR = [
+  'button',
+  '[role="button"]',
+  'input[type="button"]',
+  'input[type="submit"]',
+].join(', ');
+
+const SIGNUP_CONTINUE_PATTERN = /continue|next|submit|sign\s*up|create|register|继续|下一步|注册|创建/i;
+const SOCIAL_AUTH_ACTION_PATTERN = /google|apple|phone|microsoft|github|sso|手机号|手机|电话/i;
+
+function getVisibleElements(selector, root = document) {
+  return Array.from(root.querySelectorAll(selector)).filter(isVisibleElement);
+}
+
+function getFirstVisibleElement(selector, root = document) {
+  return getVisibleElements(selector, root)[0] || null;
+}
+
+async function waitForVisibleElement(selector, timeout = 10000, label = selector) {
+  const start = Date.now();
+  let logged = false;
+
+  while (Date.now() - start < timeout) {
+    throwIfStopped();
+    const element = getFirstVisibleElement(selector);
+    if (element) return element;
+
+    if (!logged) {
+      log(`正在等待可见元素：${label}...`);
+      logged = true;
+    }
+    await sleep(200);
+  }
+
+  throw new Error(`未找到可见元素：${label}。URL: ${location.href}`);
+}
+
+function getVisibleSignupEmailInput() {
+  return getFirstVisibleElement(SIGNUP_EMAIL_INPUT_SELECTOR);
+}
+
+async function waitForSignupEmailInput(timeout = 12000) {
+  return waitForVisibleElement(SIGNUP_EMAIL_INPUT_SELECTOR, timeout, '邮箱输入框');
+}
+
+function findSignupSubmitAction(pattern = SIGNUP_CONTINUE_PATTERN, options = {}) {
+  const { allowDisabled = false, root = document } = options;
+  const candidates = Array.from(root.querySelectorAll(SIGNUP_ACTION_SELECTOR))
+    .filter((el) => isVisibleElement(el))
+    .filter((el) => allowDisabled || isActionEnabled(el))
+    .filter((el) => !SOCIAL_AUTH_ACTION_PATTERN.test(getActionText(el)));
+
+  const scored = candidates.map((el, index) => {
+    const text = getActionText(el);
+    const type = String(el.getAttribute?.('type') || el.type || '').toLowerCase();
+    let score = 0;
+
+    if (pattern.test(text)) score += 40;
+    if (type === 'submit') score += 20;
+    if (el.tagName === 'BUTTON') score += 5;
+
+    return { el, score, index };
+  }).filter((item) => item.score > 0);
+
+  scored.sort((a, b) => b.score - a.score || a.index - b.index);
+  return scored[0]?.el || null;
+}
+
+async function waitForSignupActionEnabled(action, timeout = 15000, label = '按钮') {
+  const start = Date.now();
+  let logged = false;
+
+  while (Date.now() - start < timeout) {
+    throwIfStopped();
+    if (!action || !document.contains(action)) {
+      throw new Error(`${label} 已从页面移除。URL: ${location.href}`);
+    }
+    if (isActionEnabled(action)) return action;
+
+    if (!logged) {
+      log(`正在等待${label}变为可点击...`);
+      logged = true;
+    }
+    await sleep(200);
+  }
+
+  throw new Error(`${label}长时间不可点击。URL: ${location.href}`);
+}
+
+async function clickSignupAction(action, label = '按钮') {
+  if (!action) throw new Error(`无法点击空的${label}。`);
+
+  action.scrollIntoView?.({ block: 'center', inline: 'center' });
+  action.focus?.();
+  await humanPause(250, 700);
+
+  try {
+    dispatchPointerClick(action);
+  } catch (err) {
+    log(`${label}指针点击失败，改用普通点击：${err.message}`, 'warn');
+    simulateClick(action);
+  }
+}
+
+async function waitForSignupPasswordInput(timeout = 25000) {
+  const start = Date.now();
+  let logged = false;
+
+  while (Date.now() - start < timeout) {
+    throwIfStopped();
+
+    const passwordInput = getSignupPasswordInput();
+    if (passwordInput) return passwordInput;
+
+    if (isVerificationPageStillVisible() || isStep5Ready()) {
+      throw new Error('页面已越过密码输入阶段，未发现可填写的密码框。URL: ' + location.href);
+    }
+
+    if (!logged) {
+      log('步骤 3：正在等待密码输入框出现...');
+      logged = true;
+    }
+    await sleep(250);
+  }
+
+  throw new Error('长时间未找到密码输入框。URL: ' + location.href);
+}
+
+async function waitForPasswordOrEnabledAction(action, timeout = 25000, label = '按钮') {
+  const start = Date.now();
+  let logged = false;
+
+  while (Date.now() - start < timeout) {
+    throwIfStopped();
+
+    const passwordInput = getSignupPasswordInput();
+    if (passwordInput) return { passwordInput };
+
+    if (action && document.contains(action) && isActionEnabled(action)) {
+      return { action };
+    }
+
+    if (!logged) {
+      log(`步骤 3：正在等待${label}可点击或密码页出现...`);
+      logged = true;
+    }
+    await sleep(200);
+  }
+
+  throw new Error(`${label}长时间不可点击，且密码页未出现。URL: ${location.href}`);
+}
+
+async function fillAndSubmitSignupEmail(emailInput, email, options = {}) {
+  const { waitForPassword = true } = options;
+  const form = emailInput.closest('form') || document;
+  const currentValue = (emailInput.value || '').trim();
+
+  await humanPause(350, 900);
+  if (currentValue !== email) {
+    fillInput(emailInput, email);
+    await sleep(250);
+  } else {
+    log('步骤 3：邮箱已在输入框中，准备提交...');
+  }
+
+  const submitBtn = findSignupSubmitAction(SIGNUP_CONTINUE_PATTERN, {
+    allowDisabled: true,
+    root: form,
+  }) || findSignupSubmitAction(SIGNUP_CONTINUE_PATTERN, { allowDisabled: true });
+
+  if (!submitBtn) {
+    throw new Error('未找到邮箱 Continue 按钮。URL: ' + location.href);
+  }
+
+  const ready = await waitForPasswordOrEnabledAction(submitBtn, 20000, '邮箱 Continue 按钮');
+  if (ready.passwordInput) return ready.passwordInput;
+
+  await clickSignupAction(ready.action || submitBtn, '邮箱 Continue 按钮');
+  log('步骤 3：邮箱已提交');
+
+  if (!waitForPassword) {
+    return null;
+  }
+
+  return waitForSignupPasswordInput(30000);
+}
+
+async function submitChatGptSignupEmail(payload) {
+  const { email } = payload;
+  if (!email) throw new Error('未提供邮箱地址，请先在侧边栏粘贴邮箱。');
+
+  log(`步骤 3：正在 ChatGPT 弹窗填写邮箱：${email}`);
+  const emailInput = getVisibleSignupEmailInput() || await waitForSignupEmailInput(15000);
+  await fillAndSubmitSignupEmail(emailInput, email, { waitForPassword: false });
+
+  return {
+    emailSubmitted: true,
+    source: 'chatgpt-page',
+    url: location.href,
+  };
+}
+
 async function step3_fillEmailPassword(payload) {
   const { email, password } = payload;
   if (!password) throw new Error('未提供密码，步骤 3 需要可用密码。');
@@ -481,16 +870,13 @@ async function step3_fillEmailPassword(payload) {
 
   // Report complete BEFORE submit, because submit causes page navigation
   // which kills the content script connection
-  const signupVerificationRequestedAt = submitBtn ? Date.now() : null;
-  reportComplete(3, { email, signupVerificationRequestedAt });
+  const signupVerificationRequestedAt = Date.now();
+  await reportComplete(3, { email, signupVerificationRequestedAt });
 
   // Submit the form (page will navigate away after this)
-  await sleep(500);
-  if (submitBtn) {
-    await humanPause(500, 1300);
-    simulateClick(submitBtn);
-    log('步骤 3：表单已提交');
-  }
+  await humanPause(400, 1000);
+  await clickSignupAction(submitBtn, '密码 Continue 按钮');
+  log('步骤 3：表单已提交');
 }
 
 // ============================================================
@@ -544,7 +930,23 @@ function getVerificationErrorText() {
 
 function isStep5Ready() {
   return Boolean(
-    document.querySelector('input[name="name"], input[autocomplete="name"], input[name="birthday"], input[name="age"], [role="spinbutton"][data-type="year"]')
+    document.querySelector([
+      'input[name="name"]',
+      'input[autocomplete="name"]',
+      'input[name*="first" i]',
+      'input[id*="first" i]',
+      'input[autocomplete="given-name"]',
+      'input[name*="last" i]',
+      'input[id*="last" i]',
+      'input[autocomplete="family-name"]',
+      'input[name="birthday"]',
+      'input[name*="birth" i]',
+      'input[id*="birth" i]',
+      'input[name="age"]',
+      'input[name*="age" i]',
+      '[role="spinbutton"][data-type="year"]',
+      '.react-aria-Select',
+    ].join(', '))
   );
 }
 
@@ -680,6 +1082,222 @@ async function setReactAriaBirthdaySelect(control, value) {
   control.nativeSelect.dispatchEvent(new Event('input', { bubbles: true }));
   control.nativeSelect.dispatchEvent(new Event('change', { bubbles: true }));
   await sleep(120);
+}
+
+function findBirthdayReactAriaSelectByLabels(labels) {
+  for (const label of labels) {
+    const control = findBirthdayReactAriaSelect(label);
+    if (control) return control;
+  }
+  return null;
+}
+
+function findProfileNameFields() {
+  const full = getFirstVisibleElement([
+    'input[name="name"]',
+    'input[autocomplete="name"]',
+    'input[placeholder*="Full name" i]',
+    'input[placeholder*="全名"]',
+    'input[id="name" i]',
+  ].join(', '));
+
+  const first = getFirstVisibleElement([
+    'input[name*="first" i]',
+    'input[id*="first" i]',
+    'input[autocomplete="given-name"]',
+    'input[placeholder*="First" i]',
+    'input[placeholder*="名"]',
+  ].join(', '));
+
+  const last = getFirstVisibleElement([
+    'input[name*="last" i]',
+    'input[id*="last" i]',
+    'input[autocomplete="family-name"]',
+    'input[placeholder*="Last" i]',
+    'input[placeholder*="姓"]',
+  ].join(', '));
+
+  return { full, first, last };
+}
+
+async function waitForProfileNameFields(timeout = 12000) {
+  const start = Date.now();
+  let logged = false;
+
+  while (Date.now() - start < timeout) {
+    throwIfStopped();
+    const fields = findProfileNameFields();
+    if (fields.full || fields.first || fields.last) return fields;
+
+    if (!logged) {
+      log('步骤 5：正在等待姓名输入框...');
+      logged = true;
+    }
+    await sleep(200);
+  }
+
+  throw new Error('未找到姓名输入框。URL: ' + location.href);
+}
+
+async function fillProfileNameFields(firstName, lastName) {
+  const fields = await waitForProfileNameFields();
+  const fullName = `${firstName} ${lastName}`;
+
+  await humanPause(500, 1300);
+  if (fields.full) {
+    fillInput(fields.full, fullName);
+    return { mode: 'full', value: fullName };
+  }
+
+  if (fields.first) {
+    fillInput(fields.first, firstName);
+  }
+  if (fields.last) {
+    fillInput(fields.last, lastName);
+  }
+
+  if (!fields.first && fields.last) {
+    fillInput(fields.last, fullName);
+    return { mode: 'single-last-fallback', value: fullName };
+  }
+
+  if (fields.first && !fields.last) {
+    fillInput(fields.first, fullName);
+    return { mode: 'single-first-fallback', value: fullName };
+  }
+
+  return { mode: 'split', value: fullName };
+}
+
+function findVisibleAgeInput() {
+  return getFirstVisibleElement([
+    'input[name="age"]',
+    'input[name*="age" i]',
+    'input[id*="age" i]',
+    'input[placeholder*="Age" i]',
+    'input[placeholder*="年龄"]',
+  ].join(', '));
+}
+
+function getMonthOptionAliases(month) {
+  const value = Number(month);
+  const padded = String(value).padStart(2, '0');
+  const names = [
+    'january',
+    'february',
+    'march',
+    'april',
+    'may',
+    'june',
+    'july',
+    'august',
+    'september',
+    'october',
+    'november',
+    'december',
+  ];
+  const shortNames = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'];
+  return [
+    String(value),
+    padded,
+    names[value - 1],
+    shortNames[value - 1],
+  ].filter(Boolean);
+}
+
+function resolveSelectOptionValue(select, desiredValue, type = '') {
+  const aliases = type === 'month'
+    ? getMonthOptionAliases(desiredValue)
+    : [String(Number(desiredValue)), String(desiredValue).padStart(2, '0'), String(desiredValue)];
+
+  const normalizedAliases = aliases.map((item) => String(item).toLowerCase());
+  const option = Array.from(select.options).find((item) => {
+    const value = String(item.value || '').trim().toLowerCase();
+    const text = normalizeInlineText(item.textContent).toLowerCase();
+    return normalizedAliases.includes(value)
+      || normalizedAliases.includes(text)
+      || normalizedAliases.some((alias) => text.startsWith(alias));
+  });
+
+  return option?.value || String(desiredValue);
+}
+
+function setNativeDatePartControl(control, value, type = '') {
+  if (!control) return;
+  const tag = String(control.tagName || '').toLowerCase();
+
+  if (tag === 'select') {
+    fillSelect(control, resolveSelectOptionValue(control, value, type));
+  } else {
+    const shouldPad = type === 'month' || type === 'day';
+    fillInput(control, shouldPad ? String(value).padStart(2, '0') : String(value));
+  }
+}
+
+function findNativeBirthdayControls() {
+  const dateInput = getFirstVisibleElement([
+    'input[type="date"]',
+    'input[autocomplete="bday"]',
+    'input[name*="birthday" i]',
+    'input[id*="birthday" i]',
+    'input[name*="birthdate" i]',
+    'input[id*="birthdate" i]',
+  ].join(', '));
+
+  const year = getFirstVisibleElement([
+    'select[name*="year" i]',
+    'select[id*="year" i]',
+    'select[aria-label*="year" i]',
+    'select[aria-label*="年"]',
+    'input[name*="year" i]',
+    'input[id*="year" i]',
+    'input[placeholder*="YYYY" i]',
+    'input[placeholder*="Year" i]',
+    'input[aria-label*="year" i]',
+    'input[aria-label*="年"]',
+  ].join(', '));
+
+  const month = getFirstVisibleElement([
+    'select[name*="month" i]',
+    'select[id*="month" i]',
+    'select[aria-label*="month" i]',
+    'select[aria-label*="月"]',
+    'input[name*="month" i]',
+    'input[id*="month" i]',
+    'input[placeholder*="MM" i]',
+    'input[placeholder*="Month" i]',
+    'input[aria-label*="month" i]',
+    'input[aria-label*="月"]',
+  ].join(', '));
+
+  const day = getFirstVisibleElement([
+    'select[name*="day" i]',
+    'select[id*="day" i]',
+    'select[aria-label*="day" i]',
+    'select[aria-label*="日"]',
+    'select[aria-label*="天"]',
+    'input[name*="day" i]',
+    'input[id*="day" i]',
+    'input[placeholder*="DD" i]',
+    'input[placeholder*="Day" i]',
+    'input[aria-label*="day" i]',
+    'input[aria-label*="日"]',
+    'input[aria-label*="天"]',
+  ].join(', '));
+
+  return { dateInput, year, month, day };
+}
+
+function setHiddenBirthdayValue(year, month, day) {
+  const hiddenBirthday = document.querySelector('input[name="birthday"]');
+  if (!hiddenBirthday) return false;
+
+  const dateStr = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+  hiddenBirthday.value = dateStr;
+  hiddenBirthday.dispatchEvent(new Event('input', { bubbles: true }));
+  hiddenBirthday.dispatchEvent(new Event('change', { bubbles: true }));
+  log(`步骤 5：已设置隐藏生日输入框：${dateStr}`);
+  return true;
 }
 
 function getStep5ErrorText() {
@@ -1857,19 +2475,8 @@ async function step5_fillNameBirthday(payload) {
   // - Birthday: React Aria DateField or hidden input[name="birthday"]
   // - Age: <input name="age" type="text|number">
 
-  // --- Full Name (single field, not first+last) ---
-  let nameInput = null;
-  try {
-    nameInput = await waitForElement(
-      'input[name="name"], input[placeholder*="全名"], input[autocomplete="name"]',
-      10000
-    );
-  } catch {
-    throw new Error('未找到姓名输入框。URL: ' + location.href);
-  }
-  await humanPause(500, 1300);
-  fillInput(nameInput, fullName);
-  log(`步骤 5：姓名已填写：${fullName}`);
+  const nameResult = await fillProfileNameFields(firstName, lastName);
+  log(`步骤 5：姓名已填写：${nameResult.value}（${nameResult.mode}）`);
 
   let birthdayMode = false;
   let ageInput = null;
@@ -1880,21 +2487,28 @@ async function step5_fillNameBirthday(payload) {
   let yearReactSelect = null;
   let monthReactSelect = null;
   let dayReactSelect = null;
+  let nativeBirthdayControls = null;
   let visibleAgeInput = false;
   let visibleBirthdaySpinners = false;
   let visibleBirthdaySelects = false;
+  let visibleNativeBirthday = false;
 
   for (let i = 0; i < 100; i++) {
     yearSpinner = document.querySelector('[role="spinbutton"][data-type="year"]');
     monthSpinner = document.querySelector('[role="spinbutton"][data-type="month"]');
     daySpinner = document.querySelector('[role="spinbutton"][data-type="day"]');
     hiddenBirthday = document.querySelector('input[name="birthday"]');
-    ageInput = document.querySelector('input[name="age"]');
-    yearReactSelect = findBirthdayReactAriaSelect('年');
-    monthReactSelect = findBirthdayReactAriaSelect('月');
-    dayReactSelect = findBirthdayReactAriaSelect('天');
+    ageInput = findVisibleAgeInput();
+    nativeBirthdayControls = findNativeBirthdayControls();
+    yearReactSelect = findBirthdayReactAriaSelectByLabels(['年', 'Year', 'year']);
+    monthReactSelect = findBirthdayReactAriaSelectByLabels(['月', 'Month', 'month']);
+    dayReactSelect = findBirthdayReactAriaSelectByLabels(['天', '日', 'Day', 'day']);
 
     visibleAgeInput = Boolean(ageInput && isVisibleElement(ageInput));
+    visibleNativeBirthday = Boolean(
+      nativeBirthdayControls?.dateInput
+      || (nativeBirthdayControls?.year && nativeBirthdayControls?.month && nativeBirthdayControls?.day)
+    );
     visibleBirthdaySpinners = Boolean(
       yearSpinner
       && monthSpinner
@@ -1913,7 +2527,7 @@ async function step5_fillNameBirthday(payload) {
     );
 
     if (visibleAgeInput) break;
-    if (visibleBirthdaySpinners || visibleBirthdaySelects) {
+    if (visibleNativeBirthday || visibleBirthdaySpinners || visibleBirthdaySelects || hiddenBirthday) {
       birthdayMode = true;
       break;
     }
@@ -1925,15 +2539,37 @@ async function step5_fillNameBirthday(payload) {
       throw new Error('检测到生日字段，但未提供生日数据。');
     }
 
+    let birthdayFilled = false;
+    const desiredDate = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    const nativeBirthdayControls = findNativeBirthdayControls();
     const yearSpinner = document.querySelector('[role="spinbutton"][data-type="year"]');
     const monthSpinner = document.querySelector('[role="spinbutton"][data-type="month"]');
     const daySpinner = document.querySelector('[role="spinbutton"][data-type="day"]');
-    const yearReactSelect = findBirthdayReactAriaSelect('年');
-    const monthReactSelect = findBirthdayReactAriaSelect('月');
-    const dayReactSelect = findBirthdayReactAriaSelect('天');
+    const yearReactSelect = findBirthdayReactAriaSelectByLabels(['年', 'Year', 'year']);
+    const monthReactSelect = findBirthdayReactAriaSelectByLabels(['月', 'Month', 'month']);
+    const dayReactSelect = findBirthdayReactAriaSelectByLabels(['天', '日', 'Day', 'day']);
 
-    if (yearReactSelect?.nativeSelect && monthReactSelect?.nativeSelect && dayReactSelect?.nativeSelect) {
-      const desiredDate = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    if (nativeBirthdayControls.dateInput) {
+      log('步骤 5：检测到原生日期输入框，正在填写生日...');
+      await humanPause(450, 1100);
+      fillInput(nativeBirthdayControls.dateInput, desiredDate);
+      birthdayFilled = true;
+      log(`步骤 5：生日已填写：${desiredDate}`);
+    }
+
+    if (!birthdayFilled && nativeBirthdayControls.year && nativeBirthdayControls.month && nativeBirthdayControls.day) {
+      log('步骤 5：检测到原生生日年月日字段，正在填写生日...');
+      await humanPause(450, 1100);
+      setNativeDatePartControl(nativeBirthdayControls.year, year, 'year');
+      await humanPause(200, 550);
+      setNativeDatePartControl(nativeBirthdayControls.month, month, 'month');
+      await humanPause(200, 550);
+      setNativeDatePartControl(nativeBirthdayControls.day, day, 'day');
+      birthdayFilled = true;
+      log(`步骤 5：生日已填写：${desiredDate}`);
+    }
+
+    if (!birthdayFilled && yearReactSelect?.nativeSelect && monthReactSelect?.nativeSelect && dayReactSelect?.nativeSelect) {
       const hiddenBirthday = document.querySelector('input[name="birthday"]');
 
       log('步骤 5：检测到 React Aria 下拉生日字段，正在填写生日...');
@@ -1957,9 +2593,10 @@ async function step5_fillNameBirthday(payload) {
       }
 
       log(`步骤 5：React Aria 生日已填写：${desiredDate}`);
+      birthdayFilled = true;
     }
 
-    if (yearSpinner && monthSpinner && daySpinner) {
+    if (!birthdayFilled && yearSpinner && monthSpinner && daySpinner) {
       log('步骤 5：检测到生日字段，正在填写生日...');
 
       async function setSpinButton(el, value) {
@@ -1988,16 +2625,16 @@ async function step5_fillNameBirthday(payload) {
       await setSpinButton(monthSpinner, String(month).padStart(2, '0'));
       await humanPause(250, 650);
       await setSpinButton(daySpinner, String(day).padStart(2, '0'));
-      log(`步骤 5：生日已填写：${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`);
+      birthdayFilled = true;
+      log(`步骤 5：生日已填写：${desiredDate}`);
     }
 
-    const hiddenBirthday = document.querySelector('input[name="birthday"]');
-    if (hiddenBirthday) {
-      const dateStr = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
-      hiddenBirthday.value = dateStr;
-      hiddenBirthday.dispatchEvent(new Event('input', { bubbles: true }));
-      hiddenBirthday.dispatchEvent(new Event('change', { bubbles: true }));
-      log(`步骤 5：已设置隐藏生日输入框：${dateStr}`);
+    if (setHiddenBirthdayValue(year, month, day)) {
+      birthdayFilled = true;
+    }
+
+    if (!birthdayFilled) {
+      throw new Error('检测到生日区域，但未能识别可填写的生日控件。URL: ' + location.href);
     }
   } else if (ageInput) {
     if (resolvedAge == null || Number.isNaN(Number(resolvedAge))) {
@@ -2012,14 +2649,14 @@ async function step5_fillNameBirthday(payload) {
 
   // Click "完成帐户创建" button
   await sleep(500);
-  const completeBtn = document.querySelector('button[type="submit"]')
+  const completeBtn = findSignupSubmitAction(/完成|create|continue|finish|done|agree/i, { allowDisabled: true })
     || await waitForElementByText('button', /完成|create|continue|finish|done|agree/i, 5000).catch(() => null);
   if (!completeBtn) {
     throw new Error('未找到“完成帐户创建”按钮。URL: ' + location.href);
   }
 
-  await humanPause(500, 1300);
-  simulateClick(completeBtn);
+  await waitForSignupActionEnabled(completeBtn, 15000, '完成帐户创建按钮');
+  await clickSignupAction(completeBtn, '完成帐户创建按钮');
   log('步骤 5：已点击“完成帐户创建”，正在等待页面结果...');
 
   const outcome = await waitForStep5SubmitOutcome();

--- a/content/utils.js
+++ b/content/utils.js
@@ -12,7 +12,7 @@ const SCRIPT_SOURCE = (() => {
   if (hostname === 'mail.google.com') return 'gmail-mail';
   if (hostname === 'www.icloud.com' || hostname === 'www.icloud.com.cn') return 'icloud-mail';
   if (url.includes('duckduckgo.com/email/settings/autofill')) return 'duck-mail';
-  if (url.includes('chatgpt.com')) return 'chatgpt';
+  if (url.includes('chatgpt.com')) return 'chatgpt-page';
   if (url.includes("2925.com")) return "mail-2925";
   // VPS panel — detected dynamically since URL is configurable
   return 'vps-panel';
@@ -292,7 +292,7 @@ function reportComplete(step, data = {}) {
     payload: data,
     error: null,
   };
-  Promise.resolve(chrome.runtime.sendMessage(message))
+  return Promise.resolve(chrome.runtime.sendMessage(message))
     .then((response) => {
       console.log(LOG_PREFIX, `STEP_COMPLETE sent successfully for step ${step}`, {
         response,

--- a/content/vps-panel.js
+++ b/content/vps-panel.js
@@ -27,6 +27,7 @@ console.log('[MultiPage:vps-panel] Content script loaded on', location.href);
 
 const VPS_PANEL_LISTENER_SENTINEL = 'data-multipage-vps-panel-listener';
 const STEP9_SUCCESS_BADGE_TIMEOUT_MS = 120000;
+const STEP9_SUCCESS_BADGE_PATTERN = /认证成功|authentication\s+successful/i;
 const {
   isRecoverableStep9AuthFailure,
 } = self.MultiPageActivationUtils || {};
@@ -237,10 +238,14 @@ function getStatusBadgeDiagnostics() {
   const visibleEntries = entries.filter((entry) => entry.visible);
   const selectedEntry = visibleEntries[0] || null;
   const selectedText = selectedEntry?.text || '';
-  const successLikeEntries = visibleEntries.filter((entry) => /认证成功/.test(entry.text || ''));
-  const exactSuccessEntries = visibleEntries.filter((entry) => entry.text === '认证成功！');
+  const successLikeEntries = visibleEntries.filter((entry) => STEP9_SUCCESS_BADGE_PATTERN.test(entry.text || ''));
+  const exactSuccessEntries = visibleEntries.filter((entry) => {
+    const text = entry.text || '';
+    return text === '认证成功！' || /^authentication\s+successful!?$/i.test(text);
+  });
   const visibleSummary = summarizeStatusBadgeEntries(visibleEntries);
   const pageSnippet = getPageTextSnippet();
+  const successText = exactSuccessEntries[0]?.text || successLikeEntries[0]?.text || '';
 
   return {
     selectedText,
@@ -248,6 +253,7 @@ function getStatusBadgeDiagnostics() {
     visibleSummary,
     hasSuccessLikeVisibleBadge: successLikeEntries.length > 0,
     hasExactSuccessVisibleBadge: exactSuccessEntries.length > 0,
+    successText,
     successLikeSummary: summarizeStatusBadgeEntries(successLikeEntries),
     exactSuccessSummary: summarizeStatusBadgeEntries(exactSuccessEntries),
     pageSnippet,
@@ -281,7 +287,6 @@ async function waitForExactSuccessBadge(timeout = STEP9_SUCCESS_BADGE_TIMEOUT_MS
   const start = Date.now();
   let lastDiagnosticsSignature = '';
   let lastHeartbeatLoggedAt = 0;
-  let lastSuccessLikeMismatchSignature = '';
 
   while (Date.now() - start < timeout) {
     throwIfStopped();
@@ -300,20 +305,8 @@ async function waitForExactSuccessBadge(timeout = STEP9_SUCCESS_BADGE_TIMEOUT_MS
       console.log(LOG_PREFIX, '[Step 9] still waiting for success badge', diagnostics);
     }
 
-    if (diagnostics.hasSuccessLikeVisibleBadge && !diagnostics.hasExactSuccessVisibleBadge) {
-      const mismatchSignature = JSON.stringify({
-        selectedText: diagnostics.selectedText,
-        successLikeSummary: diagnostics.successLikeSummary,
-        visibleSummary: diagnostics.visibleSummary,
-      });
-      if (mismatchSignature !== lastSuccessLikeMismatchSignature) {
-        lastSuccessLikeMismatchSignature = mismatchSignature;
-        log(
-          `步骤 9：检测到“认证成功”相关徽标，但未命中精确条件。当前选中="${getInlineTextSnippet(diagnostics.selectedText || '(空)', 80)}"；成功相关徽标：${diagnostics.successLikeSummary}`,
-          'warn'
-        );
-        console.warn(LOG_PREFIX, '[Step 9] success-like badge detected without exact match', diagnostics);
-      }
+    if (diagnostics.hasExactSuccessVisibleBadge || diagnostics.hasSuccessLikeVisibleBadge) {
+      return diagnostics.successText || statusText || '认证成功！';
     }
 
     if (isOAuthCallbackTimeoutFailure(statusText)) {
@@ -321,9 +314,6 @@ async function waitForExactSuccessBadge(timeout = STEP9_SUCCESS_BADGE_TIMEOUT_MS
     }
     if (typeof isRecoverableStep9AuthFailure === 'function' && isRecoverableStep9AuthFailure(statusText)) {
       throw new Error(`STEP9_OAUTH_RETRY::${statusText}`);
-    }
-    if (statusText === '认证成功！') {
-      return statusText;
     }
     await sleep(200);
   }
@@ -336,6 +326,9 @@ async function waitForExactSuccessBadge(timeout = STEP9_SUCCESS_BADGE_TIMEOUT_MS
   }
   if (typeof isRecoverableStep9AuthFailure === 'function' && isRecoverableStep9AuthFailure(finalText)) {
     throw new Error(`STEP9_OAUTH_RETRY::${finalText}${diagnosticsSuffix}`);
+  }
+  if (finalDiagnostics.hasExactSuccessVisibleBadge || finalDiagnostics.hasSuccessLikeVisibleBadge) {
+    return finalDiagnostics.successText || finalText || '认证成功！';
   }
   throw new Error(finalText
     ? `CPA 面板状态不是“认证成功！”，当前为“${finalText}”。${diagnosticsSuffix}`

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "多页面自动化",
-  "version": "9.4.0",
+  "version": "9.5.6",
   "description": "用于自动执行多步骤 OAuth 注册流程",
   "permissions": [
     "sidePanel",
@@ -9,6 +9,7 @@
     "tabs",
     "webNavigation",
     "declarativeNetRequest",
+    "browsingData",
     "debugger",
     "browsingData",
     "cookies",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "codex-oauth-automation-extension",
+  "version": "9.5.6",
   "private": true,
   "scripts": {
     "test": "node --test tests/*.test.js"

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -527,7 +527,7 @@
       <span id="steps-progress" class="steps-progress">0 / 9</span>
     </div>
     <div class="steps-list">
-      <div class="step-row" data-step="1">
+      <div class="step-row" data-step="1" hidden>
         <div class="step-indicator" data-step="1"><span class="step-num">1</span></div>
         <button class="step-btn" data-step="1">打开 ChatGPT 官网</button>
         <span class="step-status" data-step="1"></span>
@@ -571,6 +571,11 @@
         <div class="step-indicator" data-step="9"><span class="step-num">9</span></div>
         <button class="step-btn" data-step="9">平台回调验证</button>
         <span class="step-status" data-step="9"></span>
+      </div>
+      <div class="step-row" data-step="10">
+        <div class="step-indicator" data-step="10"><span class="step-num">10</span></div>
+        <button class="step-btn" data-step="10">清理 ChatGPT 登录残留</button>
+        <span class="step-status" data-step="10"></span>
       </div>
     </div>
   </section>

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -182,8 +182,16 @@ const STEP_DEFAULT_STATUSES = {
   7: 'pending',
   8: 'pending',
   9: 'pending',
+  10: 'pending',
 };
-const SKIPPABLE_STEPS = new Set([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+const FIRST_VISIBLE_STEP = 2;
+const LAST_STEP = 10;
+const VISIBLE_STEPS = Array.from(
+  { length: LAST_STEP - FIRST_VISIBLE_STEP + 1 },
+  (_, index) => FIRST_VISIBLE_STEP + index
+);
+const TOTAL_VISIBLE_STEPS = VISIBLE_STEPS.length;
+const SKIPPABLE_STEPS = new Set(VISIBLE_STEPS);
 const AUTO_DELAY_MIN_MINUTES = 1;
 const AUTO_DELAY_MAX_MINUTES = 1440;
 const AUTO_DELAY_DEFAULT_MINUTES = 30;
@@ -704,9 +712,19 @@ function getStepStatuses(state = latestState) {
   return { ...STEP_DEFAULT_STATUSES, ...(state?.stepStatuses || {}) };
 }
 
+function getVisibleStepStatuses(state = latestState) {
+  const statuses = getStepStatuses(state);
+  return VISIBLE_STEPS.map((step) => statuses[step]);
+}
+
+function getPreviousVisibleStep(step) {
+  const index = VISIBLE_STEPS.indexOf(step);
+  return index > 0 ? VISIBLE_STEPS[index - 1] : null;
+}
+
 function getFirstUnfinishedStep(state = latestState) {
   const statuses = getStepStatuses(state);
-  for (let step = 1; step <= 9; step++) {
+  for (const step of VISIBLE_STEPS) {
     if (!isDoneStatus(statuses[step])) {
       return step;
     }
@@ -716,15 +734,11 @@ function getFirstUnfinishedStep(state = latestState) {
 
 function getRunningSteps(state = latestState) {
   const statuses = getStepStatuses(state);
-  return Object.entries(statuses)
-    .filter(([, status]) => status === 'running')
-    .map(([step]) => Number(step))
-    .sort((a, b) => a - b);
+  return VISIBLE_STEPS.filter((step) => statuses[step] === 'running');
 }
 
 function hasSavedProgress(state = latestState) {
-  const statuses = getStepStatuses(state);
-  return Object.values(statuses).some((status) => status !== 'pending');
+  return getVisibleStepStatuses(state).some((status) => status !== 'pending');
 }
 
 function shouldOfferAutoModeChoice(state = latestState) {
@@ -2870,8 +2884,9 @@ function updateStepUI(step, status) {
 }
 
 function updateProgressCounter() {
-  const completed = Object.values(getStepStatuses()).filter(isDoneStatus).length;
-  stepsProgress.textContent = `${completed} / 9`;
+  const statuses = getStepStatuses();
+  const completed = VISIBLE_STEPS.filter((step) => isDoneStatus(statuses[step])).length;
+  stepsProgress.textContent = `${completed} / ${TOTAL_VISIBLE_STEPS}`;
 }
 
 function updateButtonStates() {
@@ -2880,16 +2895,17 @@ function updateButtonStates() {
   const autoLocked = isAutoRunLockedPhase();
   const autoScheduled = isAutoRunScheduledPhase();
 
-  for (let step = 1; step <= 9; step++) {
+  for (const step of VISIBLE_STEPS) {
     const btn = document.querySelector(`.step-btn[data-step="${step}"]`);
     if (!btn) continue;
+    const prevStep = getPreviousVisibleStep(step);
 
     if (anyRunning || autoLocked || autoScheduled) {
       btn.disabled = true;
-    } else if (step === 1) {
+    } else if (!prevStep) {
       btn.disabled = false;
     } else {
-      const prevStatus = statuses[step - 1];
+      const prevStatus = statuses[prevStep];
       const currentStatus = statuses[step];
       btn.disabled = !(isDoneStatus(prevStatus) || currentStatus === 'failed' || isDoneStatus(currentStatus) || currentStatus === 'stopped');
     }
@@ -2898,7 +2914,8 @@ function updateButtonStates() {
   document.querySelectorAll('.step-manual-btn').forEach((btn) => {
     const step = Number(btn.dataset.step);
     const currentStatus = statuses[step];
-    const prevStatus = statuses[step - 1];
+    const prevStep = getPreviousVisibleStep(step);
+    const prevStatus = prevStep ? statuses[prevStep] : null;
 
     if (!SKIPPABLE_STEPS.has(step) || anyRunning || autoLocked || autoScheduled || currentStatus === 'running' || isDoneStatus(currentStatus)) {
       btn.style.display = 'none';
@@ -2907,10 +2924,10 @@ function updateButtonStates() {
       return;
     }
 
-    if (step > 1 && !isDoneStatus(prevStatus)) {
+    if (prevStep && !isDoneStatus(prevStatus)) {
       btn.style.display = 'none';
       btn.disabled = true;
-      btn.title = `请先完成步骤 ${step - 1}`;
+      btn.title = `请先完成步骤 ${prevStep}`;
       return;
     }
 
@@ -2973,7 +2990,9 @@ function updateStatusDisplay(state) {
     return;
   }
 
-  const running = Object.entries(state.stepStatuses).find(([, s]) => s === 'running');
+  const running = VISIBLE_STEPS
+    .map((step) => [String(step), state.stepStatuses?.[step]])
+    .find(([, s]) => s === 'running');
   if (running) {
     displayStatus.textContent = `步骤 ${running[0]} 运行中...`;
     statusBar.classList.add('running');
@@ -2986,27 +3005,30 @@ function updateStatusDisplay(state) {
     return;
   }
 
-  const failed = Object.entries(state.stepStatuses).find(([, s]) => s === 'failed');
+  const failed = VISIBLE_STEPS
+    .map((step) => [String(step), state.stepStatuses?.[step]])
+    .find(([, s]) => s === 'failed');
   if (failed) {
     displayStatus.textContent = `步骤 ${failed[0]} 失败`;
     statusBar.classList.add('failed');
     return;
   }
 
-  const stopped = Object.entries(state.stepStatuses).find(([, s]) => s === 'stopped');
+  const stopped = VISIBLE_STEPS
+    .map((step) => [String(step), state.stepStatuses?.[step]])
+    .find(([, s]) => s === 'stopped');
   if (stopped) {
     displayStatus.textContent = `步骤 ${stopped[0]} 已停止`;
     statusBar.classList.add('stopped');
     return;
   }
 
-  const lastCompleted = Object.entries(state.stepStatuses)
-    .filter(([, s]) => isDoneStatus(s))
-    .map(([k]) => Number(k))
+  const lastCompleted = VISIBLE_STEPS
+    .filter((step) => isDoneStatus(state.stepStatuses?.[step]))
     .sort((a, b) => b - a)[0];
 
-  if (lastCompleted === 9) {
-    displayStatus.textContent = (state.stepStatuses[9] === 'manual_completed' || state.stepStatuses[9] === 'skipped') ? '全部步骤已跳过/完成' : '全部步骤已完成';
+  if (lastCompleted === LAST_STEP) {
+    displayStatus.textContent = (state.stepStatuses[LAST_STEP] === 'manual_completed' || state.stepStatuses[LAST_STEP] === 'skipped') ? '全部步骤已跳过/完成' : '全部步骤已完成';
     statusBar.classList.add('completed');
   } else if (lastCompleted) {
     displayStatus.textContent = (state.stepStatuses[lastCompleted] === 'manual_completed' || state.stepStatuses[lastCompleted] === 'skipped')


### PR DESCRIPTION
﻿## 本次改动
- 将步骤 1 到步骤 3 调整为从 ChatGPT 官网入口进入注册流程，并拆分为输入邮箱、进入密码页、填写密码三个阶段
- 新增官网注册入口与密码页就绪检测，减少页面切换时脚本未就绪导致的中断
- 同步调整侧边栏步骤文案和自动流程日志，使官网注册流程与后续 OAuth 登录流程保持一致

## 风险与影响
- ChatGPT 官网首页、注册入口和密码页 DOM 如果继续变化，步骤 2 和步骤 3 仍然需要重点关注
- 本次改动重排了前 3 个步骤的职责，建议重点验证自动运行首轮流程和中断后继续流程

## 测试情况
- 已执行 `node --check background.js`
- 已执行 `node --check content/signup-page.js`
- 未运行完整自动化测试，请开发者自行验证
