### PR TITLE
Security: Plaintext passwords are persisted in extension state

### DIFF
--- a/background/steps/fill-password.js
+++ b/background/steps/fill-password.js
@@ -30,7 +30,7 @@
       await setPasswordState(password);
 
       const accounts = state.accounts || [];
-      accounts.push({ email: resolvedEmail, password, createdAt: new Date().toISOString() });
+      accounts.push({ email: resolvedEmail, createdAt: new Date().toISOString() });
       await setState({ accounts });
 
       await chrome.tabs.update(signupTabId, { active: true });


### PR DESCRIPTION
## Summary

Security: Plaintext passwords are persisted in extension state

## Problem

**Severity**: `High` | **File**: `background/steps/fill-password.js:L32`

Step 3 appends `{ email, password, createdAt }` directly into `state.accounts` and writes it via `setState`. This stores raw credentials in extension-managed state, increasing impact if extension storage is exposed (local compromise, backup/sync leakage, debug export, or other extension bugs).

## Solution

Do not persist raw passwords. Prefer one-time in-memory use only. If persistence is unavoidable, store an encrypted secret (using a key not persisted alongside data), add TTL-based deletion, and avoid storing credentials in account history arrays.

## Changes

- `background/steps/fill-password.js` (modified)