### PR TITLE
步骤 5 完成后自动跳过 ChatGPT 新用户引导页

### DIFF
--- a/background.js
+++ b/background.js
@@ -7439,12 +7439,82 @@ async function executeStep5(state) {
 
   await addLog(`步骤 5：已生成姓名 ${firstName} ${lastName}，生日 ${year}-${month}-${day}`);
 
-  await sendToContentScript('signup-page', {
-    type: 'EXECUTE_STEP',
-    step: 5,
-    source: 'background',
-    payload: { firstName, lastName, year, month, day },
+  const signupTabId = await getTabId('signup-page');
+
+  try {
+    await sendToContentScript('signup-page', {
+      type: 'EXECUTE_STEP',
+      step: 5,
+      source: 'background',
+      payload: { firstName, lastName, year, month, day },
+    });
+  } catch (err) {
+    if (isStopError(err)) throw err;
+
+    // Content script may have been destroyed because the auth page navigated
+    // to chatgpt.com (new-user onboarding flow).
+    // If step 5 was already completed via STEP_COMPLETE before the transport
+    // error surfaced, skip the recovery.
+    const latestStatus = (await getState()).stepStatuses?.[5];
+    if (latestStatus === 'completed') return;
+
+    if (signupTabId && isRetryableContentScriptTransportError(err)) {
+      const handled = await tryStep5OnboardingRecovery(signupTabId);
+      if (handled) return;
+    }
+
+    throw err;
+  }
+}
+
+async function tryStep5OnboardingRecovery(tabId) {
+  const tab = await waitForTabUrlMatch(
+    tabId,
+    (url) => /chatgpt\.com/i.test(url),
+    { timeoutMs: 15000, retryDelayMs: 500 },
+  );
+
+  if (!tab) return false;
+
+  await addLog('步骤 5：检测到页面已跳转到 ChatGPT，正在自动处理新用户引导页...', 'info');
+  await sleepWithStop(2000);
+
+  await chrome.scripting.executeScript({
+    target: { tabId },
+    func: (src) => { window.__MULTIPAGE_SOURCE = src; },
+    args: ['signup-page'],
   });
+  await chrome.scripting.executeScript({
+    target: { tabId },
+    files: SIGNUP_PAGE_INJECT_FILES,
+  });
+
+  await ensureContentScriptReadyOnTab('signup-page', tabId, {
+    inject: SIGNUP_PAGE_INJECT_FILES,
+    injectSource: 'signup-page',
+    timeoutMs: 20000,
+    retryDelayMs: 600,
+    logMessage: '步骤 5：ChatGPT 页面内容脚本尚未就绪，正在等待...',
+  });
+
+  const result = await sendToContentScriptResilient('signup-page', {
+    type: 'HANDLE_ONBOARDING',
+    source: 'background',
+  }, {
+    timeoutMs: 60000,
+    retryDelayMs: 1000,
+    logMessage: '步骤 5：引导页处理中...',
+  });
+
+  const dismissed = result?.dismissed || 0;
+  if (dismissed > 0) {
+    await addLog(`步骤 5：已自动跳过 ${dismissed} 个 ChatGPT 新用户引导页。`, 'ok');
+  } else {
+    await addLog('步骤 5：未检测到需要跳过的引导页，继续流程。', 'info');
+  }
+
+  await completeStepFromBackground(5, {});
+  return true;
 }
 
 // ============================================================

--- a/content/signup-page.js
+++ b/content/signup-page.js
@@ -22,6 +22,7 @@ if (document.documentElement.getAttribute(SIGNUP_PAGE_LISTENER_SENTINEL) !== '1'
       || message.type === 'RESEND_VERIFICATION_CODE'
       || message.type === 'ENSURE_SIGNUP_ENTRY_READY'
       || message.type === 'ENSURE_SIGNUP_PASSWORD_PAGE_READY'
+      || message.type === 'HANDLE_ONBOARDING'
     ) {
       resetStopState();
       handleCommand(message).then((result) => {
@@ -83,6 +84,8 @@ async function handleCommand(message) {
       return getStep8State();
     case 'STEP8_TRIGGER_CONTINUE':
       return await step8_triggerContinue(message.payload);
+    case 'HANDLE_ONBOARDING':
+      return await handleChatGPTOnboarding();
   }
 }
 
@@ -2029,4 +2032,99 @@ async function step5_fillNameBirthday(payload) {
 
   log(`步骤 5：资料已通过。`, 'ok');
   reportComplete(5, { addPhonePage: Boolean(outcome.addPhonePage) });
+}
+
+// ============================================================
+// ChatGPT Onboarding Auto-Skip
+// ============================================================
+
+const ONBOARDING_SKIP_PATTERN = /^跳过$/i;
+const ONBOARDING_SKIP_TOUR_PATTERN = /跳过导览|skip\s*tour/i;
+const ONBOARDING_CONTINUE_PATTERN = /^继续$|^continue$/i;
+const ONBOARDING_NEXT_PATTERN = /^下一步$|^next$/i;
+const ONBOARDING_START_PATTERN = /好的，开始吧|okay,?\s*let'?s\s*go|let'?s\s*go|get\s*started/i;
+
+const ONBOARDING_PAGE_PATTERNS = [
+  /是什么促使你使用\s*ChatGPT/i,
+  /你想使用\s*ChatGPT\s*做些什么/i,
+  /有问题，尽管问/i,
+  /你已准备就绪/i,
+  /入门技巧/i,
+  /what\s+brings?\s+you\s+to\s+ChatGPT/i,
+  /what\s+do\s+you\s+want\s+to\s+use\s+ChatGPT\s+for/i,
+  /you'?re\s+all\s+set/i,
+  /getting\s+started/i,
+];
+
+function isOnboardingPageVisible() {
+  const text = (document.body?.innerText || '').replace(/\s+/g, ' ').trim();
+  return ONBOARDING_PAGE_PATTERNS.some((p) => p.test(text));
+}
+
+function findOnboardingDismissButton() {
+  const allButtons = Array.from(document.querySelectorAll('button, [role="button"], a[role="button"]'));
+  const visible = allButtons.filter((el) => {
+    if (!el.offsetParent && !el.offsetWidth && !el.offsetHeight) return false;
+    const style = getComputedStyle(el);
+    return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+  });
+
+  const matchers = [
+    ONBOARDING_SKIP_TOUR_PATTERN,
+    ONBOARDING_START_PATTERN,
+    ONBOARDING_SKIP_PATTERN,
+    ONBOARDING_CONTINUE_PATTERN,
+    ONBOARDING_NEXT_PATTERN,
+  ];
+
+  for (const pattern of matchers) {
+    const btn = visible.find((el) => {
+      const text = (el.textContent || '').replace(/\s+/g, ' ').trim();
+      return pattern.test(text);
+    });
+    if (btn) return btn;
+  }
+
+  return null;
+}
+
+async function handleChatGPTOnboarding() {
+  log('[引导页] 开始检测 ChatGPT 新用户引导页...');
+  const maxRounds = 15;
+  let dismissed = 0;
+
+  for (let round = 0; round < maxRounds; round++) {
+    throwIfStopped();
+    await sleep(800);
+
+    if (!isOnboardingPageVisible()) {
+      if (dismissed > 0) {
+        log(`[引导页] 已无更多引导页，共自动跳过 ${dismissed} 个页面。`, 'ok');
+        return { dismissed };
+      }
+      if (round >= 3) {
+        log('[引导页] 未检测到引导页，跳过处理。');
+        return { dismissed: 0 };
+      }
+      continue;
+    }
+
+    const btn = findOnboardingDismissButton();
+    if (!btn) {
+      if (round >= 5) {
+        log('[引导页] 检测到引导页但未找到可点击按钮，放弃等待。', 'warn');
+        return { dismissed };
+      }
+      continue;
+    }
+
+    const btnText = (btn.textContent || '').replace(/\s+/g, ' ').trim();
+    log(`[引导页] 点击按钮："${btnText}"`);
+    btn.click();
+    dismissed += 1;
+    await sleep(600);
+  }
+
+  log(`[引导页] 达到最大轮次，共自动跳过 ${dismissed} 个引导页。`, 'warn');
+  return { dismissed };
 }


### PR DESCRIPTION
## 本次改动

新注册账号在步骤 5（填写姓名/生日）提交后，ChatGPT 会展示一系列新用户引导页面：

- "是什么促使你使用 ChatGPT？"
- "你想使用 ChatGPT 做些什么？"
- "有问题，尽管问"
- "你已准备就绪"
- "入门技巧"

这些页面需要手动点击"跳过"/"继续"/"好的，开始吧"才能通过，导致自动流程卡死在步骤 5。

本次改动包含两部分：

1. **`content/signup-page.js`**：新增 `handleChatGPTOnboarding()` 函数，自动检测并依次点击引导页上的跳过/继续按钮，支持中英文页面
2. **`background.js`**：修改 `executeStep5()`，当内容脚本因页面从 `auth.openai.com` 跳转到 `chatgpt.com` 而断开时，后台自动检测导航、注入脚本、处理引导页，然后从后台完成步骤 5

改动后，无引导页时走原有逻辑不受影响；有引导页时自动跳过，流程可无干预地继续执行步骤 6 及后续步骤。

## 风险与影响

- 仅在步骤 5 内容脚本断开且标签页已跳转到 `chatgpt.com` 时才触发恢复逻辑，不影响正常流程
- 引导页文案匹配使用正则，同时覆盖中英文，如果 ChatGPT 后续改动引导页文案可能需要更新匹配规则
- 按钮点击使用优先级策略（跳过导览 > 好的，开始吧 > 跳过 > 继续 > 下一步），避免误点

## 测试情况

- 已在实际 ChatGPT 注册流程中测试通过，引导页全部自动跳过，流程正常继续到步骤 6
- 未运行自动化测试，请维护者自行验证

Made with [Cursor](https://cursor.com)