### PR TITLE
稳定 iCloud 邮箱标签页生命周期，并修正步骤 4 验证码策略

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /data/account-run-history.json
 .npm-test.log
 .omx/
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 - 支持 `QQ Mail`、`163 Mail`、`Inbucket mailbox`
 - 支持从 DuckDuckGo Email Protection 自动生成新的 `@duck.com` 地址
 - 支持基于 Cloudflare 自定义域名自动生成随机邮箱前缀
+- 支持 iCloud 隐私邮箱双策略生成：保留现有网页方案，并新增本地 macOS System Settings 方案
 - Step 5 同时兼容两种页面：
   - 页面要求填写 `birthday`
   - 页面要求填写 `age`
@@ -202,6 +203,7 @@ Step 1 和 Step 10 都依赖这个地址。
 - Windows 运行仓库根目录的 `start-hotmail-helper.bat`
 - macOS 运行仓库根目录的 `start-hotmail-helper.command`
 - 本地 helper 当前仅依赖 Python 标准库，无需额外安装第三方 Python 包
+- 该 helper 现在也承接 iCloud 本地 Hide My Email 生成能力
 - 再新增账号
 - 点击 `校验`
 - 校验通过后，可点击 `测试收信`
@@ -250,6 +252,23 @@ Hotmail helper listening on http://127.0.0.1:17373
 - 如果 helper 已启动但扩展仍报连接失败，先确认模式切到了 `本地助手`
 - 确认本地助手地址与终端输出一致，默认应为 `http://127.0.0.1:17373`
 - 如果地址一致仍失败，再检查是否有端口占用或终端里是否已经抛出异常
+
+### `邮箱生成 = iCloud 隐私邮箱` 时的策略
+
+当你把 `邮箱生成` 设为 `iCloud 隐私邮箱` 时，侧边栏会额外提供：
+
+- `网页方案`
+- `本地 macOS System Settings`
+- 可选的 `Apple ID 密码`
+
+说明：
+
+- 默认仍是 `网页方案`，行为与旧版本兼容
+- `本地 macOS System Settings` 会复用上面的本地 helper 地址，默认仍是 `http://127.0.0.1:17373`
+- 本地方案只负责“生成并回填注册邮箱”，不会自动把你重新绑回网页 iCloud 管理链路
+- 如果本地流程中弹出 Apple ID 密码确认框，且你已填写 `Apple ID 密码`，脚本会自动继续
+- 如果弹出确认框但你没有填写该密码，会直接报清晰错误，不会静默回退到网页方案
+- 非 macOS、helper 未启动、helper 不支持该接口或 Swift 脚本不可用时，本地方案都会明确报错
 
 ### `Mailbox`
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,6 @@ Step 1 和 Step 10 都依赖这个地址。
 - Windows 运行仓库根目录的 `start-hotmail-helper.bat`
 - macOS 运行仓库根目录的 `start-hotmail-helper.command`
 - 本地 helper 当前仅依赖 Python 标准库，无需额外安装第三方 Python 包
-- 该 helper 现在也承接 iCloud 本地 Hide My Email 生成能力
 - 再新增账号
 - 点击 `校验`
 - 校验通过后，可点击 `测试收信`
@@ -264,11 +263,57 @@ Hotmail helper listening on http://127.0.0.1:17373
 说明：
 
 - 默认仍是 `网页方案`，行为与旧版本兼容
-- `本地 macOS System Settings` 会复用上面的本地 helper 地址，默认仍是 `http://127.0.0.1:17373`
+- `本地 macOS System Settings` 现在默认走 Chrome Native Messaging host，浏览器会按需拉起本地宿主，不再要求你手动常驻启动 localhost helper
 - 本地方案只负责“生成并回填注册邮箱”，不会自动把你重新绑回网页 iCloud 管理链路
 - 如果本地流程中弹出 Apple ID 密码确认框，且你已填写 `Apple ID 密码`，脚本会自动继续
 - 如果弹出确认框但你没有填写该密码，会直接报清晰错误，不会静默回退到网页方案
-- 非 macOS、helper 未启动、helper 不支持该接口或 Swift 脚本不可用时，本地方案都会明确报错
+- 非 macOS、本地宿主缺失/未注册、本地宿主超时、Apple ID 密码未配置、宿主版本过旧/协议不匹配、Swift 脚本不可用时，本地方案都会明确报错
+
+#### Native Messaging host 安装（仅 `local-macos` 需要）
+
+首次使用 `本地 macOS System Settings` 前，需要先做一次宿主安装：
+
+1. 在 `chrome://extensions/` 中打开本扩展，复制当前扩展 ID
+2. 运行：
+
+```bash
+chmod +x ./install-native-host.command
+./install-native-host.command <你的扩展ID>
+```
+
+也可以直接运行 Python 安装脚本：
+
+```bash
+python3 scripts/install_native_messaging_host.py --extension-id <你的扩展ID>
+```
+
+安装脚本会：
+
+- 校验本地宿主脚本可执行
+- 写入 Chrome Native Messaging manifest
+- 绑定当前扩展 ID 到 `allowed_origins`
+- 输出 manifest 路径，后续无需手动常驻 helper
+
+卸载命令：
+
+```bash
+chmod +x ./uninstall-native-host.command
+./uninstall-native-host.command
+```
+
+如果你需要排查宿主状态，也可以手动执行：
+
+```bash
+python3 scripts/native_messaging_host.py --self-check
+```
+
+该命令会输出宿主版本、协议版本、Swift 脚本路径与日志文件位置。
+
+#### localhost helper 兼容说明
+
+- `start-hotmail-helper.command` / `python3 scripts/hotmail_helper.py` 仍保留给 Hotmail 本地收信与账号记录快照同步
+- iCloud `local-macos` 默认不再走 localhost helper，也不会自动回退到 localhost helper
+- 旧 localhost iCloud 端点仅作为短期兼容代码保留，不再是默认产品路径
 
 ### `Mailbox`
 

--- a/background.js
+++ b/background.js
@@ -5780,6 +5780,7 @@ const step4Executor = self.MultiPageBackgroundStep4?.createStep4Executor({
   getMailConfig,
   getTabId,
   HOTMAIL_PROVIDER,
+  ICLOUD_PROVIDER,
   isTabAlive,
   LUCKMAIL_PROVIDER,
   CLOUDFLARE_TEMP_EMAIL_PROVIDER,
@@ -6043,6 +6044,7 @@ function getMailConfig(state) {
     const loginUrl = getIcloudLoginUrlForHost(configuredHost) || 'https://www.icloud.com/';
     const mailUrl = getIcloudMailUrlForHost(configuredHost) || loginUrl;
     return {
+      provider: ICLOUD_PROVIDER,
       source: 'icloud-mail',
       url: mailUrl,
       label: 'iCloud 邮箱',

--- a/background.js
+++ b/background.js
@@ -293,6 +293,7 @@ const DEFAULT_STATE = {
   flowStartTime: null, // 当前流程开始时间。
   tabRegistry: {}, // 程序维护的标签页注册表。
   sourceLastUrls: {}, // 各来源页面最近一次打开的地址记录。
+  retainedTabOwnership: {}, // 仅保留自动化自己拥有的窄范围标签页所有权记录。
   logs: [], // 侧边栏展示的运行日志。
   ...PERSISTED_SETTING_DEFAULTS, // 合并 chrome.storage.local 中持久化保存的用户配置。
   luckmailApiKey: '',
@@ -1257,6 +1258,7 @@ async function resetState() {
       'accounts',
       'tabRegistry',
       'sourceLastUrls',
+      'retainedTabOwnership',
       'luckmailApiKey',
       'luckmailBaseUrl',
       'luckmailEmailType',
@@ -1279,6 +1281,7 @@ async function resetState() {
     accounts: prev.accounts || [],
     tabRegistry: prev.tabRegistry || {},
     sourceLastUrls: prev.sourceLastUrls || {},
+    retainedTabOwnership: prev.retainedTabOwnership || {},
     luckmailApiKey: String(prev.luckmailApiKey || ''),
     luckmailBaseUrl: normalizeLuckmailBaseUrl(prev.luckmailBaseUrl),
     luckmailEmailType: normalizeLuckmailEmailType(prev.luckmailEmailType),
@@ -3458,6 +3461,10 @@ async function getTabId(source) {
   return tabRuntime.getTabId(source);
 }
 
+async function preserveIcloudMailTabForManualInspection() {
+  return tabRuntime.logOwnedTabPreserved?.('icloud-mail');
+}
+
 function parseUrlSafely(rawUrl) {
   if (typeof navigationUtils !== 'undefined' && navigationUtils?.parseUrlSafely) {
     return navigationUtils.parseUrlSafely(rawUrl);
@@ -4798,6 +4805,7 @@ async function finalizeDeferredStepExecutionError(step, error) {
     return;
   }
 
+  await preserveIcloudMailTabForManualInspection();
   await setStepStatus(step, 'failed');
   await addLog(`步骤 ${step} 失败：${getErrorMessage(error)}`, 'error');
   await appendManualAccountRunRecordIfNeeded(`step${step}_failed`, latestState, getErrorMessage(error));
@@ -4922,6 +4930,7 @@ async function requestStop(options = {}) {
   cleanupStep8NavigationListeners();
   rejectPendingStep8(new Error(STOP_ERROR_MESSAGE));
 
+  await preserveIcloudMailTabForManualInspection();
   await addLog(logMessage, 'warn');
   await broadcastStopToContentScripts();
 
@@ -4978,6 +4987,7 @@ async function executeStep(step, options = {}) {
       throw err;
     }
     if (!(deferRetryableTransportError && doesStepUseCompletionSignal(step) && isRetryableContentScriptTransportError(err))) {
+      await preserveIcloudMailTabForManualInspection();
       await setStepStatus(step, 'failed');
       await addLog(`步骤 ${step} 失败：${err.message}`, 'error');
       await appendManualAccountRunRecordIfNeeded(`step${step}_failed`, state, getErrorMessage(err));

--- a/background.js
+++ b/background.js
@@ -417,7 +417,7 @@ function normalizeRunCount(value) {
   if (!Number.isFinite(numeric)) {
     return 1;
   }
-  return Math.min(50, Math.max(1, Math.floor(numeric)));
+  return Math.max(1, Math.floor(numeric));
 }
 
 function normalizeAutoRunTimerKind(value = '') {

--- a/background.js
+++ b/background.js
@@ -170,6 +170,8 @@ const DEFAULT_ACCOUNT_RUN_HISTORY_HELPER_BASE_URL = DEFAULT_HOTMAIL_LOCAL_BASE_U
 const HOTMAIL_LOCAL_HELPER_TIMEOUT_MS = 45000;
 const ICLOUD_GENERATION_STRATEGY_WEB = 'web';
 const ICLOUD_GENERATION_STRATEGY_LOCAL_MACOS = 'local-macos';
+const ICLOUD_NATIVE_MESSAGING_HOST_NAME = 'com.qlhazycoder.codex_oauth_automation_extension';
+const ICLOUD_NATIVE_MESSAGING_PROTOCOL_VERSION = 1;
 const ICLOUD_LOCAL_HELPER_TIMEOUT_MS = 120000;
 const DEFAULT_LUCKMAIL_PROJECT_CODE = 'openai';
 const DISPLAY_TIMEZONE = 'Asia/Shanghai';
@@ -1573,6 +1575,97 @@ async function getRuntimePlatformOs() {
     console.warn(LOG_PREFIX, 'Failed to read runtime platform info:', err?.message || err);
   }
   return '';
+}
+
+function createIcloudNativeHostRequestId() {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+  return `icloud-native-host-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function getIcloudNativeHostClientVersion() {
+  try {
+    const manifest = chrome.runtime?.getManifest?.();
+    return String(manifest?.version_name || manifest?.version || '').trim() || '0.0.0-local';
+  } catch (err) {
+    console.warn(LOG_PREFIX, 'Failed to read extension manifest version for native host:', err?.message || err);
+    return '0.0.0-local';
+  }
+}
+
+async function sendNativeHostMessage(hostName, payload, timeoutMs) {
+  if (!chrome.runtime?.sendNativeMessage) {
+    throw new Error('Native Messaging API 不可用。请确认扩展已声明 nativeMessaging 权限。');
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      reject(new Error('timeout'));
+    }, timeoutMs);
+
+    const complete = (callback) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      callback();
+    };
+
+    try {
+      chrome.runtime.sendNativeMessage(hostName, payload, (response) => {
+        const runtimeError = chrome.runtime?.lastError;
+        if (runtimeError) {
+          complete(() => reject(new Error(runtimeError.message || 'native messaging host error')));
+          return;
+        }
+        complete(() => resolve(response));
+      });
+    } catch (err) {
+      complete(() => reject(err));
+    }
+  });
+}
+
+function getIcloudNativeHostTransportErrorMessage(error) {
+  const rawMessage = String(error?.message || error || '').trim();
+  if (!rawMessage || rawMessage === 'timeout') {
+    return `本地宿主响应超时（>${Math.round(ICLOUD_LOCAL_HELPER_TIMEOUT_MS / 1000)} 秒）。`;
+  }
+  if (/specified native messaging host not found/i.test(rawMessage)) {
+    return '未找到已注册的本地宿主。请先运行 install-native-host.command，并传入当前扩展 ID。';
+  }
+  if (/access to the specified native messaging host is forbidden/i.test(rawMessage)) {
+    return '本地宿主已安装，但未授权当前扩展 ID。请重新运行 install-native-host.command，并确认扩展 ID 正确。';
+  }
+  if (/native host has exited|error when communicating with the native messaging host|failed to start native messaging host/i.test(rawMessage)) {
+    return '本地宿主启动或通信失败。请确认宿主已安装、Python 3 / Swift 可用，且宿主版本与扩展匹配。';
+  }
+  return `本地宿主调用失败：${rawMessage}`;
+}
+
+function getIcloudNativeHostResponseErrorMessage(response) {
+  const code = String(response?.error?.code || '').trim().toUpperCase();
+  const message = String(response?.error?.message || '').trim();
+  switch (code) {
+    case 'PLATFORM_UNSUPPORTED':
+    case 'SWIFT_UNAVAILABLE':
+    case 'SWIFT_SCRIPT_MISSING':
+    case 'APPLE_ID_PASSWORD_NOT_CONFIGURED':
+    case 'HOST_TIMEOUT':
+      return message || '本地宿主执行失败。';
+    case 'UNSUPPORTED_PROTOCOL':
+    case 'UNSUPPORTED_COMMAND':
+      return '本地宿主版本过旧或协议不匹配，请重新安装/更新宿主后重试。';
+    default:
+      return message || '本地宿主返回了未知错误。';
+  }
 }
 
 async function requestHotmailRemoteMailbox(account, mailbox = 'INBOX') {
@@ -3369,7 +3462,7 @@ async function deleteUsedIcloudAliases() {
   return { deleted, skipped };
 }
 
-async function fetchIcloudHideMyEmailLocally(state = null, options = {}) {
+async function fetchIcloudHideMyEmailViaLegacyLocalHelper(state = null, options = {}) {
   throwIfStopped();
 
   const currentState = state || await getState();
@@ -3436,6 +3529,65 @@ async function fetchIcloudHideMyEmailLocally(state = null, options = {}) {
   await setEmailState(alias);
   await addLog(`iCloud：已通过本地 macOS 方案创建新别名 ${alias}`, 'ok');
   broadcastIcloudAliasesChanged({ reason: 'created-local', email: alias });
+  return alias;
+}
+
+async function fetchIcloudHideMyEmailLocally(state = null, options = {}) {
+  throwIfStopped();
+
+  const currentState = state || await getState();
+  const platformOs = await getRuntimePlatformOs();
+  if (platformOs && platformOs !== 'mac') {
+    throw new Error('iCloud 本地生成仅支持 macOS；当前环境不是 macOS。');
+  }
+
+  const appleIdPassword = Object.prototype.hasOwnProperty.call(options, 'icloudAppleIdPassword')
+    ? String(options.icloudAppleIdPassword || '')
+    : String(currentState.icloudAppleIdPassword || '');
+  const requestId = createIcloudNativeHostRequestId();
+
+  await addLog(`iCloud：正在通过 Native Messaging 宿主创建新的 Hide My Email 地址（${ICLOUD_NATIVE_MESSAGING_HOST_NAME}）...`, 'info');
+
+  let response;
+  try {
+    response = await sendNativeHostMessage(ICLOUD_NATIVE_MESSAGING_HOST_NAME, {
+      requestId,
+      type: 'icloud.createHideMyEmail',
+      protocolVersion: ICLOUD_NATIVE_MESSAGING_PROTOCOL_VERSION,
+      clientVersion: getIcloudNativeHostClientVersion(),
+      payload: {
+        label: getIcloudAliasLabel(),
+        appleIdPassword,
+      },
+    }, ICLOUD_LOCAL_HELPER_TIMEOUT_MS);
+  } catch (err) {
+    throw new Error(`iCloud 本地生成失败：${getIcloudNativeHostTransportErrorMessage(err)}`);
+  }
+
+  if (!response || typeof response !== 'object') {
+    throw new Error('iCloud 本地生成失败：本地宿主返回了无法识别的响应，请重新安装/更新宿主后重试。');
+  }
+  if (String(response.requestId || '') !== requestId) {
+    throw new Error('iCloud 本地生成失败：本地宿主响应与当前请求不匹配，请重试。');
+  }
+  if (Number(response.protocolVersion) !== ICLOUD_NATIVE_MESSAGING_PROTOCOL_VERSION) {
+    throw new Error('iCloud 本地生成失败：本地宿主版本过旧或协议不匹配，请重新安装/更新宿主后重试。');
+  }
+  if (response.ok !== true) {
+    throw new Error(`iCloud 本地生成失败：${getIcloudNativeHostResponseErrorMessage(response)}`);
+  }
+
+  const alias = String(response?.result?.email || '').trim().toLowerCase();
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(alias)) {
+    throw new Error('iCloud 本地生成失败：本地宿主没有返回有效邮箱地址。');
+  }
+
+  await setEmailState(alias);
+  await addLog(
+    `iCloud：已通过 Native Messaging 宿主创建新别名 ${alias}${response?.hostVersion ? `（host ${response.hostVersion}）` : ''}`,
+    'ok'
+  );
+  broadcastIcloudAliasesChanged({ reason: 'created-local-native-host', email: alias });
   return alias;
 }
 
@@ -4142,6 +4294,7 @@ function getAutoRunStatusPayload(phase, payload = {}) {
     autoRunCountdownAt: Number.isFinite(Number(normalizedPayload.countdownAt)) ? Number(normalizedPayload.countdownAt) : null,
     autoRunCountdownTitle: normalizedPayload.countdownTitle === undefined ? '' : String(normalizedPayload.countdownTitle || ''),
     autoRunCountdownNote: normalizedPayload.countdownNote === undefined ? '' : String(normalizedPayload.countdownNote || ''),
+    autoRunFailureSummary: normalizedPayload.failureSummary === undefined ? '' : String(normalizedPayload.failureSummary || ''),
   };
 }
 
@@ -4160,6 +4313,7 @@ async function broadcastAutoRunStatus(phase, payload = {}, extraState = {}) {
     countdownAt: rawCountdownAt === null ? null : Number(rawCountdownAt),
     countdownTitle: payload.countdownTitle === undefined ? '' : String(payload.countdownTitle || ''),
     countdownNote: payload.countdownNote === undefined ? '' : String(payload.countdownNote || ''),
+    failureSummary: payload.failureSummary === undefined ? '' : String(payload.failureSummary || ''),
   };
 
   await setState({
@@ -5368,103 +5522,6 @@ async function ensureAutoEmailReady(targetRun, totalRuns, attemptRuns) {
   }
 
   if (isGeneratedAliasProvider(currentState)) {
-    if (currentState.mailProvider === GMAIL_PROVIDER) {
-      if (!currentState.emailPrefix) {
-        throw new Error('Gmail 原邮箱未设置，请先在侧边栏填写。');
-      }
-      await addLog(`=== 鐩爣 ${targetRun}/${totalRuns} 杞細Gmail +tag 妯″紡宸插惎鐢紝灏嗗湪姝ラ 3 鑷姩鐢熸垚閭锛堢 ${attemptRuns} 娆″皾璇曪級===`, 'info');
-      return null;
-    }
-    if (!currentState.emailPrefix) {
-      throw new Error('2925 邮箱前缀未设置，请先在侧边栏填写。');
-    }
-    await addLog(`=== 目标 ${targetRun}/${totalRuns} 轮：2925 模式已启用，将在步骤 3 自动生成邮箱（第 ${attemptRuns} 次尝试）===`, 'info');
-    return null;
-  }
-
-  if (currentState.email) {
-    return currentState.email;
-  }
-
-  if (shouldUseCustomRegistrationEmail(currentState)) {
-    await addLog(`=== 目标 ${targetRun}/${totalRuns} 轮已暂停：请先填写自定义注册邮箱，然后继续 ===`, 'warn');
-    await broadcastAutoRunStatus('waiting_email', {
-      currentRun: targetRun,
-      totalRuns,
-      attemptRun: attemptRuns,
-    });
-
-    await waitForResume();
-
-    const resumedState = await getState();
-    if (!resumedState.email) {
-      throw new Error('无法继续：当前没有注册邮箱。');
-    }
-    return resumedState.email;
-  }
-
-  const generator = normalizeEmailGenerator(currentState.emailGenerator);
-  const generatorLabel = getEmailGeneratorLabel(generator);
-  let lastError = null;
-  for (let attempt = 1; attempt <= EMAIL_FETCH_MAX_ATTEMPTS; attempt++) {
-    try {
-      if (attempt > 1) {
-        await addLog(`${generatorLabel}：正在进行第 ${attempt}/${EMAIL_FETCH_MAX_ATTEMPTS} 次自动获取重试...`, 'warn');
-      }
-      const generatedEmail = await fetchGeneratedEmail(currentState, { generateNew: true, generator });
-      await addLog(
-        `=== 目标 ${targetRun}/${totalRuns} 轮：${generatorLabel}已就绪：${generatedEmail}（第 ${attemptRuns} 次尝试，第 ${attempt}/${EMAIL_FETCH_MAX_ATTEMPTS} 次获取）===`,
-        'ok'
-      );
-      return generatedEmail;
-    } catch (err) {
-      lastError = err;
-      await addLog(`${generatorLabel}自动获取失败（${attempt}/${EMAIL_FETCH_MAX_ATTEMPTS}）：${err.message}`, 'warn');
-      if (
-        (generator === 'cloudflare' && /域名/.test(String(err.message || '')))
-        || (generator === CLOUDFLARE_TEMP_EMAIL_GENERATOR && /(服务地址|Admin Auth|域名)/.test(String(err.message || '')))
-      ) {
-        break;
-      }
-    }
-  }
-
-  await addLog(`${generatorLabel}自动获取已连续失败 ${EMAIL_FETCH_MAX_ATTEMPTS} 次：${lastError?.message || '未知错误'}`, 'error');
-  await addLog(`=== 目标 ${targetRun}/${totalRuns} 轮已暂停：请先自动获取邮箱或手动粘贴邮箱，然后继续 ===`, 'warn');
-  await broadcastAutoRunStatus('waiting_email', {
-    currentRun: targetRun,
-    totalRuns,
-    attemptRun: attemptRuns,
-  });
-
-  await waitForResume();
-
-  const resumedState = await getState();
-  if (!resumedState.email) {
-    throw new Error('无法继续：当前没有邮箱地址。');
-  }
-  return resumedState.email;
-}
-
-async function ensureAutoEmailReady(targetRun, totalRuns, attemptRuns) {
-  const currentState = await getState();
-  if (isHotmailProvider(currentState)) {
-    const account = await ensureHotmailAccountForFlow({
-      allowAllocate: true,
-      markUsed: true,
-      preferredAccountId: null,
-    });
-    await addLog(`=== 目标 ${targetRun}/${totalRuns} 轮：已分配 Hotmail 账号 ${account.email}（第 ${attemptRuns} 次尝试）===`, 'ok');
-    return account.email;
-  }
-
-  if (isLuckmailProvider(currentState)) {
-    const purchase = await ensureLuckmailPurchaseForFlow({ allowReuse: true });
-    await addLog(`=== 目标 ${targetRun}/${totalRuns} 轮：LuckMail 邮箱已就绪：${purchase.email_address}（第 ${attemptRuns} 次尝试）===`, 'ok');
-    return purchase.email_address;
-  }
-
-  if (isGeneratedAliasProvider(currentState)) {
     if (isReusableGeneratedAliasEmail(currentState)) {
       await addLog(`=== 目标 ${targetRun}/${totalRuns} 轮：当前已复用 ${currentState.email}，将直接继续执行（第 ${attemptRuns} 次尝试）===`, 'info');
       return currentState.email;
@@ -5488,11 +5545,13 @@ async function ensureAutoEmailReady(targetRun, totalRuns, attemptRuns) {
   }
 
   if (shouldUseCustomRegistrationEmail(currentState)) {
+    const failureSummary = '请先填写自定义注册邮箱。';
     await addLog(`=== 目标 ${targetRun}/${totalRuns} 轮已暂停：请先填写自定义注册邮箱，然后继续 ===`, 'warn');
     await broadcastAutoRunStatus('waiting_email', {
       currentRun: targetRun,
       totalRuns,
       attemptRun: attemptRuns,
+      failureSummary,
     });
 
     await waitForResume();
@@ -5530,12 +5589,14 @@ async function ensureAutoEmailReady(targetRun, totalRuns, attemptRuns) {
     }
   }
 
+  const failureSummaryPrefix = `${generatorLabel}自动获取失败：`;
   await addLog(`${generatorLabel}自动获取已连续失败 ${EMAIL_FETCH_MAX_ATTEMPTS} 次：${lastError?.message || '未知错误'}`, 'error');
   await addLog(`=== 目标 ${targetRun}/${totalRuns} 轮已暂停：请先自动获取邮箱或手动粘贴邮箱，然后继续 ===`, 'warn');
   await broadcastAutoRunStatus('waiting_email', {
     currentRun: targetRun,
     totalRuns,
     attemptRun: attemptRuns,
+    failureSummary: `${failureSummaryPrefix}${lastError?.message || '未知错误'}`,
   });
 
   await waitForResume();

--- a/background.js
+++ b/background.js
@@ -168,6 +168,9 @@ const DEFAULT_HOTMAIL_REMOTE_BASE_URL = '';
 const DEFAULT_HOTMAIL_LOCAL_BASE_URL = 'http://127.0.0.1:17373';
 const DEFAULT_ACCOUNT_RUN_HISTORY_HELPER_BASE_URL = DEFAULT_HOTMAIL_LOCAL_BASE_URL;
 const HOTMAIL_LOCAL_HELPER_TIMEOUT_MS = 45000;
+const ICLOUD_GENERATION_STRATEGY_WEB = 'web';
+const ICLOUD_GENERATION_STRATEGY_LOCAL_MACOS = 'local-macos';
+const ICLOUD_LOCAL_HELPER_TIMEOUT_MS = 120000;
 const DEFAULT_LUCKMAIL_PROJECT_CODE = 'openai';
 const DISPLAY_TIMEZONE = 'Asia/Shanghai';
 const MICROSOFT_TOKEN_DNR_RULE_ID = 1001;
@@ -229,6 +232,8 @@ const PERSISTED_SETTING_DEFAULTS = {
   emailGenerator: 'duck',
   autoDeleteUsedIcloudAlias: false,
   icloudHostPreference: 'auto',
+  icloudGenerationStrategy: ICLOUD_GENERATION_STRATEGY_WEB,
+  icloudAppleIdPassword: '',
   accountRunHistoryTextEnabled: false,
   accountRunHistoryHelperBaseUrl: DEFAULT_ACCOUNT_RUN_HISTORY_HELPER_BASE_URL,
   gmailBaseEmail: '',
@@ -612,6 +617,12 @@ function normalizeEmailGenerator(value = '') {
   return 'duck';
 }
 
+function normalizeIcloudGenerationStrategy(value = '') {
+  return String(value || '').trim().toLowerCase() === ICLOUD_GENERATION_STRATEGY_LOCAL_MACOS
+    ? ICLOUD_GENERATION_STRATEGY_LOCAL_MACOS
+    : ICLOUD_GENERATION_STRATEGY_WEB;
+}
+
 function normalizePanelMode(value = '') {
   return String(value || '').trim().toLowerCase() === 'sub2api' ? 'sub2api' : 'cpa';
 }
@@ -858,6 +869,10 @@ function normalizePersistentSettingValue(key, value) {
       return Boolean(value);
     case 'icloudHostPreference':
       return normalizeIcloudHost(value) || 'auto';
+    case 'icloudGenerationStrategy':
+      return normalizeIcloudGenerationStrategy(value);
+    case 'icloudAppleIdPassword':
+      return String(value || '');
     case 'accountRunHistoryHelperBaseUrl':
       return normalizeAccountRunHistoryHelperBaseUrl(value);
     case 'gmailBaseEmail':
@@ -1546,6 +1561,18 @@ async function ensureHotmailAccountForFlow(options = {}) {
 function buildHotmailLocalEndpoint(baseUrl, path) {
   const normalizedBaseUrl = normalizeHotmailLocalBaseUrl(baseUrl);
   return new URL(path, `${normalizedBaseUrl}/`).toString();
+}
+
+async function getRuntimePlatformOs() {
+  try {
+    if (chrome.runtime?.getPlatformInfo) {
+      const platformInfo = await chrome.runtime.getPlatformInfo();
+      return String(platformInfo?.os || '').trim().toLowerCase();
+    }
+  } catch (err) {
+    console.warn(LOG_PREFIX, 'Failed to read runtime platform info:', err?.message || err);
+  }
+  return '';
 }
 
 async function requestHotmailRemoteMailbox(account, mailbox = 'INBOX') {
@@ -3342,6 +3369,76 @@ async function deleteUsedIcloudAliases() {
   return { deleted, skipped };
 }
 
+async function fetchIcloudHideMyEmailLocally(state = null, options = {}) {
+  throwIfStopped();
+
+  const currentState = state || await getState();
+  const platformOs = await getRuntimePlatformOs();
+  if (platformOs && platformOs !== 'mac') {
+    throw new Error('iCloud 本地生成仅支持 macOS；当前环境不是 macOS。');
+  }
+
+  const helperBaseUrl = getHotmailServiceSettings(currentState).localBaseUrl;
+  const helperUrl = buildHotmailLocalEndpoint(helperBaseUrl, '/icloud/create-hide-my-email');
+  const appleIdPassword = Object.prototype.hasOwnProperty.call(options, 'icloudAppleIdPassword')
+    ? String(options.icloudAppleIdPassword || '')
+    : String(currentState.icloudAppleIdPassword || '');
+
+  await addLog(`iCloud：正在通过本地 macOS 方案创建新的 Hide My Email 地址（${helperBaseUrl}）...`, 'info');
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(new Error('timeout')), ICLOUD_LOCAL_HELPER_TIMEOUT_MS);
+
+  let response;
+  try {
+    response = await fetch(helperUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        label: getIcloudAliasLabel(),
+        appleIdPassword,
+      }),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (err?.name === 'AbortError') {
+      throw new Error(`iCloud 本地生成失败：本地 helper 请求超时（>${Math.round(ICLOUD_LOCAL_HELPER_TIMEOUT_MS / 1000)} 秒）。`);
+    }
+    throw new Error(`iCloud 本地生成失败：无法连接本地 helper（${helperBaseUrl}）。请先启动本地 helper 后重试。`);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  const text = await response.text();
+  let payload = {};
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    payload = { raw: text };
+  }
+
+  if (!response.ok || payload?.ok === false) {
+    if (response.status === 404) {
+      throw new Error('iCloud 本地生成失败：当前本地 helper 不支持该接口，请更新 helper 后重试。');
+    }
+    const errorText = payload?.error || payload?.message || payload?.raw || text || `HTTP ${response.status}`;
+    throw new Error(`iCloud 本地生成失败：${errorText}`);
+  }
+
+  const alias = String(payload?.email || '').trim().toLowerCase();
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(alias)) {
+    throw new Error('iCloud 本地生成失败：本地 helper 没有返回有效邮箱地址。');
+  }
+
+  await setEmailState(alias);
+  await addLog(`iCloud：已通过本地 macOS 方案创建新别名 ${alias}`, 'ok');
+  broadcastIcloudAliasesChanged({ reason: 'created-local', email: alias });
+  return alias;
+}
+
 async function fetchIcloudHideMyEmail() {
   return withIcloudLoginHelp('获取 iCloud 隐私邮箱', async () => {
     throwIfStopped();
@@ -5066,7 +5163,8 @@ const generatedEmailHelpers = self.MultiPageGeneratedEmailHelpers?.createGenerat
   CLOUDFLARE_TEMP_EMAIL_GENERATOR,
   DUCK_AUTOFILL_URL,
   fetch,
-  fetchIcloudHideMyEmail,
+  fetchIcloudHideMyEmailLocal: fetchIcloudHideMyEmailLocally,
+  fetchIcloudHideMyEmailWeb: fetchIcloudHideMyEmail,
   getCloudflareTempEmailAddressFromResponse,
   getCloudflareTempEmailConfig,
   getState,
@@ -5074,6 +5172,7 @@ const generatedEmailHelpers = self.MultiPageGeneratedEmailHelpers?.createGenerat
   normalizeCloudflareDomain,
   normalizeCloudflareTempEmailAddress,
   normalizeEmailGenerator,
+  normalizeIcloudGenerationStrategy,
   isGeneratedAliasProvider,
   reuseOrCreateTab,
   sendToContentScript,

--- a/background/auto-run-controller.js
+++ b/background/auto-run-controller.js
@@ -382,6 +382,7 @@
               autoRunSessionId: sessionId,
               tabRegistry: {},
               sourceLastUrls: {},
+              retainedTabOwnership: { ...(prevState.retainedTabOwnership || {}) },
               ...getAutoRunStatusPayload('running', { currentRun: targetRun, totalRuns, attemptRun, sessionId }),
             };
             await resetState();

--- a/background/generated-email-helpers.js
+++ b/background/generated-email-helpers.js
@@ -9,7 +9,8 @@
       CLOUDFLARE_TEMP_EMAIL_GENERATOR,
       DUCK_AUTOFILL_URL,
       fetch,
-      fetchIcloudHideMyEmail,
+      fetchIcloudHideMyEmailLocal,
+      fetchIcloudHideMyEmailWeb,
       getCloudflareTempEmailAddressFromResponse,
       getCloudflareTempEmailConfig,
       getState,
@@ -17,6 +18,7 @@
       normalizeCloudflareDomain,
       normalizeCloudflareTempEmailAddress,
       normalizeEmailGenerator,
+      normalizeIcloudGenerationStrategy,
       isGeneratedAliasProvider,
       reuseOrCreateTab,
       sendToContentScript,
@@ -207,6 +209,18 @@
       return email;
     }
 
+    function resolveIcloudGenerationStrategy(state = {}, options = {}) {
+      const rawValue = options && Object.prototype.hasOwnProperty.call(options, 'icloudGenerationStrategy')
+        ? options.icloudGenerationStrategy
+        : state?.icloudGenerationStrategy;
+      if (typeof normalizeIcloudGenerationStrategy === 'function') {
+        return normalizeIcloudGenerationStrategy(rawValue);
+      }
+      return String(rawValue || '').trim().toLowerCase() === 'local-macos'
+        ? 'local-macos'
+        : 'web';
+    }
+
     async function fetchGeneratedEmail(state, options = {}) {
       const currentState = state || await getState();
       const provider = String(options.mailProvider || currentState.mailProvider || '').trim().toLowerCase();
@@ -218,7 +232,17 @@
         throw new Error('当前邮箱生成方式为自定义邮箱，请直接填写注册邮箱。');
       }
       if (generator === 'icloud') {
-        return fetchIcloudHideMyEmail();
+        const strategy = resolveIcloudGenerationStrategy(currentState, options);
+        if (strategy === 'local-macos') {
+          return fetchIcloudHideMyEmailLocal(currentState, {
+            ...options,
+            icloudGenerationStrategy: strategy,
+          });
+        }
+        return fetchIcloudHideMyEmailWeb(currentState, {
+          ...options,
+          icloudGenerationStrategy: strategy,
+        });
       }
       if (generator === 'cloudflare') {
         return fetchCloudflareEmail(currentState, options);

--- a/background/logging-status.js
+++ b/background/logging-status.js
@@ -147,6 +147,7 @@
         autoRunCountdownAt: Number.isFinite(Number(payload.countdownAt)) ? Number(payload.countdownAt) : null,
         autoRunCountdownTitle: payload.countdownTitle === undefined ? '' : String(payload.countdownTitle || ''),
         autoRunCountdownNote: payload.countdownNote === undefined ? '' : String(payload.countdownNote || ''),
+        autoRunFailureSummary: payload.failureSummary === undefined ? '' : String(payload.failureSummary || ''),
       };
     }
 

--- a/background/steps/fetch-signup-code.js
+++ b/background/steps/fetch-signup-code.js
@@ -10,6 +10,7 @@
       getMailConfig,
       getTabId,
       HOTMAIL_PROVIDER,
+      ICLOUD_PROVIDER,
       isTabAlive,
       LUCKMAIL_PROVIDER,
       CLOUDFLARE_TEMP_EMAIL_PROVIDER,
@@ -92,7 +93,7 @@
 
       await resolveVerificationStep(4, state, mail, {
         filterAfterTimestamp: stepStartedAt,
-        requestFreshCodeFirst: mail.provider === HOTMAIL_PROVIDER ? false : true,
+        requestFreshCodeFirst: !(mail.provider === HOTMAIL_PROVIDER || mail.provider === ICLOUD_PROVIDER),
         resendIntervalMs: (mail.provider === HOTMAIL_PROVIDER || mail.provider === '2925')
           ? 0
           : STANDARD_MAIL_VERIFICATION_RESEND_INTERVAL_MS,

--- a/background/tab-runtime.js
+++ b/background/tab-runtime.js
@@ -18,6 +18,12 @@
     } = deps;
 
     const pendingCommands = new Map();
+    const ICLOUD_MAIL_SOURCE = 'icloud-mail';
+    const RETAINED_TAB_OWNERSHIP_KEY = 'retainedTabOwnership';
+
+    function supportsRetainedOwnership(source) {
+      return source === ICLOUD_MAIL_SOURCE;
+    }
 
     async function sleepOrStop(ms) {
       if (typeof sleepWithStop === 'function') {
@@ -84,30 +90,99 @@
       return state.tabRegistry || {};
     }
 
-    async function registerTab(source, tabId) {
+    async function getRetainedTabOwnership() {
+      const state = await getState();
+      return state[RETAINED_TAB_OWNERSHIP_KEY] || {};
+    }
+
+    async function setRegistryEntry(source, tabId, options = {}) {
+      const { ready = true } = options;
       const registry = await getTabRegistry();
-      registry[source] = { tabId, ready: true };
+      registry[source] = { tabId, ready };
       await setState({ tabRegistry: registry });
+    }
+
+    async function setRetainedOwnedTab(source, entry) {
+      if (!supportsRetainedOwnership(source)) return;
+      const retained = await getRetainedTabOwnership();
+      if (!entry || !Number.isInteger(entry.tabId)) {
+        delete retained[source];
+      } else {
+        retained[source] = {
+          tabId: entry.tabId,
+          url: entry.url || '',
+        };
+      }
+      await setState({ [RETAINED_TAB_OWNERSHIP_KEY]: retained });
+    }
+
+    async function getRetainedOwnedTab(source) {
+      if (!supportsRetainedOwnership(source)) return null;
+      const retained = await getRetainedTabOwnership();
+      const entry = retained[source];
+      return Number.isInteger(entry?.tabId) ? entry : null;
+    }
+
+    async function rememberOwnedTab(source, tabId, url = '') {
+      if (!supportsRetainedOwnership(source) || !Number.isInteger(tabId)) return;
+      await setRetainedOwnedTab(source, { tabId, url });
+    }
+
+    async function mirrorOwnedTabIntoRegistry(source, tabId, options = {}) {
+      if (!supportsRetainedOwnership(source) || !Number.isInteger(tabId)) return;
+      await setRegistryEntry(source, tabId, options);
+      await addLog(`${source} mirror-owned-tab-into-registry`, 'info');
+    }
+
+    async function logOwnedTabPreserved(source) {
+      const owned = await getRetainedOwnedTab(source);
+      if (!owned) return false;
+      try {
+        await chrome.tabs.get(owned.tabId);
+      } catch {
+        return false;
+      }
+      await addLog(`${source} preserve-for-manual-inspection`, 'info');
+      return true;
+    }
+
+    async function registerTab(source, tabId) {
+      const tab = await chrome.tabs.get(tabId).catch(() => null);
+      await setRegistryEntry(source, tabId, { ready: true });
+      await rememberOwnedTab(source, tabId, tab?.url || '');
       console.log(LOG_PREFIX, `Tab registered: ${source} -> ${tabId}`);
     }
 
     async function isTabAlive(source) {
       const registry = await getTabRegistry();
       const entry = registry[source];
-      if (!entry) return false;
-      try {
-        await chrome.tabs.get(entry.tabId);
-        return true;
-      } catch {
-        registry[source] = null;
-        await setState({ tabRegistry: registry });
-        return false;
+      if (entry) {
+        try {
+          await chrome.tabs.get(entry.tabId);
+          return true;
+        } catch {
+          registry[source] = null;
+          await setState({ tabRegistry: registry });
+        }
       }
+      const retained = await getRetainedOwnedTab(source);
+      if (retained?.tabId) {
+        try {
+          await chrome.tabs.get(retained.tabId);
+          return true;
+        } catch {
+          await setRetainedOwnedTab(source, null);
+        }
+      }
+      return false;
     }
 
     async function getTabId(source) {
       const registry = await getTabRegistry();
-      return registry[source]?.tabId || null;
+      if (Number.isInteger(registry[source]?.tabId)) {
+        return registry[source].tabId;
+      }
+      return (await getRetainedOwnedTab(source))?.tabId || null;
     }
 
     async function rememberSourceLastUrl(source, url) {
@@ -119,6 +194,7 @@
     }
 
     async function closeConflictingTabsForSource(source, currentUrl, options = {}) {
+      if (supportsRetainedOwnership(source)) return;
       const { excludeTabIds = [] } = options;
       const excluded = new Set(excludeTabIds.filter((id) => Number.isInteger(id)));
       const state = await getState();
@@ -464,6 +540,130 @@
     }
 
     async function reuseOrCreateTab(source, url, options = {}) {
+      if (supportsRetainedOwnership(source)) {
+        const registry = await getTabRegistry();
+        let currentTab = null;
+        let hadRetainedOwnership = false;
+
+        if (Number.isInteger(registry[source]?.tabId)) {
+          try {
+            currentTab = await chrome.tabs.get(registry[source].tabId);
+            await rememberOwnedTab(source, currentTab.id, currentTab.url || url);
+          } catch {
+            registry[source] = null;
+            await setState({ tabRegistry: registry });
+          }
+        }
+
+        if (!currentTab) {
+          const retained = await getRetainedOwnedTab(source);
+          hadRetainedOwnership = Boolean(retained);
+          if (retained?.tabId) {
+            try {
+              currentTab = await chrome.tabs.get(retained.tabId);
+            } catch {
+              await setRetainedOwnedTab(source, null);
+            }
+          }
+        }
+
+        if (currentTab) {
+          const sameUrl = currentTab.url === url;
+          const shouldReloadOnReuse = sameUrl && options.reloadIfSameUrl;
+
+          await chrome.tabs.update(currentTab.id, { active: true });
+          await mirrorOwnedTabIntoRegistry(source, currentTab.id, { ready: !shouldReloadOnReuse });
+
+          if (sameUrl) {
+            await addLog(`${source} reuse-owned-tab`, 'info');
+
+            if (shouldReloadOnReuse) {
+              await setRegistryEntry(source, currentTab.id, { ready: false });
+              await chrome.tabs.reload(currentTab.id);
+              await waitForTabUpdateComplete(currentTab.id);
+            }
+
+            if (options.inject) {
+              await setRegistryEntry(source, currentTab.id, { ready: false });
+              if (options.injectSource) {
+                await chrome.scripting.executeScript({
+                  target: { tabId: currentTab.id },
+                  func: (injectedSource) => {
+                    window.__MULTIPAGE_SOURCE = injectedSource;
+                  },
+                  args: [options.injectSource],
+                });
+              }
+              await chrome.scripting.executeScript({
+                target: { tabId: currentTab.id },
+                files: options.inject,
+              });
+              await sleepOrStop(500);
+            }
+
+            await rememberSourceLastUrl(source, url);
+            await rememberOwnedTab(source, currentTab.id, url);
+            return currentTab.id;
+          }
+
+          await addLog(`${source} recover-owned-tab-via-navigation`, 'info');
+          await setRegistryEntry(source, currentTab.id, { ready: false });
+          await chrome.tabs.update(currentTab.id, { url, active: true });
+          await waitForTabUpdateComplete(currentTab.id);
+
+          if (options.inject) {
+            if (options.injectSource) {
+              await chrome.scripting.executeScript({
+                target: { tabId: currentTab.id },
+                func: (injectedSource) => {
+                  window.__MULTIPAGE_SOURCE = injectedSource;
+                },
+                args: [options.injectSource],
+              });
+            }
+            await chrome.scripting.executeScript({
+              target: { tabId: currentTab.id },
+              files: options.inject,
+            });
+          }
+
+          await sleepOrStop(500);
+          await rememberSourceLastUrl(source, url);
+          await rememberOwnedTab(source, currentTab.id, url);
+          return currentTab.id;
+        }
+
+        if (!hadRetainedOwnership) {
+          await addLog(`${source} ownership-missing-create-new`, 'info');
+        }
+
+        const tab = await chrome.tabs.create({ url, active: true });
+        await addLog(`${source} create-owned-tab`, 'info');
+        await rememberOwnedTab(source, tab.id, url);
+        await mirrorOwnedTabIntoRegistry(source, tab.id, { ready: !options.inject });
+
+        if (options.inject) {
+          await setRegistryEntry(source, tab.id, { ready: false });
+          await waitForTabUpdateComplete(tab.id);
+          if (options.injectSource) {
+            await chrome.scripting.executeScript({
+              target: { tabId: tab.id },
+              func: (injectedSource) => {
+                window.__MULTIPAGE_SOURCE = injectedSource;
+              },
+              args: [options.injectSource],
+            });
+          }
+          await chrome.scripting.executeScript({
+            target: { tabId: tab.id },
+            files: options.inject,
+          });
+        }
+
+        await rememberSourceLastUrl(source, url);
+        return tab.id;
+      }
+
       const alive = await isTabAlive(source);
       if (alive) {
         const tabId = await getTabId(source);
@@ -676,10 +876,12 @@
       flushCommand,
       getContentScriptResponseTimeoutMs,
       getMessageDebugLabel,
+      getRetainedTabOwnership,
       getTabId,
       getTabRegistry,
       isLocalhostOAuthCallbackTabMatch,
       isTabAlive,
+      logOwnedTabPreserved,
       pingContentScriptOnTab,
       queueCommand,
       registerTab,

--- a/docs/superpowers/plans/2026-04-20-native-host-migration-probe.md
+++ b/docs/superpowers/plans/2026-04-20-native-host-migration-probe.md
@@ -1,0 +1,233 @@
+# Native Host Migration Probe
+
+**Goal:** Probe the current `codex-oauth-automation-extension` codebase for a Chrome Native Messaging migration path, identify the exact touchpoints, and outline the safest staged rollout from the current localhost helper model.
+
+**Architecture snapshot:** The extension currently talks to a local Python helper over HTTP at `http://127.0.0.1:17373`. The helper is a long-lived `ThreadingHTTPServer` process that exposes `/messages`, `/code`, `/sync-account-run-records`, `/append-account-log`, and `/icloud/create-hide-my-email`. The extension has no Native Messaging capability in `manifest.json` yet.
+
+**Recommendation:** Do not replace the existing localhost helper in one shot. First add a Native Messaging transport shim for the same helper capabilities, then migrate iCloud local generation and mailbox/account-history calls behind a shared background bridge with HTTP fallback during the transition.
+
+---
+
+## Grounded Facts
+
+1. `manifest.json` currently has no `nativeMessaging`, `connectNative`, or `sendNativeMessage` surface.
+2. `background.js` centralizes helper URL construction via `buildHotmailLocalEndpoint(baseUrl, path)` and currently issues localhost `fetch()` calls for:
+   - `/messages`
+   - `/code`
+   - `/icloud/create-hide-my-email`
+3. `background/account-run-history.js` also depends on the same local helper shape for `/sync-account-run-records`.
+4. `scripts/hotmail_helper.py` is currently an HTTP server process, not a stdio Native Messaging host.
+5. The helper logic is still reusable for a native host because the business functions are imported/executed under a normal `if __name__ == "__main__": main()` guard.
+
+---
+
+## Current Code Touchpoints
+
+### Extension-side touchpoints
+
+- `manifest.json`
+  - add Native Messaging permission/capability for the target Chromium runtime
+- `background.js`
+  - helper base URL defaults and normalization
+  - `buildHotmailLocalEndpoint()`
+  - mailbox helper calls (`/messages`, `/code`)
+  - iCloud local generation call (`/icloud/create-hide-my-email`)
+- `background/generated-email-helpers.js`
+  - generator routing for `icloud` / `local-macos`
+- `background/account-run-history.js`
+  - local helper sync path for account history files
+- `sidepanel/sidepanel.js` / `sidepanel/sidepanel.html`
+  - currently expose helper URL / local mode configuration only; likely need status messaging rather than direct Native Host controls
+
+### Helper-side touchpoints
+
+- `scripts/hotmail_helper.py`
+  - contains the actual business handlers already worth reusing
+  - currently exposes HTTP routes only
+- helper start scripts
+  - `start-hotmail-helper.command`
+  - `start-hotmail-helper.bat`
+- `README.md`
+  - documents manual helper startup and localhost assumptions
+
+### Test/documentation touchpoints
+
+- helper-related tests under `tests/`
+- architecture docs and rollout docs under `docs/`
+
+---
+
+## Key Migration Constraint
+
+Native Messaging is **not** a drop-in transport swap for the current helper process.
+
+Today the helper is a server that binds `127.0.0.1:17373` and waits for HTTP requests. A Native Messaging host must instead:
+
+- start on demand from the browser
+- read length-prefixed JSON messages from stdin
+- write length-prefixed JSON replies to stdout
+- exit cleanly when idle / when the port is closed
+
+So the current Python file cannot simply be “registered as-is” without an adapter.
+
+---
+
+## Safest Migration Shape
+
+### Phase 1 — add a Native Host shim, keep existing HTTP helper intact
+
+Create a separate native host entrypoint, for example:
+
+- `scripts/native_host.py`
+
+Responsibilities:
+
+- read Native Messaging requests from stdin
+- dispatch to existing helper business functions already implemented in `scripts/hotmail_helper.py`
+- serialize replies/errors back to stdout
+- avoid starting `ThreadingHTTPServer`
+
+Why this is safest:
+
+- preserves current localhost helper behavior for existing users
+- avoids large refactors inside the already-working HTTP helper
+- lets the extension migrate call-by-call behind a bridge layer
+
+### Phase 2 — add a background transport bridge in the extension
+
+Introduce a single background-owned helper transport abstraction, for example:
+
+- `invokeLocalCompanion({ action, payload, transportPreference })`
+
+The bridge should:
+
+1. try Native Messaging when enabled/available
+2. optionally fall back to HTTP localhost during migration
+3. normalize all response/error shapes for callers
+
+This keeps the rest of the extension from caring whether a reply came from HTTP or Native Messaging.
+
+### Phase 3 — migrate the highest-value paths first
+
+Recommended order:
+
+1. `iCloud local-macos` generation (`/icloud/create-hide-my-email`)
+2. mailbox polling (`/messages`, `/code`)
+3. account run history sync (`/sync-account-run-records`, `/append-account-log`)
+
+Reason:
+
+- iCloud local generation is the user-visible pain point that motivated the lifecycle discussion
+- mailbox/account-history paths already work with localhost and can follow after the transport abstraction is proven
+
+### Phase 4 — add installer/registration tooling
+
+Needed artifacts:
+
+- native host manifest template(s)
+- macOS install/uninstall script
+- host registration path docs
+- version compatibility check between extension and host
+
+Without this, the transport code can compile but the browser still will not be able to launch the host.
+
+---
+
+## Concrete File-Level Work Plan
+
+### Task 1: Introduce a transport bridge in background
+
+**Files:**
+- Modify: `background.js`
+- Modify: `background/generated-email-helpers.js`
+- Modify: `background/account-run-history.js`
+- Add: `background/native-host-client.js` (preferred) or equivalent helper module
+
+**Goal:** Move all helper invocations behind one background-owned API.
+
+### Task 2: Add a Python Native Host shim
+
+**Files:**
+- Add: `scripts/native_host.py`
+- Optionally modify: `scripts/hotmail_helper.py` (only to extract reusable pure helpers if required)
+
+**Goal:** Reuse current business functions without binding an HTTP server.
+
+### Task 3: Register the host with the browser
+
+**Files:**
+- Modify: `manifest.json`
+- Add: browser native host manifest(s)
+- Add: install/uninstall scripts/docs
+
+**Goal:** Make the browser capable of launching the host on demand.
+
+### Task 4: Migrate the iCloud local path first
+
+**Files:**
+- Modify: `background.js`
+- Modify: `background/generated-email-helpers.js`
+- Modify: `README.md`
+- Modify: related tests in `tests/`
+
+**Goal:** Prove the new bridge on the most important path before touching all helper consumers.
+
+### Task 5: Migrate mailbox/account-history consumers
+
+**Files:**
+- Modify: `background.js`
+- Modify: `background/account-run-history.js`
+- Modify: tests and docs
+
+**Goal:** Bring the remaining localhost helper endpoints behind the same bridge.
+
+---
+
+## Risks to Call Out Early
+
+1. **Shared-file overlap risk**
+   - `background.js`, `README.md`, helper scripts, and sidepanel files are already the exact files involved in recent helper lifecycle work; avoid parallel blind edits.
+2. **Registration/distribution risk**
+   - Native Messaging is only as good as install + registration reliability.
+3. **Protocol drift risk**
+   - If HTTP and Native Messaging responses diverge, extension callers will accumulate transport-specific branches.
+4. **One-shot rewrite risk**
+   - Replacing the HTTP helper outright would combine transport change, install change, and feature regression risk in one step.
+
+---
+
+## Verification Checklist for the Migration Work
+
+### Bridge-level verification
+
+- Native Messaging host call succeeds when the host is installed
+- structured errors distinguish “host missing”, “host timeout”, and “business failure”
+- HTTP fallback still works when explicitly enabled during migration
+
+### iCloud verification
+
+- first local iCloud generation works without a prestarted localhost server
+- Apple ID password flow still surfaces actionable errors
+- success path still writes the generated alias back into extension state
+
+### Mailbox/account-history verification
+
+- mailbox fetch/code fetch still return the same normalized payload shape
+- account history sync still writes the expected file outputs
+
+### Rollout verification
+
+- fresh install path works on macOS
+- uninstall/rollback returns the extension to the documented localhost/manual mode
+
+---
+
+## Bottom Line
+
+The repo is structurally ready for a staged Native Messaging migration, but **not** for a safe one-shot swap. The cleanest path is:
+
+1. add a Native Host shim around existing Python helper logic,
+2. add one background transport bridge,
+3. migrate the iCloud local path first,
+4. then move mailbox/account-history traffic,
+5. and only later consider retiring localhost mode.

--- a/install-native-host.command
+++ b/install-native-host.command
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+EXTENSION_ID="${1:-}"
+TARGET="${2:-chrome}"
+
+if [[ -z "$EXTENSION_ID" ]]; then
+  read -r -p "Chrome 扩展 ID: " EXTENSION_ID
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+  exec python3 scripts/install_native_messaging_host.py --extension-id "$EXTENSION_ID" --target "$TARGET"
+fi
+
+echo "Python 3 not found. Please install Python 3.10+ and try again."
+read -r -p "Press Enter to exit..."

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,7 @@
     "tabs",
     "webNavigation",
     "declarativeNetRequest",
+    "nativeMessaging",
     "debugger",
     "browsingData",
     "cookies",

--- a/scripts/create_hide_my_email_ax.swift
+++ b/scripts/create_hide_my_email_ax.swift
@@ -203,7 +203,7 @@ func activateSystemSettings() {
     guard let app = systemSettingsApp() else {
         return
     }
-    _ = app.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+    _ = app.activate(options: [.activateAllWindows])
 }
 
 func terminateSystemSettingsIfRunning() {

--- a/scripts/create_hide_my_email_ax.swift
+++ b/scripts/create_hide_my_email_ax.swift
@@ -1,0 +1,866 @@
+#!/usr/bin/env swift
+
+import AppKit
+import ApplicationServices
+import CoreGraphics
+import Foundation
+
+let label = ProcessInfo.processInfo.environment["HIDE_MY_EMAIL_LABEL"] ?? "Codex"
+let bundleID = "com.apple.systempreferences"
+let iCloudURL = "x-apple.systempreferences:com.apple.systempreferences.AppleIDSettings:icloud"
+let iCloudWindowTitleHints = ["iCloud", "iCloud+"]
+
+let hideMyEmailDescriptions = ["隐藏邮件地址", "Hide My Email"]
+let accountNavigationTerms = ["iCloud", "Apple账户", "Apple Account"]
+let createButtonTitles = ["创建新地址", "Create New Address"]
+let continueButtonTitles = ["继续", "Continue"]
+let doneButtonTitles = ["完成", "Done"]
+let cancelButtonTitles = ["取消", "Cancel"]
+let passwordPromptTerms = ["输入密码", "Apple ID", "Apple Account", "密码", "Password", "账户详细信息", "account details"]
+let passwordPromptStrongTerms = ["输入密码", "密码", "Password", "账户详细信息", "account details", "忘记密码", "Forgot Password"]
+let passwordContinueButtonTitles = ["继续", "Continue", "下一步", "Next", "登录", "Sign In", "允许", "Allow", "好", "OK"]
+let launchTimeout: TimeInterval = 20
+let transitionTimeout: TimeInterval = 20
+let transitionAttempts = 3
+let appleIDPassword = (ProcessInfo.processInfo.environment["HIDDEN_MAIL_APPLE_ID_PASSWORD"] ?? "")
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+
+func fail(_ message: String) -> Never {
+    fputs("\(message)\n", stderr)
+    exit(1)
+}
+
+func attr(_ element: AXUIElement, _ name: String) -> CFTypeRef? {
+    var value: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, name as CFString, &value) == .success else {
+        return nil
+    }
+    return value
+}
+
+func strAttr(_ element: AXUIElement, _ name: String) -> String? {
+    attr(element, name) as? String
+}
+
+func children(of element: AXUIElement) -> [AXUIElement] {
+    attr(element, kAXChildrenAttribute) as? [AXUIElement] ?? []
+}
+
+func parent(of element: AXUIElement) -> AXUIElement? {
+    guard let value = attr(element, kAXParentAttribute) else {
+        return nil
+    }
+    return unsafeBitCast(value, to: AXUIElement.self)
+}
+
+func actionNames(of element: AXUIElement) -> [String] {
+    var value: CFArray?
+    guard AXUIElementCopyActionNames(element, &value) == .success,
+          let array = value as? [String] else {
+        return []
+    }
+    return array
+}
+
+func closeButton(of element: AXUIElement) -> AXUIElement? {
+    guard let value = attr(element, kAXCloseButtonAttribute) else {
+        return nil
+    }
+    return unsafeBitCast(value, to: AXUIElement.self)
+}
+
+func cgPointAttr(_ element: AXUIElement, _ name: String) -> CGPoint? {
+    guard let value = attr(element, name) else {
+        return nil
+    }
+    let axValue = unsafeBitCast(value, to: AXValue.self)
+    guard AXValueGetType(axValue) == .cgPoint else {
+        return nil
+    }
+    var point = CGPoint.zero
+    return AXValueGetValue(axValue, .cgPoint, &point) ? point : nil
+}
+
+func cgSizeAttr(_ element: AXUIElement, _ name: String) -> CGSize? {
+    guard let value = attr(element, name) else {
+        return nil
+    }
+    let axValue = unsafeBitCast(value, to: AXValue.self)
+    guard AXValueGetType(axValue) == .cgSize else {
+        return nil
+    }
+    var size = CGSize.zero
+    return AXValueGetValue(axValue, .cgSize, &size) ? size : nil
+}
+
+func walkElements<T>(startingAt element: AXUIElement, visit: (AXUIElement) -> T?) -> T? {
+    var stack: [AXUIElement] = [element]
+    var seen = Set<CFHashCode>()
+
+    while let current = stack.popLast() {
+        let hash = CFHash(current)
+        if seen.contains(hash) {
+            continue
+        }
+        seen.insert(hash)
+
+        if let found = visit(current) {
+            return found
+        }
+
+        stack.append(contentsOf: children(of: current).reversed())
+    }
+
+    return nil
+}
+
+func systemSettingsApp() -> NSRunningApplication? {
+    NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).first
+}
+
+func systemSettingsElement() -> AXUIElement? {
+    guard let app = systemSettingsApp() else {
+        return nil
+    }
+    return AXUIElementCreateApplication(app.processIdentifier)
+}
+
+func iCloudWindow() -> AXUIElement? {
+    guard let appElement = systemSettingsElement() else {
+        return nil
+    }
+
+    let windows = attr(appElement, kAXWindowsAttribute) as? [AXUIElement] ?? []
+    return windows.first {
+        let title = strAttr($0, kAXTitleAttribute) ?? ""
+        return iCloudWindowTitleHints.contains(where: { hint in !hint.isEmpty && title.contains(hint) })
+    }
+}
+
+func focusedSystemSettingsWindow() -> AXUIElement? {
+    guard let appElement = systemSettingsElement(),
+          let value = attr(appElement, kAXFocusedWindowAttribute) else {
+        return nil
+    }
+    return unsafeBitCast(value, to: AXUIElement.self)
+}
+
+func mainSystemSettingsWindow() -> AXUIElement? {
+    guard let appElement = systemSettingsElement(),
+          let value = attr(appElement, kAXMainWindowAttribute) else {
+        return nil
+    }
+    return unsafeBitCast(value, to: AXUIElement.self)
+}
+
+func anySystemSettingsWindow() -> AXUIElement? {
+    guard let appElement = systemSettingsElement() else {
+        return nil
+    }
+
+    let windows = attr(appElement, kAXWindowsAttribute) as? [AXUIElement] ?? []
+    return windows.first
+}
+
+func systemSettingsWindows() -> [AXUIElement] {
+    guard let appElement = systemSettingsElement() else {
+        return []
+    }
+    return attr(appElement, kAXWindowsAttribute) as? [AXUIElement] ?? []
+}
+
+func preferredSystemSettingsWindow() -> AXUIElement? {
+    iCloudWindow() ?? focusedSystemSettingsWindow() ?? mainSystemSettingsWindow() ?? anySystemSettingsWindow()
+}
+
+func currentWindowDiagnostics() -> String {
+    guard let appElement = systemSettingsElement() else {
+        return "system-settings-app=missing"
+    }
+
+    let windows = (attr(appElement, kAXWindowsAttribute) as? [AXUIElement] ?? []).map {
+        strAttr($0, kAXTitleAttribute) ?? "<untitled>"
+    }
+    let focusedTitle = focusedSystemSettingsWindow().flatMap { strAttr($0, kAXTitleAttribute) } ?? "<none>"
+    let mainTitle = mainSystemSettingsWindow().flatMap { strAttr($0, kAXTitleAttribute) } ?? "<none>"
+    let preferredTitle = preferredSystemSettingsWindow().flatMap { strAttr($0, kAXTitleAttribute) } ?? "<none>"
+    return "preferred=\(preferredTitle) focused=\(focusedTitle) main=\(mainTitle) windows=\(windows.joined(separator: ", "))"
+}
+
+@discardableResult
+func waitUntil(timeout: TimeInterval = 15, interval: TimeInterval = 0.2, _ condition: () -> Bool) -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        if condition() {
+            return true
+        }
+        RunLoop.current.run(until: Date().addingTimeInterval(interval))
+    }
+    return false
+}
+
+func activateSystemSettings() {
+    guard let app = systemSettingsApp() else {
+        return
+    }
+    _ = app.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+}
+
+func terminateSystemSettingsIfRunning() {
+    guard let app = systemSettingsApp() else {
+        return
+    }
+
+    if app.terminate() {
+        if waitUntil(timeout: 5, {
+            systemSettingsApp() == nil
+        }) {
+            return
+        }
+    }
+
+    _ = app.forceTerminate()
+    _ = waitUntil(timeout: 5, {
+        systemSettingsApp() == nil
+    })
+}
+
+func ensureSystemSettingsWindow() {
+    if anySystemSettingsWindow() != nil {
+        activateSystemSettings()
+        return
+    }
+
+    guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else {
+        fail("failed to resolve System Settings.app")
+    }
+
+    let configuration = NSWorkspace.OpenConfiguration()
+    configuration.activates = true
+
+    var launchError: Error?
+    let semaphore = DispatchSemaphore(value: 0)
+    NSWorkspace.shared.openApplication(at: appURL, configuration: configuration) { _, error in
+        launchError = error
+        semaphore.signal()
+    }
+    semaphore.wait()
+
+    if let launchError {
+        fail("failed to launch System Settings: \(launchError.localizedDescription)")
+    }
+
+    guard waitUntil(timeout: launchTimeout, {
+        activateSystemSettings()
+        return anySystemSettingsWindow() != nil
+    }) else {
+        fail("timed out waiting for a System Settings window")
+    }
+}
+
+func iCloudWindowReadyToContinue(_ window: AXUIElement) -> Bool {
+    findPressableElement(in: window, terms: hideMyEmailDescriptions) != nil ||
+    findButton(in: window, titles: createButtonTitles) != nil ||
+    findSheetContainingButton(in: window, titles: continueButtonTitles) != nil
+}
+
+@discardableResult
+func openICloudPaneViaURL() -> Bool {
+    guard let url = URL(string: iCloudURL), NSWorkspace.shared.open(url) else {
+        return false
+    }
+
+    return waitUntil(timeout: launchTimeout) {
+        activateSystemSettings()
+        return iCloudWindow() != nil
+    }
+}
+
+func ensureICloudPane() {
+    ensureSystemSettingsWindow()
+
+    if let currentICloudWindow = iCloudWindow() {
+        if iCloudWindowReadyToContinue(currentICloudWindow) {
+            activateSystemSettings()
+            return
+        }
+
+        terminateSystemSettingsIfRunning()
+        ensureSystemSettingsWindow()
+    }
+
+    if openICloudPaneViaURL() {
+        return
+    }
+
+    terminateSystemSettingsIfRunning()
+    ensureSystemSettingsWindow()
+    activateSystemSettings()
+}
+
+func findButton(
+    in element: AXUIElement,
+    titles: [String] = [],
+    descriptions: [String] = []
+) -> AXUIElement? {
+    walkElements(startingAt: element) { candidate in
+        guard (strAttr(candidate, kAXRoleAttribute) ?? "") == (kAXButtonRole as String) else {
+            return nil
+        }
+
+        let title = strAttr(candidate, kAXTitleAttribute) ?? ""
+        let description = strAttr(candidate, kAXDescriptionAttribute) ?? ""
+
+        if titles.contains(where: { !title.isEmpty && title.contains($0) }) {
+            return candidate
+        }
+
+        if descriptions.contains(where: { !description.isEmpty && description.contains($0) }) {
+            return candidate
+        }
+
+        return nil
+    }
+}
+
+func findSheetContainingButton(in element: AXUIElement, titles: [String]) -> AXUIElement? {
+    walkElements(startingAt: element) { candidate in
+        guard (strAttr(candidate, kAXRoleAttribute) ?? "") == (kAXSheetRole as String) else {
+            return nil
+        }
+
+        return findButton(in: candidate, titles: titles) != nil ? candidate : nil
+    }
+}
+
+func findEmailText(in element: AXUIElement) -> String? {
+    walkElements(startingAt: element) { candidate in
+        let value = strAttr(candidate, kAXValueAttribute) ?? ""
+        return value.contains("@icloud.com") ? value : nil
+    }
+}
+
+func findTextField(in element: AXUIElement) -> AXUIElement? {
+    walkElements(startingAt: element) { candidate in
+        let role = strAttr(candidate, kAXRoleAttribute) ?? ""
+        return role == (kAXTextFieldRole as String) || role == "AXSecureTextField" ? candidate : nil
+    }
+}
+
+func findSecureTextField(in element: AXUIElement) -> AXUIElement? {
+    walkElements(startingAt: element) { candidate in
+        (strAttr(candidate, kAXRoleAttribute) ?? "") == "AXSecureTextField" ? candidate : nil
+    }
+}
+
+func hasProgressIndicator(in element: AXUIElement) -> Bool {
+    walkElements(startingAt: element) { candidate in
+        (strAttr(candidate, kAXRoleAttribute) ?? "") == (kAXProgressIndicatorRole as String) ? true : nil
+    } ?? false
+}
+
+func normalizedText(_ value: String) -> String {
+    value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+}
+
+func containsAnyTerm(title: String, description: String, value: String, terms: [String]) -> Bool {
+    let haystacks = [normalizedText(title), normalizedText(description), normalizedText(value)]
+    return terms.contains { term in
+        let normalizedTerm = normalizedText(term)
+        return haystacks.contains(where: { !$0.isEmpty && $0.contains(normalizedTerm) })
+    }
+}
+
+func elementContainsTerms(in element: AXUIElement, terms: [String]) -> Bool {
+    walkElements(startingAt: element) { candidate in
+        let title = strAttr(candidate, kAXTitleAttribute) ?? ""
+        let description = strAttr(candidate, kAXDescriptionAttribute) ?? ""
+        let value = strAttr(candidate, kAXValueAttribute) ?? ""
+        return containsAnyTerm(title: title, description: description, value: value, terms: terms) ? true : nil
+    } ?? false
+}
+
+func hasButton(in element: AXUIElement, titles: [String]) -> Bool {
+    findButton(in: element, titles: titles) != nil
+}
+
+func findPasswordPrompt(in element: AXUIElement) -> AXUIElement? {
+    walkElements(startingAt: element) { candidate in
+        let role = strAttr(candidate, kAXRoleAttribute) ?? ""
+        guard role == (kAXSheetRole as String) || role == (kAXWindowRole as String) else {
+            return nil
+        }
+        guard findEmailText(in: candidate) == nil else {
+            return nil
+        }
+        guard hasButton(in: candidate, titles: cancelButtonTitles) else {
+            return nil
+        }
+        guard hasButton(in: candidate, titles: passwordContinueButtonTitles) else {
+            return nil
+        }
+        guard findSecureTextField(in: candidate) != nil || findTextField(in: candidate) != nil else {
+            return nil
+        }
+        guard elementContainsTerms(in: candidate, terms: passwordPromptStrongTerms)
+            || elementContainsTerms(in: candidate, terms: passwordPromptTerms) else {
+            return nil
+        }
+        return candidate
+    }
+}
+
+func findHideMyEmailManager(in element: AXUIElement) -> AXUIElement? {
+    walkElements(startingAt: element) { candidate in
+        let role = strAttr(candidate, kAXRoleAttribute) ?? ""
+        guard role == (kAXSheetRole as String) || role == (kAXWindowRole as String) else {
+            return nil
+        }
+        guard hasButton(in: candidate, titles: doneButtonTitles) else {
+            return nil
+        }
+        return elementContainsTerms(in: candidate, terms: hideMyEmailDescriptions) ? candidate : nil
+    }
+}
+
+func anyPasswordPrompt() -> AXUIElement? {
+    for window in systemSettingsWindows() {
+        if let prompt = findPasswordPrompt(in: window) {
+            return prompt
+        }
+    }
+    return nil
+}
+
+func anyHideMyEmailManager() -> AXUIElement? {
+    for window in systemSettingsWindows() {
+        if let manager = findHideMyEmailManager(in: window) {
+            return manager
+        }
+    }
+    return nil
+}
+
+func findPressableElement(in element: AXUIElement, terms: [String]) -> AXUIElement? {
+    walkElements(startingAt: element) { candidate in
+        let role = strAttr(candidate, kAXRoleAttribute) ?? ""
+        if role == (kAXApplicationRole as String)
+            || role == "AXMenuBar"
+            || role == "AXMenuBarItem"
+            || role == "AXMenu"
+            || role == "AXMenuItem" {
+            return nil
+        }
+
+        let title = strAttr(candidate, kAXTitleAttribute) ?? ""
+        let description = strAttr(candidate, kAXDescriptionAttribute) ?? ""
+        let value = strAttr(candidate, kAXValueAttribute) ?? ""
+        guard containsAnyTerm(title: title, description: description, value: value, terms: terms) else {
+            return nil
+        }
+
+        var current: AXUIElement? = candidate
+        for _ in 0..<6 {
+            guard let currentElement = current else {
+                break
+            }
+
+            let currentRole = strAttr(currentElement, kAXRoleAttribute) ?? ""
+            if currentRole == "AXMenuBar"
+                || currentRole == "AXMenuBarItem"
+                || currentRole == "AXMenu"
+                || currentRole == "AXMenuItem" {
+                break
+            }
+
+            let actions = actionNames(of: currentElement)
+            if actions.contains(kAXPressAction as String) {
+                return currentElement
+            }
+            current = parent(of: currentElement)
+        }
+
+        return nil
+    }
+}
+
+func interestingElementSummaries(in element: AXUIElement) -> [String] {
+    var seen = Set<String>()
+    var summaries: [String] = []
+
+    _ = walkElements(startingAt: element) { candidate in
+        let role = strAttr(candidate, kAXRoleAttribute) ?? ""
+        if role == (kAXApplicationRole as String) || role.hasPrefix("AXMenu") {
+            return nil
+        }
+        let title = strAttr(candidate, kAXTitleAttribute) ?? ""
+        let description = strAttr(candidate, kAXDescriptionAttribute) ?? ""
+        let value = strAttr(candidate, kAXValueAttribute) ?? ""
+        guard !title.isEmpty || !description.isEmpty || !value.isEmpty else {
+            return nil
+        }
+
+        let summary = "role=\(role) title=\(title) desc=\(description) value=\(value)"
+        guard !summary.isEmpty, !seen.contains(summary) else {
+            return nil
+        }
+
+        seen.insert(summary)
+        summaries.append(summary)
+        return nil
+    } as Never?
+
+    return summaries
+}
+
+func press(_ element: AXUIElement, context: String) {
+    let result = AXUIElementPerformAction(element, kAXPressAction as CFString)
+    guard result == .success else {
+        let role = strAttr(element, kAXRoleAttribute) ?? "<unknown>"
+        let title = strAttr(element, kAXTitleAttribute) ?? ""
+        let description = strAttr(element, kAXDescriptionAttribute) ?? ""
+        let actions = actionNames(of: element).joined(separator: ",")
+        fail("AXPress failed for \(context): \(result.rawValue); role=\(role) title=\(title) desc=\(description) actions=\(actions)")
+    }
+}
+
+func clickCenter(of element: AXUIElement, context: String) {
+    guard let origin = cgPointAttr(element, kAXPositionAttribute),
+          let size = cgSizeAttr(element, kAXSizeAttribute) else {
+        fail("failed to resolve click target geometry for \(context)")
+    }
+
+    let center = CGPoint(x: origin.x + (size.width / 2), y: origin.y + (size.height / 2))
+    let source = CGEventSource(stateID: .hidSystemState)
+
+    guard let move = CGEvent(mouseEventSource: source, mouseType: .mouseMoved, mouseCursorPosition: center, mouseButton: .left),
+          let down = CGEvent(mouseEventSource: source, mouseType: .leftMouseDown, mouseCursorPosition: center, mouseButton: .left),
+          let up = CGEvent(mouseEventSource: source, mouseType: .leftMouseUp, mouseCursorPosition: center, mouseButton: .left) else {
+        fail("failed to synthesize mouse click for \(context)")
+    }
+
+    move.post(tap: .cghidEventTap)
+    down.post(tap: .cghidEventTap)
+    up.post(tap: .cghidEventTap)
+}
+
+func setText(_ value: String, in element: AXUIElement, context: String) {
+    let result = AXUIElementSetAttributeValue(element, kAXValueAttribute as CFString, value as CFTypeRef)
+    guard result == .success else {
+        fail("failed to set \(context): \(result.rawValue)")
+    }
+}
+
+func postKey(_ keyCode: CGKeyCode, flags: CGEventFlags = []) {
+    let source = CGEventSource(stateID: .hidSystemState)
+
+    guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true),
+          let keyUp = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false) else {
+        fail("failed to post key event for keyCode \(keyCode)")
+    }
+
+    keyDown.flags = flags
+    keyDown.post(tap: .cghidEventTap)
+
+    keyUp.flags = flags
+    keyUp.post(tap: .cghidEventTap)
+}
+
+func typeUnicode(_ text: String) {
+    let source = CGEventSource(stateID: .hidSystemState)
+
+    for scalar in text.utf16 {
+        var value = scalar
+
+        guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) else {
+            fail("failed to post Unicode key events")
+        }
+
+        keyDown.keyboardSetUnicodeString(stringLength: 1, unicodeString: &value)
+        keyDown.post(tap: .cghidEventTap)
+
+        keyUp.keyboardSetUnicodeString(stringLength: 1, unicodeString: &value)
+        keyUp.post(tap: .cghidEventTap)
+    }
+}
+
+func fillTextField(_ value: String, in element: AXUIElement, context: String, verifyObservedValue: Bool = true) {
+    setText(value, in: element, context: context)
+    if !verifyObservedValue || (strAttr(element, kAXValueAttribute) ?? "") == value {
+        return
+    }
+
+    let focusResult = AXUIElementSetAttributeValue(element, kAXFocusedAttribute as CFString, kCFBooleanTrue)
+    guard focusResult == .success else {
+        fail("failed to focus \(context): \(focusResult.rawValue)")
+    }
+
+    RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+    postKey(0, flags: .maskCommand)
+    RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+    postKey(51)
+    RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+    typeUnicode(value)
+
+    guard waitUntil(timeout: 2, {
+        (strAttr(element, kAXValueAttribute) ?? "") == value
+    }) else {
+        fail("typed \(context) but did not observe the expected value")
+    }
+}
+
+func resolvePasswordPromptIfPresent(startingFrom window: AXUIElement) -> Bool {
+    guard let prompt = findPasswordPrompt(in: window) ?? anyPasswordPrompt() else {
+        return false
+    }
+
+    guard !appleIDPassword.isEmpty else {
+        fail("Apple ID password prompt appeared, but HIDDEN_MAIL_APPLE_ID_PASSWORD is not configured")
+    }
+
+    guard let passwordField = findSecureTextField(in: prompt) ?? findTextField(in: prompt) else {
+        fail("Apple ID password prompt appeared, but no password field was found")
+    }
+    fillTextField(appleIDPassword, in: passwordField, context: "Apple ID password", verifyObservedValue: false)
+
+    guard let continueButton = findButton(in: prompt, titles: passwordContinueButtonTitles)
+            ?? findPressableElement(in: prompt, terms: passwordContinueButtonTitles) else {
+        fail("Apple ID password prompt appeared, but no continue button was found")
+    }
+    press(continueButton, context: "Apple ID password continue button")
+
+    guard waitUntil(timeout: transitionTimeout, {
+        anyPasswordPrompt() == nil
+    }) else {
+        fail("timed out waiting for Apple ID password prompt to dismiss")
+    }
+
+    return true
+}
+
+func waitForSettingsState(
+    timeout: TimeInterval = transitionTimeout,
+    ready: @escaping (AXUIElement) -> Bool
+) -> AXUIElement? {
+    var matchedWindow: AXUIElement?
+    let succeeded = waitUntil(timeout: timeout) {
+        guard let refreshed = preferredSystemSettingsWindow() else {
+            return false
+        }
+        activateSystemSettings()
+
+        if ready(refreshed) {
+            matchedWindow = refreshed
+            return true
+        }
+
+        if resolvePasswordPromptIfPresent(startingFrom: refreshed) {
+            return false
+        }
+
+        _ = hasProgressIndicator(in: refreshed)
+        return false
+    }
+
+    return succeeded ? matchedWindow : nil
+}
+
+func ensureHideMyEmailManager(startingFrom window: AXUIElement) -> AXUIElement {
+    if let readyWindow = waitForSettingsState(timeout: 1, ready: { refreshed in
+        findButton(in: refreshed, titles: createButtonTitles) != nil ||
+        findSheetContainingButton(in: refreshed, titles: continueButtonTitles) != nil
+    }) {
+        return readyWindow
+    }
+
+    var currentWindow = window
+
+    for attempt in 1...transitionAttempts {
+        if let hideButton = findPressableElement(in: currentWindow, terms: hideMyEmailDescriptions) {
+            press(hideButton, context: "Hide My Email entry (attempt \(attempt))")
+
+            if let readyWindow = waitForSettingsState(ready: { refreshed in
+                findButton(in: refreshed, titles: createButtonTitles) != nil ||
+                findSheetContainingButton(in: refreshed, titles: continueButtonTitles) != nil
+            }) {
+                return readyWindow
+            }
+        } else if let navigationTarget = findPressableElement(in: currentWindow, terms: accountNavigationTerms) {
+            press(navigationTarget, context: "iCloud navigation fallback (attempt \(attempt))")
+
+            if let readyWindow = waitForSettingsState(ready: { refreshed in
+                findPressableElement(in: refreshed, terms: hideMyEmailDescriptions) != nil ||
+                findButton(in: refreshed, titles: createButtonTitles) != nil ||
+                findSheetContainingButton(in: refreshed, titles: continueButtonTitles) != nil
+            }) {
+                currentWindow = readyWindow
+                continue
+            }
+        } else {
+            let availableElements = interestingElementSummaries(in: currentWindow).joined(separator: " | ")
+            fail("failed to find Hide My Email entry in iCloud pane; available elements: \(availableElements)")
+        }
+
+        guard let refreshed = preferredSystemSettingsWindow() else {
+            break
+        }
+        currentWindow = refreshed
+    }
+
+    fail("timed out waiting for Hide My Email manager after \(transitionAttempts) attempts; \(currentWindowDiagnostics())")
+}
+
+func ensureCreateSheet(startingFrom window: AXUIElement) -> AXUIElement {
+    if let readyWindow = waitForSettingsState(timeout: 1, ready: { refreshed in
+        findSheetContainingButton(in: refreshed, titles: continueButtonTitles) != nil
+    }) {
+        return readyWindow
+    }
+
+    var currentWindow = window
+
+    for attempt in 1...transitionAttempts {
+        guard let createButton = findButton(in: currentWindow, titles: createButtonTitles) else {
+            fail("failed to find create-address button")
+        }
+        press(createButton, context: "Create new Hide My Email address (attempt \(attempt))")
+
+        if let readyWindow = waitForSettingsState(ready: { refreshed in
+            findSheetContainingButton(in: refreshed, titles: continueButtonTitles) != nil
+        }) {
+            return readyWindow
+        }
+
+        guard let refreshed = preferredSystemSettingsWindow() else {
+            break
+        }
+        currentWindow = refreshed
+    }
+
+    fail("timed out waiting for create-address sheet after \(transitionAttempts) attempts")
+}
+
+func dismissHideMyEmailManager(_ window: AXUIElement) {
+    _ = window
+
+    func managerDismissedGlobally() -> Bool {
+        anyPasswordPrompt() == nil && anyHideMyEmailManager() == nil
+    }
+
+    func waitForManagerToSettle(timeout: TimeInterval = transitionTimeout) {
+        _ = waitUntil(timeout: timeout) {
+            activateSystemSettings()
+            if let promptWindow = preferredSystemSettingsWindow(), resolvePasswordPromptIfPresent(startingFrom: promptWindow) {
+                return false
+            }
+
+            guard let manager = anyHideMyEmailManager() else {
+                return false
+            }
+
+            return !hasProgressIndicator(in: manager)
+        }
+    }
+
+    func waitForDismissal(timeout: TimeInterval = transitionTimeout) -> Bool {
+        waitUntil(timeout: timeout) {
+            activateSystemSettings()
+            if let promptWindow = preferredSystemSettingsWindow(), resolvePasswordPromptIfPresent(startingFrom: promptWindow) {
+                return false
+            }
+
+            return managerDismissedGlobally()
+        }
+    }
+
+    if resolvePasswordPromptIfPresent(startingFrom: window) {
+        guard anyHideMyEmailManager() != nil else {
+            return
+        }
+        dismissHideMyEmailManager(window)
+        return
+    }
+
+    waitForManagerToSettle()
+
+    if let manager = anyHideMyEmailManager(),
+       let doneButton = findButton(in: manager, titles: doneButtonTitles) {
+        press(doneButton, context: "Hide My Email done button")
+        if waitForDismissal() {
+            return
+        }
+    }
+
+    if let manager = anyHideMyEmailManager(),
+       let retryDoneButton = findButton(in: manager, titles: doneButtonTitles) {
+        press(retryDoneButton, context: "Hide My Email done button retry")
+        if waitForDismissal() {
+            return
+        }
+    }
+
+    if let manager = anyHideMyEmailManager(),
+       let windowCloseButton = closeButton(of: manager) {
+        press(windowCloseButton, context: "Hide My Email close button")
+        if waitForDismissal() {
+            return
+        }
+    }
+
+    activateSystemSettings()
+    postKey(13, flags: .maskCommand)
+
+    guard waitForDismissal() else {
+        fail("failed to dismiss Hide My Email manager")
+    }
+}
+
+ensureICloudPane()
+activateSystemSettings()
+
+guard let initialWindow = preferredSystemSettingsWindow() else {
+    fail("missing System Settings window after opening pane")
+}
+
+let managerWindow = ensureHideMyEmailManager(startingFrom: initialWindow)
+let createSheetWindow = ensureCreateSheet(startingFrom: managerWindow)
+
+guard let createSheet = findSheetContainingButton(in: createSheetWindow, titles: continueButtonTitles) else {
+    fail("failed to locate create-address sheet")
+}
+
+guard let relayEmail = findEmailText(in: createSheet) else {
+    fail("failed to read the newly generated Hide My Email relay address")
+}
+
+guard let labelField = findTextField(in: createSheet) else {
+    fail("failed to locate the Hide My Email label field")
+}
+fillTextField(label, in: labelField, context: "Hide My Email label")
+
+var completedWindow: AXUIElement?
+for attempt in 1...transitionAttempts {
+    guard let refreshedWindow = preferredSystemSettingsWindow(),
+          let refreshedCreateSheet = findSheetContainingButton(in: refreshedWindow, titles: continueButtonTitles),
+          let continueButton = findButton(in: refreshedCreateSheet, titles: continueButtonTitles) else {
+        fail("failed to locate the create-address continue button")
+    }
+
+    press(continueButton, context: "Create-address continue button (attempt \(attempt))")
+
+    if let closedWindow = waitForSettingsState(ready: { refreshed in
+        findSheetContainingButton(in: refreshed, titles: continueButtonTitles) == nil
+    }) {
+        completedWindow = closedWindow
+        break
+    }
+}
+
+guard let completedWindow else {
+    fail("timed out waiting for create-address sheet to close")
+}
+
+dismissHideMyEmailManager(completedWindow)
+
+print(relayEmail)

--- a/scripts/hotmail_helper.py
+++ b/scripts/hotmail_helper.py
@@ -4,6 +4,9 @@ import imaplib
 import json
 import os
 import re
+import shutil
+import subprocess
+import sys
 import threading
 import time
 import traceback
@@ -66,6 +69,11 @@ BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 ACCOUNT_LOG_PATH = os.path.join(BASE_DIR, "data", "account-run-history.txt")
 ACCOUNT_RECORDS_SNAPSHOT_PATH = os.path.join(BASE_DIR, "data", "account-run-history.json")
 ACCOUNT_RECORDS_LOCK = threading.Lock()
+ICLOUD_CREATE_SWIFT_SCRIPT = os.environ.get(
+    "MULTIPAGE_ICLOUD_CREATE_SWIFT_SCRIPT",
+    os.path.join(BASE_DIR, "scripts", "create_hide_my_email_ax.swift"),
+)
+ICLOUD_CREATE_TIMEOUT_MS = int(os.environ.get("MULTIPAGE_ICLOUD_CREATE_TIMEOUT_MS", "120000") or 120000)
 
 
 def json_response(handler, status, payload):
@@ -228,6 +236,54 @@ def sync_account_run_records(payload):
             json.dump(normalized_payload, handle, ensure_ascii=False, indent=2)
             handle.write("\n")
     return ACCOUNT_RECORDS_SNAPSHOT_PATH
+
+
+def create_icloud_hide_my_email_alias(label="", apple_id_password=""):
+    if sys.platform != "darwin":
+        raise RuntimeError("iCloud 本地生成仅支持 macOS。")
+
+    swift_bin = shutil.which("swift")
+    if not swift_bin:
+        raise RuntimeError("当前环境未安装 Swift，无法运行 iCloud 本地创建脚本。")
+
+    if not os.path.isfile(ICLOUD_CREATE_SWIFT_SCRIPT):
+        raise RuntimeError(f"未找到 iCloud 本地创建脚本：{ICLOUD_CREATE_SWIFT_SCRIPT}")
+
+    env = os.environ.copy()
+    env["HIDE_MY_EMAIL_LABEL"] = str(label or "").strip() or "MultiPage"
+    env["HIDDEN_MAIL_APPLE_ID_PASSWORD"] = str(apple_id_password or "")
+
+    try:
+        completed = subprocess.run(
+            [swift_bin, ICLOUD_CREATE_SWIFT_SCRIPT],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=ICLOUD_CREATE_TIMEOUT_MS / 1000,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        detail = compact_text((exc.stderr or exc.stdout or "").strip())
+        if detail:
+            raise RuntimeError(f"iCloud 本地创建脚本超时：{detail}") from exc
+        raise RuntimeError(f"iCloud 本地创建脚本超时（>{ICLOUD_CREATE_TIMEOUT_MS}ms）。") from exc
+
+    stdout = str(completed.stdout or "").strip()
+    stderr = str(completed.stderr or "").strip()
+    if completed.returncode != 0:
+        detail = compact_text(stderr or stdout or f"swift exited with code {completed.returncode}")
+        if "HIDDEN_MAIL_APPLE_ID_PASSWORD is not configured" in detail:
+            raise RuntimeError("本地 iCloud 方案遇到 Apple ID 密码确认框，但未配置 Apple ID 密码。请在侧边栏填写后重试。")
+        raise RuntimeError(f"iCloud 本地创建脚本失败：{detail}")
+
+    email_addr = stdout.splitlines()[-1].strip() if stdout else ""
+    if not re.fullmatch(r"[^@\s]+@[^@\s]+\.[^@\s]+", email_addr):
+        raise RuntimeError("iCloud 本地创建脚本没有返回有效邮箱地址。")
+
+    return {
+        "email": email_addr,
+        "createdAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
 
 
 def try_refresh_access_token(endpoint, client_id, refresh_token):
@@ -717,6 +773,18 @@ class HotmailHelperHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         try:
             payload = read_json_payload(self)
+
+            if self.path == "/icloud/create-hide-my-email":
+                created = create_icloud_hide_my_email_alias(
+                    payload.get("label"),
+                    payload.get("appleIdPassword"),
+                )
+                json_response(self, 200, {
+                    "ok": True,
+                    "email": created["email"],
+                    "createdAt": created["createdAt"],
+                })
+                return
 
             if self.path == "/sync-account-run-records":
                 file_path = sync_account_run_records(payload)

--- a/scripts/install_native_messaging_host.py
+++ b/scripts/install_native_messaging_host.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+
+
+HOST_NAME = "com.qlhazycoder.codex_oauth_automation_extension"
+HOST_PROTOCOL_VERSION = 1
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+HOST_SCRIPT_PATH = os.path.join(BASE_DIR, "scripts", "native_messaging_host.py")
+TARGET_DIRECTORIES = {
+    "chrome": os.path.expanduser("~/Library/Application Support/Google/Chrome/NativeMessagingHosts"),
+    "chrome-beta": os.path.expanduser("~/Library/Application Support/Google/Chrome Beta/NativeMessagingHosts"),
+    "chrome-canary": os.path.expanduser("~/Library/Application Support/Google/Chrome Canary/NativeMessagingHosts"),
+    "chromium": os.path.expanduser("~/Library/Application Support/Chromium/NativeMessagingHosts"),
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Install the Chrome Native Messaging host for codex-oauth-automation-extension.")
+    parser.add_argument("--extension-id", required=True, help="Chrome extension ID (32 chars, a-p).")
+    parser.add_argument(
+        "--target",
+        action="append",
+        choices=sorted(TARGET_DIRECTORIES),
+        help="Browser target to install into. Defaults to chrome.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        help="Override manifest output directory for testing.",
+    )
+    parser.add_argument(
+        "--skip-self-check",
+        action="store_true",
+        help="Skip running the native host self-check before writing the manifest.",
+    )
+    return parser.parse_args()
+
+
+def validate_extension_id(extension_id):
+    value = str(extension_id or "").strip()
+    if not re.fullmatch(r"[a-p]{32}", value):
+        raise RuntimeError("Chrome 扩展 ID 格式无效，应为 32 位 a-p 字符。")
+    return value
+
+
+def ensure_executable(path):
+    mode = os.stat(path).st_mode
+    os.chmod(
+        path,
+        mode
+        | stat.S_IXUSR
+        | stat.S_IXGRP
+        | stat.S_IXOTH,
+    )
+
+
+def run_self_check():
+    completed = subprocess.run(
+        [HOST_SCRIPT_PATH, "--self-check"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(f"Native host self-check failed: {completed.stderr.strip() or completed.stdout.strip() or completed.returncode}")
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Native host self-check returned invalid JSON: {exc}") from exc
+    if not payload.get("ok"):
+        raise RuntimeError("Native host self-check did not report success.")
+    return payload
+
+
+def build_manifest(extension_id):
+    return {
+        "name": HOST_NAME,
+        "description": "Codex OAuth Automation local Native Messaging host",
+        "path": HOST_SCRIPT_PATH,
+        "type": "stdio",
+        "allowed_origins": [
+            f"chrome-extension://{extension_id}/",
+        ],
+        "protocol_version": HOST_PROTOCOL_VERSION,
+    }
+
+
+def write_manifest(output_dir, manifest):
+    os.makedirs(output_dir, exist_ok=True)
+    manifest_path = os.path.join(output_dir, f"{HOST_NAME}.json")
+    with open(manifest_path, "w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+    return manifest_path
+
+
+def main():
+    args = parse_args()
+    extension_id = validate_extension_id(args.extension_id)
+    ensure_executable(HOST_SCRIPT_PATH)
+    self_check = None if args.skip_self_check else run_self_check()
+
+    targets = args.target or ["chrome"]
+    output_directories = [os.path.abspath(args.output_dir)] if args.output_dir else [TARGET_DIRECTORIES[target] for target in targets]
+    manifest = build_manifest(extension_id)
+
+    manifest_paths = [write_manifest(output_dir, manifest) for output_dir in output_directories]
+    summary = {
+        "ok": True,
+        "hostName": HOST_NAME,
+        "hostScriptPath": HOST_SCRIPT_PATH,
+        "manifestPaths": manifest_paths,
+        "extensionOrigin": manifest["allowed_origins"][0],
+        "protocolVersion": HOST_PROTOCOL_VERSION,
+    }
+    if self_check is not None:
+        summary["selfCheck"] = self_check
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/native_messaging_host.py
+++ b/scripts/native_messaging_host.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import shutil
+import struct
+import sys
+import traceback
+from datetime import datetime, timezone
+
+from hotmail_helper import ICLOUD_CREATE_SWIFT_SCRIPT, create_icloud_hide_my_email_alias
+
+
+HOST_NAME = "com.qlhazycoder.codex_oauth_automation_extension"
+HOST_PROTOCOL_VERSION = 1
+COMMAND_PING = "host.ping"
+COMMAND_CREATE_ICLOUD_ALIAS = "icloud.createHideMyEmail"
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+DATA_DIR = os.path.join(BASE_DIR, "data")
+LOG_PATH = os.path.join(DATA_DIR, "native-messaging-host.log")
+MANIFEST_PATH = os.path.join(BASE_DIR, "manifest.json")
+
+
+def utc_now():
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def read_manifest_version():
+    try:
+        with open(MANIFEST_PATH, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except Exception:
+        return "0.0.0-local"
+
+    version_name = str(payload.get("version_name") or "").strip()
+    if version_name:
+        return version_name
+
+    version = str(payload.get("version") or "").strip()
+    return f"v{version}" if version else "0.0.0-local"
+
+
+HOST_VERSION = read_manifest_version()
+
+
+def append_log(message):
+    os.makedirs(DATA_DIR, exist_ok=True)
+    line = f"[{utc_now()}] {message}\n"
+    with open(LOG_PATH, "a", encoding="utf-8") as handle:
+        handle.write(line)
+
+
+def build_error(code, message, details=None):
+    payload = {
+        "code": str(code or "INTERNAL_ERROR"),
+        "message": str(message or "未知错误"),
+    }
+    if details:
+        payload["details"] = details
+    return payload
+
+
+def classify_runtime_error(exc):
+    message = str(exc or "").strip() or "未知错误"
+    lowered = message.lower()
+    if "仅支持 macos" in message:
+        return build_error("PLATFORM_UNSUPPORTED", message)
+    if "未安装 swift" in message:
+        return build_error("SWIFT_UNAVAILABLE", message)
+    if "未找到 icloud 本地创建脚本" in message:
+        return build_error("SWIFT_SCRIPT_MISSING", message)
+    if "未配置 apple id 密码" in message:
+        return build_error("APPLE_ID_PASSWORD_NOT_CONFIGURED", message)
+    if "超时" in message or "timeout" in lowered:
+        return build_error("HOST_TIMEOUT", message)
+    return build_error("INTERNAL_ERROR", message)
+
+
+def build_response(request_id, ok, result=None, error=None):
+    payload = {
+        "requestId": request_id,
+        "ok": bool(ok),
+        "protocolVersion": HOST_PROTOCOL_VERSION,
+        "hostName": HOST_NAME,
+        "hostVersion": HOST_VERSION,
+        "timestamp": utc_now(),
+    }
+    if result is not None:
+        payload["result"] = result
+    if error is not None:
+        payload["error"] = error
+    return payload
+
+
+def read_native_message():
+    header = sys.stdin.buffer.read(4)
+    if not header:
+        return None
+    if len(header) != 4:
+        raise RuntimeError("Native host header length is invalid.")
+    message_length = struct.unpack("<I", header)[0]
+    if message_length <= 0:
+        raise RuntimeError("Native host payload length is invalid.")
+    body = sys.stdin.buffer.read(message_length)
+    if len(body) != message_length:
+        raise RuntimeError("Native host payload is truncated.")
+    return json.loads(body.decode("utf-8"))
+
+
+def write_native_message(payload):
+    encoded = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    sys.stdout.buffer.write(struct.pack("<I", len(encoded)))
+    sys.stdout.buffer.write(encoded)
+    sys.stdout.buffer.flush()
+
+
+def self_check_payload():
+    return {
+        "ok": True,
+        "hostName": HOST_NAME,
+        "hostVersion": HOST_VERSION,
+        "protocolVersion": HOST_PROTOCOL_VERSION,
+        "platform": sys.platform,
+        "pythonExecutable": sys.executable,
+        "swiftAvailable": bool(shutil.which("swift")),
+        "swiftScriptPath": ICLOUD_CREATE_SWIFT_SCRIPT,
+        "swiftScriptExists": os.path.isfile(ICLOUD_CREATE_SWIFT_SCRIPT),
+        "logPath": LOG_PATH,
+    }
+
+
+def handle_message(message):
+    if not isinstance(message, dict):
+        raise RuntimeError("Native host request must be a JSON object.")
+
+    request_id = str(message.get("requestId") or "")
+    protocol_version = int(message.get("protocolVersion") or 0)
+    if protocol_version != HOST_PROTOCOL_VERSION:
+        return build_response(
+            request_id,
+            False,
+            error=build_error(
+                "UNSUPPORTED_PROTOCOL",
+                f"宿主协议版本不匹配：当前仅支持 {HOST_PROTOCOL_VERSION}，收到 {protocol_version}。",
+                details={"expectedProtocolVersion": HOST_PROTOCOL_VERSION},
+            ),
+        )
+
+    command = str(message.get("type") or "").strip()
+    if command == COMMAND_PING:
+        return build_response(
+            request_id,
+            True,
+            result={
+                "capabilities": [COMMAND_PING, COMMAND_CREATE_ICLOUD_ALIAS],
+            },
+        )
+
+    if command == COMMAND_CREATE_ICLOUD_ALIAS:
+        payload = message.get("payload") if isinstance(message.get("payload"), dict) else {}
+        created = create_icloud_hide_my_email_alias(
+            label=payload.get("label"),
+            apple_id_password=payload.get("appleIdPassword"),
+        )
+        return build_response(request_id, True, result=created)
+
+    return build_response(
+        request_id,
+        False,
+        error=build_error("UNSUPPORTED_COMMAND", f"不支持的宿主命令：{command or '<empty>'}"),
+    )
+
+
+def run_self_check():
+    print(json.dumps(self_check_payload(), ensure_ascii=False, indent=2))
+
+
+def run_host_loop():
+    while True:
+        try:
+            message = read_native_message()
+            if message is None:
+                break
+            response = handle_message(message)
+        except Exception as exc:
+            append_log(f"native host request failed: {exc}\n{traceback.format_exc()}")
+            request_id = ""
+            if "message" in locals() and isinstance(message, dict):
+                request_id = str(message.get("requestId") or "")
+            response = build_response(request_id, False, error=classify_runtime_error(exc))
+        write_native_message(response)
+
+
+def main():
+    if len(sys.argv) > 1 and sys.argv[1] == "--self-check":
+        run_self_check()
+        return
+    run_host_loop()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/uninstall_native_messaging_host.py
+++ b/scripts/uninstall_native_messaging_host.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import sys
+
+
+HOST_NAME = "com.qlhazycoder.codex_oauth_automation_extension"
+TARGET_DIRECTORIES = {
+    "chrome": os.path.expanduser("~/Library/Application Support/Google/Chrome/NativeMessagingHosts"),
+    "chrome-beta": os.path.expanduser("~/Library/Application Support/Google/Chrome Beta/NativeMessagingHosts"),
+    "chrome-canary": os.path.expanduser("~/Library/Application Support/Google/Chrome Canary/NativeMessagingHosts"),
+    "chromium": os.path.expanduser("~/Library/Application Support/Chromium/NativeMessagingHosts"),
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Uninstall the Chrome Native Messaging host for codex-oauth-automation-extension.")
+    parser.add_argument(
+        "--target",
+        action="append",
+        choices=sorted(TARGET_DIRECTORIES),
+        help="Browser target to uninstall from. Defaults to chrome.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        help="Override manifest directory for testing.",
+    )
+    return parser.parse_args()
+
+
+def manifest_paths(args):
+    if args.output_dir:
+        return [os.path.join(os.path.abspath(args.output_dir), f"{HOST_NAME}.json")]
+    targets = args.target or ["chrome"]
+    return [os.path.join(TARGET_DIRECTORIES[target], f"{HOST_NAME}.json") for target in targets]
+
+
+def main():
+    args = parse_args()
+    removed = []
+    missing = []
+    for path in manifest_paths(args):
+        if os.path.exists(path):
+            os.remove(path)
+            removed.append(path)
+        else:
+            missing.append(path)
+
+    print(json.dumps({
+        "ok": True,
+        "removed": removed,
+        "missing": missing,
+    }, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -472,6 +472,22 @@
         </select>
       </div>
       <div class="data-row">
+        <span class="data-label">生成策略</span>
+        <select id="select-icloud-generation-strategy" class="data-select">
+          <option value="web">网页方案</option>
+          <option value="local-macos">本地 macOS System Settings</option>
+        </select>
+      </div>
+      <div class="data-row" id="row-icloud-apple-id-password" style="display:none;">
+        <span class="data-label">Apple ID 密码</span>
+        <div class="input-with-icon">
+          <input type="password" id="input-icloud-apple-id-password" class="data-input data-input-with-icon"
+            placeholder="本地方案可选；仅在弹出确认框时使用" />
+          <button id="btn-toggle-icloud-apple-id-password" class="input-icon-btn" type="button"
+            aria-label="显示 Apple ID 密码" title="显示 Apple ID 密码"></button>
+        </div>
+      </div>
+      <div class="data-row">
         <span class="data-label">自动删除</span>
         <label class="option-toggle" for="checkbox-auto-delete-icloud">
           <input type="checkbox" id="checkbox-auto-delete-icloud" />

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -30,7 +30,7 @@
     </div>
     <div class="header-btns">
       <div class="run-group">
-        <input type="number" id="input-run-count" class="run-count-input" value="1" min="1" max="50" title="运行次数" />
+        <input type="number" id="input-run-count" class="run-count-input" value="1" min="1" title="运行次数" />
         <button id="btn-auto-run" class="btn btn-success" title="自动执行全部步骤">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
             <polygon points="5 3 19 12 5 21 5 3" />

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -539,7 +539,7 @@
         <line x1="12" y1="8" x2="12" y2="12" />
         <line x1="12" y1="16" x2="12.01" y2="16" />
       </svg>
-      <span class="auto-hint">先自动获取邮箱，或手动粘贴邮箱后再继续</span>
+      <span id="auto-continue-hint" class="auto-hint">先自动获取邮箱，或手动粘贴邮箱后再继续</span>
       <button id="btn-auto-continue" class="btn btn-primary btn-sm">继续</button>
     </div>
     <div id="auto-schedule-bar" class="auto-schedule-bar" style="display:none;">

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -47,6 +47,7 @@ const stepsProgress = document.getElementById('steps-progress');
 const btnAutoRun = document.getElementById('btn-auto-run');
 const btnAutoContinue = document.getElementById('btn-auto-continue');
 const autoContinueBar = document.getElementById('auto-continue-bar');
+const autoContinueHint = document.getElementById('auto-continue-hint');
 const autoScheduleBar = document.getElementById('auto-schedule-bar');
 const autoScheduleTitle = document.getElementById('auto-schedule-title');
 const autoScheduleMeta = document.getElementById('auto-schedule-meta');
@@ -386,6 +387,7 @@ let currentAutoRun = {
   countdownAt: null,
   countdownTitle: '',
   countdownNote: '',
+  failureSummary: '',
 };
 let settingsDirty = false;
 let settingsSaveInFlight = false;
@@ -921,6 +923,11 @@ function syncAutoRunState(source = {}) {
     countdownAt: readAutoRunStateValue(source, ['autoRunCountdownAt', 'countdownAt'], currentAutoRun.countdownAt),
     countdownTitle: readAutoRunStateValue(source, ['autoRunCountdownTitle', 'countdownTitle'], currentAutoRun.countdownTitle),
     countdownNote: readAutoRunStateValue(source, ['autoRunCountdownNote', 'countdownNote'], currentAutoRun.countdownNote),
+    failureSummary: readAutoRunStateValue(
+      source,
+      ['autoRunFailureSummary', 'failureSummary'],
+      (source.autoRunPhase !== undefined || source.phase !== undefined) ? '' : currentAutoRun.failureSummary
+    ),
   };
 }
 
@@ -952,6 +959,27 @@ function getAutoRunLabel(payload = currentAutoRun) {
     return ` (${payload.currentRun}/${payload.totalRuns}${attemptLabel})`;
   }
   return attemptLabel ? ` (${attemptLabel.slice(3)})` : '';
+}
+
+function getAutoRunWaitingEmailHintText(payload = currentAutoRun) {
+  const summary = String(payload?.failureSummary || '').trim();
+  return summary
+    ? `最近失败：${summary}`
+    : '先自动获取邮箱，或手动粘贴邮箱后再继续';
+}
+
+function getAutoRunPausedStatusText(payload = currentAutoRun) {
+  const summary = String(payload?.failureSummary || '').trim();
+  return summary
+    ? `自动已暂停${getAutoRunLabel(payload)}，等待邮箱后继续：${summary}`
+    : `自动已暂停${getAutoRunLabel(payload)}，等待邮箱后继续`;
+}
+
+function updateAutoContinueHint(payload = currentAutoRun) {
+  if (!autoContinueHint) {
+    return;
+  }
+  autoContinueHint.textContent = getAutoRunWaitingEmailHintText(payload);
 }
 
 function normalizeAutoDelayMinutes(value) {
@@ -1609,6 +1637,7 @@ async function saveSettings(options = {}) {
 
 function applyAutoRunStatus(payload = currentAutoRun) {
   syncAutoRunState(payload);
+  updateAutoContinueHint(currentAutoRun);
   const runLabel = getAutoRunLabel(currentAutoRun);
   const locked = isAutoRunLockedPhase();
   const paused = isAutoRunPausedPhase();
@@ -2679,7 +2708,7 @@ function updateStatusDisplay(state) {
   }
 
   if (isAutoRunPausedPhase()) {
-    displayStatus.textContent = `自动已暂停${getAutoRunLabel()}，等待邮箱后继续`;
+    displayStatus.textContent = getAutoRunPausedStatusText();
     statusBar.classList.add('paused');
     return;
   }
@@ -4226,6 +4255,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         autoRunCountdownAt: message.payload.countdownAt ?? null,
         autoRunCountdownTitle: message.payload.countdownTitle ?? '',
         autoRunCountdownNote: message.payload.countdownNote ?? '',
+        autoRunFailureSummary: message.payload.failureSummary ?? '',
       });
       applyAutoRunStatus(message.payload);
       updateStatusDisplay(latestState);

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -1016,7 +1016,7 @@ function formatAutoStepDelayInputValue(value) {
 }
 
 function getRunCountValue() {
-  return Math.min(50, Math.max(1, parseInt(inputRunCount.value, 10) || 1));
+  return Math.max(1, parseInt(inputRunCount.value, 10) || 1);
 }
 
 function updateFallbackThreadIntervalInputState() {

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -106,7 +106,11 @@ const btnIcloudLoginDone = document.getElementById('btn-icloud-login-done');
 const btnIcloudRefresh = document.getElementById('btn-icloud-refresh');
 const btnIcloudDeleteUsed = document.getElementById('btn-icloud-delete-used');
 const selectIcloudHostPreference = document.getElementById('select-icloud-host-preference');
+const selectIcloudGenerationStrategy = document.getElementById('select-icloud-generation-strategy');
 const checkboxAutoDeleteIcloud = document.getElementById('checkbox-auto-delete-icloud');
+const rowIcloudAppleIdPassword = document.getElementById('row-icloud-apple-id-password');
+const inputIcloudAppleIdPassword = document.getElementById('input-icloud-apple-id-password');
+const btnToggleIcloudAppleIdPassword = document.getElementById('btn-toggle-icloud-apple-id-password');
 const inputIcloudSearch = document.getElementById('input-icloud-search');
 const selectIcloudFilter = document.getElementById('select-icloud-filter');
 const checkboxIcloudSelectAll = document.getElementById('checkbox-icloud-select-all');
@@ -216,6 +220,8 @@ const AUTO_RUN_FALLBACK_RISK_RECOMMENDED_THREAD_INTERVAL_MINUTES = 5;
 const HOTMAIL_SERVICE_MODE_REMOTE = 'remote';
 const HOTMAIL_SERVICE_MODE_LOCAL = 'local';
 const ICLOUD_PROVIDER = 'icloud';
+const ICLOUD_GENERATION_STRATEGY_WEB = 'web';
+const ICLOUD_GENERATION_STRATEGY_LOCAL_MACOS = 'local-macos';
 const GMAIL_PROVIDER = 'gmail';
 const LUCKMAIL_PROVIDER = 'luckmail-api';
 const DEFAULT_LUCKMAIL_BASE_URL = 'https://mails.luckyous.com';
@@ -1292,6 +1298,53 @@ function setCloudflareTempEmailDomainEditMode(editing, options = {}) {
   }
 }
 
+function normalizeIcloudGenerationStrategy(value = '') {
+  return String(value || '').trim().toLowerCase() === ICLOUD_GENERATION_STRATEGY_LOCAL_MACOS
+    ? ICLOUD_GENERATION_STRATEGY_LOCAL_MACOS
+    : ICLOUD_GENERATION_STRATEGY_WEB;
+}
+
+function getSelectedIcloudGenerationStrategy(state = latestState) {
+  if (arguments.length > 0 && state && Object.prototype.hasOwnProperty.call(state, 'icloudGenerationStrategy')) {
+    return normalizeIcloudGenerationStrategy(state.icloudGenerationStrategy);
+  }
+  const currentValue = selectIcloudGenerationStrategy?.value;
+  if (currentValue !== undefined && currentValue !== null && currentValue !== '') {
+    return normalizeIcloudGenerationStrategy(currentValue);
+  }
+  return normalizeIcloudGenerationStrategy(state?.icloudGenerationStrategy);
+}
+
+function setIcloudGenerationStrategy(value) {
+  if (!selectIcloudGenerationStrategy) {
+    return;
+  }
+  selectIcloudGenerationStrategy.value = normalizeIcloudGenerationStrategy(value);
+}
+
+function buildIcloudGenerationSettingsPayload() {
+  return {
+    icloudGenerationStrategy: getSelectedIcloudGenerationStrategy(),
+    icloudAppleIdPassword: inputIcloudAppleIdPassword?.value || '',
+  };
+}
+
+function updateIcloudGenerationSettingsUI() {
+  if (!rowIcloudAppleIdPassword) {
+    return;
+  }
+  const useLocalStrategy = getSelectedIcloudGenerationStrategy() === ICLOUD_GENERATION_STRATEGY_LOCAL_MACOS;
+  rowIcloudAppleIdPassword.style.display = useLocalStrategy ? '' : 'none';
+}
+
+function applyIcloudGenerationSettings(state = {}) {
+  setIcloudGenerationStrategy(state?.icloudGenerationStrategy);
+  if (inputIcloudAppleIdPassword) {
+    inputIcloudAppleIdPassword.value = state?.icloudAppleIdPassword || '';
+  }
+  updateIcloudGenerationSettingsUI();
+}
+
 function collectSettingsPayload() {
   const { domains, activeDomain } = getCloudflareDomainsFromState();
   const selectedCloudflareDomain = normalizeCloudflareDomainValue(
@@ -1317,6 +1370,7 @@ function collectSettingsPayload() {
     emailGenerator: selectEmailGenerator.value,
     autoDeleteUsedIcloudAlias: checkboxAutoDeleteIcloud?.checked,
     icloudHostPreference: selectIcloudHostPreference?.value || 'auto',
+    ...buildIcloudGenerationSettingsPayload(),
     accountRunHistoryTextEnabled: Boolean(inputAccountRunHistoryTextEnabled?.checked),
     accountRunHistoryHelperBaseUrl: normalizeAccountRunHistoryHelperBaseUrlValue(inputAccountRunHistoryHelperBaseUrl?.value),
     ...buildManagedAliasBaseEmailPayload(),
@@ -1708,6 +1762,7 @@ function applySettingsState(state) {
       ? 'icloud.com'
       : (String(state?.icloudHostPreference || '').trim().toLowerCase() === 'icloud.com.cn' ? 'icloud.com.cn' : 'auto');
   }
+  applyIcloudGenerationSettings(state);
   if (checkboxAutoDeleteIcloud) {
     checkboxAutoDeleteIcloud.checked = Boolean(state?.autoDeleteUsedIcloudAlias);
   }
@@ -1769,7 +1824,7 @@ async function restoreState() {
   try {
     const state = await chrome.runtime.sendMessage({ type: 'GET_STATE', source: 'sidepanel' });
     applySettingsState(state);
-    if (getSelectedEmailGenerator() === 'icloud' && icloudSection?.style.display !== 'none') {
+    if (shouldAutoRefreshIcloudAliases(state) && icloudSection?.style.display !== 'none') {
       refreshIcloudAliases({ silent: true }).catch(() => { });
     }
 
@@ -2271,6 +2326,26 @@ function updateMailLoginButtonState() {
   btnMailLogin.title = loginUrl ? `打开 ${config.label} 登录页` : '当前邮箱服务没有可跳转的登录页';
 }
 
+function shouldAutoRefreshIcloudAliases(state = latestState) {
+  const useIcloudProvider = isIcloudMailProvider(state?.mailProvider);
+  if (useIcloudProvider) {
+    return true;
+  }
+  const strategy = arguments.length > 0
+    ? getSelectedIcloudGenerationStrategy(state)
+    : getSelectedIcloudGenerationStrategy();
+  return getSelectedEmailGenerator() === 'icloud'
+    && strategy === ICLOUD_GENERATION_STRATEGY_WEB;
+}
+
+function handleIcloudAliasesChangedMessage() {
+  if (!shouldAutoRefreshIcloudAliases()) {
+    return false;
+  }
+  queueIcloudAliasRefresh();
+  return true;
+}
+
 function updateMailProviderUI() {
   const use2925 = selectMailProvider.value === '2925';
   const useGmail = selectMailProvider.value === GMAIL_PROVIDER;
@@ -2307,10 +2382,11 @@ function updateMailProviderUI() {
   if (icloudSection) {
     const showIcloudSection = (useEmailGenerator && useIcloud) || useIcloudProvider;
     icloudSection.style.display = showIcloudSection ? '' : 'none';
-    if (showIcloudSection) {
+    updateIcloudGenerationSettingsUI();
+    if (showIcloudSection && shouldAutoRefreshIcloudAliases()) {
       queueIcloudAliasRefresh();
     }
-    if (!showIcloudSection) {
+    if (!showIcloudSection || !shouldAutoRefreshIcloudAliases()) {
       hideIcloudLoginHelp();
     }
   }
@@ -2709,6 +2785,7 @@ async function fetchGeneratedEmail(options = {}) {
         generateNew: true,
         generator: selectEmailGenerator.value,
         mailProvider: selectMailProvider.value,
+        ...buildIcloudGenerationSettingsPayload(),
         ...buildManagedAliasBaseEmailPayload(),
       },
     });
@@ -2721,7 +2798,7 @@ async function fetchGeneratedEmail(options = {}) {
     }
 
     inputEmail.value = response.email;
-    if (getSelectedEmailGenerator() === 'icloud') {
+    if (getSelectedEmailGenerator() === 'icloud' && shouldAutoRefreshIcloudAliases()) {
       queueIcloudAliasRefresh();
     }
     showToast(`已${uiCopy.successVerb} ${uiCopy.label}：${response.email}`, 'success', 2500);
@@ -3055,6 +3132,13 @@ function syncVpsPasswordToggleLabel() {
   });
 }
 
+function syncIcloudAppleIdPasswordToggleLabel() {
+  syncToggleButtonLabel(btnToggleIcloudAppleIdPassword, inputIcloudAppleIdPassword, {
+    show: '显示 Apple ID 密码',
+    hide: '隐藏 Apple ID 密码',
+  });
+}
+
 async function maybeTakeoverAutoRun(actionLabel) {
   if (!isAutoRunPausedPhase()) {
     return true;
@@ -3191,6 +3275,11 @@ btnToggleVpsUrl.addEventListener('click', () => {
 btnToggleVpsPassword.addEventListener('click', () => {
   inputVpsPassword.type = inputVpsPassword.type === 'password' ? 'text' : 'password';
   syncVpsPasswordToggleLabel();
+});
+
+btnToggleIcloudAppleIdPassword?.addEventListener('click', () => {
+  inputIcloudAppleIdPassword.type = inputIcloudAppleIdPassword.type === 'password' ? 'text' : 'password';
+  syncIcloudAppleIdPasswordToggleLabel();
 });
 
 btnMailLogin?.addEventListener('click', async () => {
@@ -3526,6 +3615,14 @@ inputPassword.addEventListener('blur', () => {
   saveSettings({ silent: true }).catch(() => { });
 });
 
+inputIcloudAppleIdPassword?.addEventListener('input', () => {
+  markSettingsDirty(true);
+  scheduleSettingsAutoSave();
+});
+inputIcloudAppleIdPassword?.addEventListener('blur', () => {
+  saveSettings({ silent: true }).catch(() => { });
+});
+
 selectMailProvider.addEventListener('change', async () => {
   const previousProvider = latestState?.mailProvider || '';
   const previousMail2925Mode = latestState?.mail2925Mode;
@@ -3588,9 +3685,15 @@ selectEmailGenerator.addEventListener('change', () => {
 selectIcloudHostPreference?.addEventListener('change', () => {
   markSettingsDirty(true);
   saveSettings({ silent: true }).catch(() => { });
-  if (getSelectedEmailGenerator() === 'icloud') {
+  if (shouldAutoRefreshIcloudAliases()) {
     queueIcloudAliasRefresh();
   }
+});
+
+selectIcloudGenerationStrategy?.addEventListener('change', () => {
+  updateMailProviderUI();
+  markSettingsDirty(true);
+  saveSettings({ silent: true }).catch(() => { });
 });
 
 checkboxAutoDeleteIcloud?.addEventListener('change', () => {
@@ -4049,6 +4152,13 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
           ? 'icloud.com'
           : (hostPreference === 'icloud.com.cn' ? 'icloud.com.cn' : 'auto');
       }
+      if (message.payload.icloudGenerationStrategy !== undefined) {
+        setIcloudGenerationStrategy(message.payload.icloudGenerationStrategy);
+        updateIcloudGenerationSettingsUI();
+      }
+      if (message.payload.icloudAppleIdPassword !== undefined && inputIcloudAppleIdPassword) {
+        inputIcloudAppleIdPassword.value = message.payload.icloudAppleIdPassword || '';
+      }
       if (message.payload.autoRunSkipFailures !== undefined) {
         inputAutoSkipFailures.checked = Boolean(message.payload.autoRunSkipFailures);
         updateFallbackThreadIntervalInputState();
@@ -4101,7 +4211,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     }
 
     case 'ICLOUD_ALIASES_CHANGED': {
-      queueIcloudAliasRefresh();
+      handleIcloudAliasesChangedMessage();
       break;
     }
 
@@ -4184,6 +4294,7 @@ restoreState().then(() => {
   syncPasswordToggleLabel();
   syncVpsUrlToggleLabel();
   syncVpsPasswordToggleLabel();
+  syncIcloudAppleIdPasswordToggleLabel();
   updatePanelModeUI();
   updateButtonStates();
   updateStatusDisplay(latestState);

--- a/tests/auto-run-fresh-attempt-reset.test.js
+++ b/tests/auto-run-fresh-attempt-reset.test.js
@@ -91,6 +91,7 @@ let stopRequested = false;
 let runCalls = 0;
 let autoRunSessionId = 0;
 let autoRunSessionSeed = 1000;
+let secondRunStartState = null;
 
 const logs = [];
 const broadcasts = [];
@@ -116,6 +117,7 @@ let currentState = {
   cloudflareDomains: [],
   tabRegistry: {},
   sourceLastUrls: {},
+  retainedTabOwnership: {},
 };
 
 async function getState() {
@@ -124,6 +126,7 @@ async function getState() {
     stepStatuses: { ...(currentState.stepStatuses || {}) },
     tabRegistry: { ...(currentState.tabRegistry || {}) },
     sourceLastUrls: { ...(currentState.sourceLastUrls || {}) },
+    retainedTabOwnership: { ...(currentState.retainedTabOwnership || {}) },
   };
 }
 
@@ -140,6 +143,9 @@ async function setState(updates) {
     sourceLastUrls: updates.sourceLastUrls
       ? { ...updates.sourceLastUrls }
       : currentState.sourceLastUrls,
+    retainedTabOwnership: updates.retainedTabOwnership
+      ? { ...updates.retainedTabOwnership }
+      : currentState.retainedTabOwnership,
   };
 }
 
@@ -167,6 +173,7 @@ async function resetState() {
     cloudflareDomains: [...(prev.cloudflareDomains || [])],
     tabRegistry: { ...(prev.tabRegistry || {}) },
     sourceLastUrls: { ...(prev.sourceLastUrls || {}) },
+    retainedTabOwnership: { ...(prev.retainedTabOwnership || {}) },
   };
 }
 
@@ -217,11 +224,14 @@ async function runAutoSequenceFromStep() {
   runCalls += 1;
   const state = await getState();
 
-  if (
-    runCalls === 2
-    && (Object.keys(state.tabRegistry || {}).length || Object.keys(state.sourceLastUrls || {}).length)
-  ) {
-    throw new Error('fresh auto-run attempt reused stale runtime tab context');
+  if (runCalls === 2) {
+    secondRunStartState = state;
+    if (Object.keys(state.tabRegistry || {}).length || Object.keys(state.sourceLastUrls || {}).length) {
+      throw new Error('fresh auto-run attempt reused stale runtime tab context');
+    }
+    if (state.retainedTabOwnership?.['icloud-mail']?.tabId !== 77) {
+      throw new Error('fresh auto-run attempt lost retained icloud ownership');
+    }
   }
 
   currentState = {
@@ -240,9 +250,14 @@ async function runAutoSequenceFromStep() {
     },
     tabRegistry: {
       'signup-page': { tabId: 88, ready: true },
+      'icloud-mail': { tabId: 77, ready: true },
     },
     sourceLastUrls: {
       'signup-page': 'https://auth.openai.com/authorize',
+      'icloud-mail': 'https://www.icloud.com/mail/',
+    },
+    retainedTabOwnership: {
+      'icloud-mail': { tabId: 77, url: 'https://www.icloud.com/mail/' },
     },
   };
 }
@@ -310,6 +325,7 @@ return {
       autoRunCurrentRun: runtime.state.autoRunCurrentRun,
       autoRunTotalRuns: runtime.state.autoRunTotalRuns,
       autoRunAttemptRun: runtime.state.autoRunAttemptRun,
+      secondRunStartState,
       currentState,
       logs,
       broadcasts,
@@ -329,6 +345,15 @@ return {
   assert.strictEqual(snapshot.currentState.autoRunSessionId, 0, 'session id should be cleared after completion');
   assert.strictEqual(snapshot.currentState.gmailBaseEmail, 'demo@gmail.com', 'gmail base email should survive fresh-attempt reset');
   assert.strictEqual(snapshot.currentState.mail2925BaseEmail, 'demo@2925.com', '2925 base email should survive fresh-attempt reset');
+  assert.deepStrictEqual(snapshot.secondRunStartState.tabRegistry, {}, 'fresh retry should clear generic tab registry state before the second run');
+  assert.deepStrictEqual(snapshot.secondRunStartState.sourceLastUrls, {}, 'fresh retry should clear generic source URL state before the second run');
+  assert.deepStrictEqual(snapshot.secondRunStartState.retainedTabOwnership, {
+    'icloud-mail': { tabId: 77, url: 'https://www.icloud.com/mail/' },
+  }, 'fresh retry should retain owned iCloud tab ownership');
+  assert.deepStrictEqual(snapshot.currentState.tabRegistry['icloud-mail'], { tabId: 77, ready: true }, 'active iCloud owned tab should be mirrored back into the registry');
+  assert.deepStrictEqual(snapshot.currentState.retainedTabOwnership, {
+    'icloud-mail': { tabId: 77, url: 'https://www.icloud.com/mail/' },
+  }, 'retained iCloud ownership should persist after the run');
 
   console.log('auto-run fresh attempt reset tests passed');
 })().catch((error) => {

--- a/tests/auto-run-timer-session-guard.test.js
+++ b/tests/auto-run-timer-session-guard.test.js
@@ -61,6 +61,16 @@ const helperBundle = [
   extractFunction(helperSource, 'launchAutoRunTimerPlan'),
 ].join('\n');
 
+test('normalizeRunCount no longer caps values above 50', () => {
+  const api = new Function(`
+${extractFunction(helperSource, 'normalizeRunCount')}
+return { normalizeRunCount };
+`)();
+
+  assert.equal(api.normalizeRunCount(75), 75);
+  assert.equal(api.normalizeRunCount('120'), 120);
+});
+
 test('launchAutoRunTimerPlan ignores stale timer plans after stop invalidates the session', async () => {
   const api = new Function(`
 const AUTO_RUN_TIMER_KIND_SCHEDULED_START = 'scheduled_start';

--- a/tests/background-account-history-settings.test.js
+++ b/tests/background-account-history-settings.test.js
@@ -60,6 +60,8 @@ test('background account history settings are normalized independently from hotm
 const DEFAULT_HOTMAIL_LOCAL_BASE_URL = 'http://127.0.0.1:17373';
 const DEFAULT_ACCOUNT_RUN_HISTORY_HELPER_BASE_URL = DEFAULT_HOTMAIL_LOCAL_BASE_URL;
 const DEFAULT_HOTMAIL_REMOTE_BASE_URL = '';
+const ICLOUD_GENERATION_STRATEGY_WEB = 'web';
+const ICLOUD_GENERATION_STRATEGY_LOCAL_MACOS = 'local-macos';
 const DEFAULT_VERIFICATION_RESEND_COUNT = 4;
 const DEFAULT_SUB2API_PROXY_NAME = 'shadowrocket';
 const HOTMAIL_SERVICE_MODE_REMOTE = 'remote';
@@ -78,6 +80,7 @@ function normalizeAutoStepDelaySeconds(value) { return value == null || value ==
 function normalizeMailProvider(value) { return String(value || '').trim().toLowerCase() || '163'; }
 function normalizeMail2925Mode(value) { return String(value || '').trim().toLowerCase() === 'receive' ? 'receive' : 'provide'; }
 function normalizeEmailGenerator(value) { return String(value || '').trim().toLowerCase() || 'duck'; }
+function normalizeIcloudGenerationStrategy(value) { return String(value || '').trim().toLowerCase() === 'local-macos' ? 'local-macos' : 'web'; }
 function normalizeIcloudHost(value) { const normalized = String(value || '').trim().toLowerCase(); return normalized === 'icloud.com' || normalized === 'icloud.com.cn' ? normalized : ''; }
 function normalizeHotmailServiceMode(value) { return String(value || '').trim().toLowerCase() === 'remote' ? 'remote' : 'local'; }
 function normalizeHotmailRemoteBaseUrl(value) { return String(value || '').trim(); }

--- a/tests/background-generated-email-module.test.js
+++ b/tests/background-generated-email-module.test.js
@@ -15,3 +15,95 @@ test('generated email helper module exposes a factory', () => {
 
   assert.equal(typeof api?.createGeneratedEmailHelpers, 'function');
 });
+
+test('generated email helper module dispatches icloud generation by strategy', async () => {
+  const source = fs.readFileSync('background/generated-email-helpers.js', 'utf8');
+  const globalScope = {};
+  const api = new Function('self', `${source}; return self.MultiPageGeneratedEmailHelpers;`)(globalScope);
+  const calls = [];
+
+  const helpers = api.createGeneratedEmailHelpers({
+    addLog: async () => {},
+    buildGeneratedAliasEmail: () => 'alias@example.com',
+    buildCloudflareTempEmailHeaders: () => ({}),
+    CLOUDFLARE_TEMP_EMAIL_GENERATOR: 'cloudflare-temp-email',
+    DUCK_AUTOFILL_URL: 'https://duckduckgo.com/email/autofill',
+    fetch: async () => ({ text: async () => '{}' }),
+    fetchIcloudHideMyEmailLocal: async () => {
+      calls.push('local');
+      return 'local@icloud.com';
+    },
+    fetchIcloudHideMyEmailWeb: async () => {
+      calls.push('web');
+      return 'web@icloud.com';
+    },
+    getCloudflareTempEmailAddressFromResponse: () => '',
+    getCloudflareTempEmailConfig: () => ({ baseUrl: '', adminAuth: '', domain: '' }),
+    getState: async () => ({ mailProvider: '163', emailGenerator: 'icloud', icloudGenerationStrategy: 'web' }),
+    joinCloudflareTempEmailUrl: (baseUrl, path) => `${baseUrl}${path}`,
+    normalizeCloudflareDomain: (value) => String(value || '').trim().toLowerCase(),
+    normalizeCloudflareTempEmailAddress: (value) => String(value || '').trim().toLowerCase(),
+    normalizeEmailGenerator: (value) => String(value || '').trim().toLowerCase() || 'duck',
+    normalizeIcloudGenerationStrategy: (value) => String(value || '').trim().toLowerCase() === 'local-macos' ? 'local-macos' : 'web',
+    isGeneratedAliasProvider: () => false,
+    reuseOrCreateTab: async () => {},
+    sendToContentScript: async () => ({}),
+    setEmailState: async () => {},
+    throwIfStopped: () => {},
+  });
+
+  assert.equal(
+    await helpers.fetchGeneratedEmail(null, { generator: 'icloud', icloudGenerationStrategy: 'local-macos' }),
+    'local@icloud.com'
+  );
+  assert.deepEqual(calls, ['local']);
+
+  calls.length = 0;
+  assert.equal(
+    await helpers.fetchGeneratedEmail(null, { generator: 'icloud' }),
+    'web@icloud.com'
+  );
+  assert.deepEqual(calls, ['web']);
+});
+
+test('generated email helper module does not silently fall back from local icloud to web', async () => {
+  const source = fs.readFileSync('background/generated-email-helpers.js', 'utf8');
+  const globalScope = {};
+  const api = new Function('self', `${source}; return self.MultiPageGeneratedEmailHelpers;`)(globalScope);
+  let webCalls = 0;
+
+  const helpers = api.createGeneratedEmailHelpers({
+    addLog: async () => {},
+    buildGeneratedAliasEmail: () => 'alias@example.com',
+    buildCloudflareTempEmailHeaders: () => ({}),
+    CLOUDFLARE_TEMP_EMAIL_GENERATOR: 'cloudflare-temp-email',
+    DUCK_AUTOFILL_URL: 'https://duckduckgo.com/email/autofill',
+    fetch: async () => ({ text: async () => '{}' }),
+    fetchIcloudHideMyEmailLocal: async () => {
+      throw new Error('local helper unavailable');
+    },
+    fetchIcloudHideMyEmailWeb: async () => {
+      webCalls += 1;
+      return 'web@icloud.com';
+    },
+    getCloudflareTempEmailAddressFromResponse: () => '',
+    getCloudflareTempEmailConfig: () => ({ baseUrl: '', adminAuth: '', domain: '' }),
+    getState: async () => ({ mailProvider: '163', emailGenerator: 'icloud', icloudGenerationStrategy: 'local-macos' }),
+    joinCloudflareTempEmailUrl: (baseUrl, path) => `${baseUrl}${path}`,
+    normalizeCloudflareDomain: (value) => String(value || '').trim().toLowerCase(),
+    normalizeCloudflareTempEmailAddress: (value) => String(value || '').trim().toLowerCase(),
+    normalizeEmailGenerator: (value) => String(value || '').trim().toLowerCase() || 'duck',
+    normalizeIcloudGenerationStrategy: (value) => String(value || '').trim().toLowerCase() === 'local-macos' ? 'local-macos' : 'web',
+    isGeneratedAliasProvider: () => false,
+    reuseOrCreateTab: async () => {},
+    sendToContentScript: async () => ({}),
+    setEmailState: async () => {},
+    throwIfStopped: () => {},
+  });
+
+  await assert.rejects(
+    () => helpers.fetchGeneratedEmail(null, { generator: 'icloud', icloudGenerationStrategy: 'local-macos' }),
+    /local helper unavailable/
+  );
+  assert.equal(webCalls, 0);
+});

--- a/tests/background-icloud-local-helper.test.js
+++ b/tests/background-icloud-local-helper.test.js
@@ -53,42 +53,49 @@ function extractFunction(name) {
 
 function createHarness(overrides = {}) {
   const bundle = [
-    extractFunction('normalizeHotmailLocalBaseUrl'),
-    extractFunction('buildHotmailLocalEndpoint'),
     extractFunction('getRuntimePlatformOs'),
+    extractFunction('createIcloudNativeHostRequestId'),
+    extractFunction('getIcloudNativeHostClientVersion'),
+    extractFunction('sendNativeHostMessage'),
+    extractFunction('getIcloudNativeHostTransportErrorMessage'),
+    extractFunction('getIcloudNativeHostResponseErrorMessage'),
     extractFunction('getIcloudAliasLabel'),
     extractFunction('fetchIcloudHideMyEmailLocally'),
   ].join('\n');
 
   return new Function('overrides', `
-const DEFAULT_HOTMAIL_LOCAL_BASE_URL = 'http://127.0.0.1:17373';
-const ICLOUD_LOCAL_HELPER_TIMEOUT_MS = 120000;
+const ICLOUD_NATIVE_MESSAGING_HOST_NAME = 'com.qlhazycoder.codex_oauth_automation_extension';
+const ICLOUD_NATIVE_MESSAGING_PROTOCOL_VERSION = 1;
+const ICLOUD_LOCAL_HELPER_TIMEOUT_MS = overrides.timeoutMs || 20;
 const LOG_PREFIX = '[test]';
+globalThis.crypto = { randomUUID: () => 'test-request-id' };
 const calls = {
   logs: [],
   emailStates: [],
   broadcasts: [],
-  fetches: [],
+  nativeMessages: [],
 };
-const chrome = overrides.chrome || { runtime: { getPlatformInfo: async () => ({ os: 'mac' }) } };
-const fetch = async (url, options) => {
-  calls.fetches.push({ url, options });
-  if (typeof overrides.fetchImpl === 'function') {
-    return overrides.fetchImpl(url, options);
-  }
-  return {
-    ok: true,
-    status: 200,
-    text: async () => JSON.stringify({ ok: true, email: 'relay@icloud.com' }),
-  };
+const runtime = {
+  lastError: null,
+  getManifest: () => ({ version_name: 'Pro2.4', version: '2.4' }),
+  getPlatformInfo: async () => ({ os: 'mac' }),
+  sendNativeMessage: (hostName, payload, callback) => {
+    calls.nativeMessages.push({ hostName, payload });
+    if (typeof overrides.sendNativeMessageImpl === 'function') {
+      return overrides.sendNativeMessageImpl({ runtime, hostName, payload, callback, calls });
+    }
+    callback({
+      requestId: payload.requestId,
+      ok: true,
+      protocolVersion: 1,
+      hostVersion: 'Pro2.4',
+      result: { email: 'relay@icloud.com', createdAt: '2026-04-20T00:00:00.000Z' },
+    });
+  },
 };
-function getHotmailServiceSettings(state = {}) {
-  return {
-    localBaseUrl: normalizeHotmailLocalBaseUrl(state.hotmailLocalBaseUrl),
-  };
-}
+const chrome = overrides.chrome || { runtime };
 async function getState() {
-  return overrides.state || { hotmailLocalBaseUrl: DEFAULT_HOTMAIL_LOCAL_BASE_URL, icloudAppleIdPassword: '' };
+  return overrides.state || { icloudAppleIdPassword: '' };
 }
 async function addLog(message, level = 'info') {
   calls.logs.push({ message, level });
@@ -108,10 +115,15 @@ return {
 `)(overrides);
 }
 
-test('local icloud helper path creates alias on macOS and stores email', async () => {
+test('manifest declares nativeMessaging permission for native host bridge', () => {
+  const manifest = JSON.parse(fs.readFileSync('manifest.json', 'utf8'));
+  assert.ok(Array.isArray(manifest.permissions));
+  assert.ok(manifest.permissions.includes('nativeMessaging'));
+});
+
+test('local icloud generation uses Native Messaging host and stores email on success', async () => {
   const harness = createHarness({
     state: {
-      hotmailLocalBaseUrl: 'http://127.0.0.1:17373',
       icloudAppleIdPassword: 'saved-password',
     },
   });
@@ -120,16 +132,21 @@ test('local icloud helper path creates alias on macOS and stores email', async (
 
   assert.equal(email, 'relay@icloud.com');
   assert.deepEqual(harness.calls.emailStates, ['relay@icloud.com']);
-  assert.equal(harness.calls.fetches.length, 1);
-  assert.match(harness.calls.fetches[0].url, /\/icloud\/create-hide-my-email$/);
-  assert.deepEqual(harness.calls.broadcasts, [{ reason: 'created-local', email: 'relay@icloud.com' }]);
+  assert.equal(harness.calls.nativeMessages.length, 1);
+  assert.equal(harness.calls.nativeMessages[0].hostName, 'com.qlhazycoder.codex_oauth_automation_extension');
+  assert.equal(harness.calls.nativeMessages[0].payload.type, 'icloud.createHideMyEmail');
+  assert.deepEqual(harness.calls.broadcasts, [{ reason: 'created-local-native-host', email: 'relay@icloud.com' }]);
 });
 
-test('local icloud helper path rejects non-macOS environments', async () => {
+test('local icloud generation rejects non-macOS environments before calling the host', async () => {
   const harness = createHarness({
     chrome: {
       runtime: {
+        getManifest: () => ({ version_name: 'Pro2.4' }),
         getPlatformInfo: async () => ({ os: 'win' }),
+        sendNativeMessage: () => {
+          throw new Error('should not be called');
+        },
       },
     },
   });
@@ -138,36 +155,71 @@ test('local icloud helper path rejects non-macOS environments', async () => {
     () => harness.fetchIcloudHideMyEmailLocally(null, {}),
     /仅支持 macOS/
   );
-  assert.equal(harness.calls.fetches.length, 0);
+  assert.equal(harness.calls.nativeMessages.length, 0);
 });
 
-test('local icloud helper path surfaces helper connectivity errors', async () => {
+test('local icloud generation surfaces host-not-registered errors clearly', async () => {
   const harness = createHarness({
-    fetchImpl: async () => {
-      throw new Error('connect ECONNREFUSED 127.0.0.1:17373');
+    sendNativeMessageImpl: ({ runtime, callback }) => {
+      runtime.lastError = { message: 'Specified native messaging host not found.' };
+      callback(undefined);
+      runtime.lastError = null;
     },
   });
 
   await assert.rejects(
     () => harness.fetchIcloudHideMyEmailLocally(null, {}),
-    /无法连接本地 helper/
+    /未找到已注册的本地宿主/
   );
 });
 
-test('local icloud helper path surfaces clear password-missing errors', async () => {
+test('local icloud generation surfaces protocol mismatch clearly', async () => {
   const harness = createHarness({
-    fetchImpl: async () => ({
-      ok: false,
-      status: 500,
-      text: async () => JSON.stringify({
+    sendNativeMessageImpl: ({ payload, callback }) => {
+      callback({
+        requestId: payload.requestId,
+        ok: true,
+        protocolVersion: 99,
+        result: { email: 'relay@icloud.com' },
+      });
+    },
+  });
+
+  await assert.rejects(
+    () => harness.fetchIcloudHideMyEmailLocally(null, {}),
+    /协议不匹配/
+  );
+});
+
+test('local icloud generation surfaces password-missing errors clearly', async () => {
+  const harness = createHarness({
+    sendNativeMessageImpl: ({ payload, callback }) => {
+      callback({
+        requestId: payload.requestId,
         ok: false,
-        error: '本地 iCloud 方案遇到 Apple ID 密码确认框，但未配置 Apple ID 密码。请在侧边栏填写后重试。',
-      }),
-    }),
+        protocolVersion: 1,
+        error: {
+          code: 'APPLE_ID_PASSWORD_NOT_CONFIGURED',
+          message: '本地 iCloud 方案遇到 Apple ID 密码确认框，但未配置 Apple ID 密码。请在侧边栏填写后重试。',
+        },
+      });
+    },
   });
 
   await assert.rejects(
     () => harness.fetchIcloudHideMyEmailLocally(null, {}),
     /未配置 Apple ID 密码/
+  );
+});
+
+test('local icloud generation enforces a host timeout', async () => {
+  const harness = createHarness({
+    timeoutMs: 5,
+    sendNativeMessageImpl: () => {},
+  });
+
+  await assert.rejects(
+    () => harness.fetchIcloudHideMyEmailLocally(null, {}),
+    /本地宿主响应超时/
   );
 });

--- a/tests/background-icloud-local-helper.test.js
+++ b/tests/background-icloud-local-helper.test.js
@@ -1,0 +1,173 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const source = fs.readFileSync('background.js', 'utf8');
+
+function extractFunction(name) {
+  const markers = [`async function ${name}(`, `function ${name}(`];
+  const start = markers
+    .map((marker) => source.indexOf(marker))
+    .find((index) => index >= 0);
+  if (start < 0) {
+    throw new Error(`missing function ${name}`);
+  }
+
+  let parenDepth = 0;
+  let signatureEnded = false;
+  let braceStart = -1;
+  for (let i = start; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === '(') {
+      parenDepth += 1;
+    } else if (ch === ')') {
+      parenDepth -= 1;
+      if (parenDepth === 0) {
+        signatureEnded = true;
+      }
+    } else if (ch === '{' && signatureEnded) {
+      braceStart = i;
+      break;
+    }
+  }
+  if (braceStart < 0) {
+    throw new Error(`missing body for function ${name}`);
+  }
+
+  let depth = 0;
+  let end = braceStart;
+  for (; end < source.length; end += 1) {
+    const ch = source[end];
+    if (ch === '{') depth += 1;
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        end += 1;
+        break;
+      }
+    }
+  }
+
+  return source.slice(start, end);
+}
+
+function createHarness(overrides = {}) {
+  const bundle = [
+    extractFunction('normalizeHotmailLocalBaseUrl'),
+    extractFunction('buildHotmailLocalEndpoint'),
+    extractFunction('getRuntimePlatformOs'),
+    extractFunction('getIcloudAliasLabel'),
+    extractFunction('fetchIcloudHideMyEmailLocally'),
+  ].join('\n');
+
+  return new Function('overrides', `
+const DEFAULT_HOTMAIL_LOCAL_BASE_URL = 'http://127.0.0.1:17373';
+const ICLOUD_LOCAL_HELPER_TIMEOUT_MS = 120000;
+const LOG_PREFIX = '[test]';
+const calls = {
+  logs: [],
+  emailStates: [],
+  broadcasts: [],
+  fetches: [],
+};
+const chrome = overrides.chrome || { runtime: { getPlatformInfo: async () => ({ os: 'mac' }) } };
+const fetch = async (url, options) => {
+  calls.fetches.push({ url, options });
+  if (typeof overrides.fetchImpl === 'function') {
+    return overrides.fetchImpl(url, options);
+  }
+  return {
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify({ ok: true, email: 'relay@icloud.com' }),
+  };
+};
+function getHotmailServiceSettings(state = {}) {
+  return {
+    localBaseUrl: normalizeHotmailLocalBaseUrl(state.hotmailLocalBaseUrl),
+  };
+}
+async function getState() {
+  return overrides.state || { hotmailLocalBaseUrl: DEFAULT_HOTMAIL_LOCAL_BASE_URL, icloudAppleIdPassword: '' };
+}
+async function addLog(message, level = 'info') {
+  calls.logs.push({ message, level });
+}
+async function setEmailState(email) {
+  calls.emailStates.push(email);
+}
+function broadcastIcloudAliasesChanged(payload) {
+  calls.broadcasts.push(payload);
+}
+function throwIfStopped() {}
+${bundle}
+return {
+  calls,
+  fetchIcloudHideMyEmailLocally,
+};
+`)(overrides);
+}
+
+test('local icloud helper path creates alias on macOS and stores email', async () => {
+  const harness = createHarness({
+    state: {
+      hotmailLocalBaseUrl: 'http://127.0.0.1:17373',
+      icloudAppleIdPassword: 'saved-password',
+    },
+  });
+
+  const email = await harness.fetchIcloudHideMyEmailLocally(null, {});
+
+  assert.equal(email, 'relay@icloud.com');
+  assert.deepEqual(harness.calls.emailStates, ['relay@icloud.com']);
+  assert.equal(harness.calls.fetches.length, 1);
+  assert.match(harness.calls.fetches[0].url, /\/icloud\/create-hide-my-email$/);
+  assert.deepEqual(harness.calls.broadcasts, [{ reason: 'created-local', email: 'relay@icloud.com' }]);
+});
+
+test('local icloud helper path rejects non-macOS environments', async () => {
+  const harness = createHarness({
+    chrome: {
+      runtime: {
+        getPlatformInfo: async () => ({ os: 'win' }),
+      },
+    },
+  });
+
+  await assert.rejects(
+    () => harness.fetchIcloudHideMyEmailLocally(null, {}),
+    /仅支持 macOS/
+  );
+  assert.equal(harness.calls.fetches.length, 0);
+});
+
+test('local icloud helper path surfaces helper connectivity errors', async () => {
+  const harness = createHarness({
+    fetchImpl: async () => {
+      throw new Error('connect ECONNREFUSED 127.0.0.1:17373');
+    },
+  });
+
+  await assert.rejects(
+    () => harness.fetchIcloudHideMyEmailLocally(null, {}),
+    /无法连接本地 helper/
+  );
+});
+
+test('local icloud helper path surfaces clear password-missing errors', async () => {
+  const harness = createHarness({
+    fetchImpl: async () => ({
+      ok: false,
+      status: 500,
+      text: async () => JSON.stringify({
+        ok: false,
+        error: '本地 iCloud 方案遇到 Apple ID 密码确认框，但未配置 Apple ID 密码。请在侧边栏填写后重试。',
+      }),
+    }),
+  });
+
+  await assert.rejects(
+    () => harness.fetchIcloudHideMyEmailLocally(null, {}),
+    /未配置 Apple ID 密码/
+  );
+});

--- a/tests/background-icloud-mail-provider.test.js
+++ b/tests/background-icloud-mail-provider.test.js
@@ -99,6 +99,7 @@ return { getMailConfig };
     mailProvider: 'icloud',
     icloudHostPreference: 'icloud.com.cn',
   }), {
+    provider: 'icloud',
     source: 'icloud-mail',
     url: 'https://www.icloud.com.cn/mail/',
     label: 'iCloud 邮箱',
@@ -137,6 +138,7 @@ return { getMailConfig };
     icloudHostPreference: 'auto',
     preferredIcloudHost: 'icloud.com.cn',
   }), {
+    provider: 'icloud',
     source: 'icloud-mail',
     url: 'https://www.icloud.com.cn/mail/',
     label: 'iCloud 邮箱',

--- a/tests/background-icloud.test.js
+++ b/tests/background-icloud.test.js
@@ -53,6 +53,7 @@ function extractFunction(name) {
 
 const bundle = [
   extractFunction('normalizeEmailGenerator'),
+  extractFunction('normalizeIcloudGenerationStrategy'),
   extractFunction('getEmailGeneratorLabel'),
   extractFunction('normalizeVerificationResendCount'),
   extractFunction('normalizePersistentSettingValue'),
@@ -67,6 +68,8 @@ const CLOUDFLARE_TEMP_EMAIL_GENERATOR = 'cloudflare-temp-email';
 const DEFAULT_LOCAL_CPA_STEP9_MODE = 'submit';
 const DEFAULT_HOTMAIL_REMOTE_BASE_URL = '';
 const DEFAULT_HOTMAIL_LOCAL_BASE_URL = 'http://127.0.0.1:17373';
+const ICLOUD_GENERATION_STRATEGY_WEB = 'web';
+const ICLOUD_GENERATION_STRATEGY_LOCAL_MACOS = 'local-macos';
 const DEFAULT_VERIFICATION_RESEND_COUNT = 4;
 const VERIFICATION_RESEND_COUNT_MIN = 0;
 const VERIFICATION_RESEND_COUNT_MAX = 20;
@@ -158,9 +161,10 @@ function getErrorMessage(error) {
 
 ${bundle}
 
-return {
+  return {
   calls,
   normalizeEmailGenerator,
+  normalizeIcloudGenerationStrategy,
   getEmailGeneratorLabel,
   normalizePersistentSettingValue,
   finalizeIcloudAliasAfterSuccessfulFlow,
@@ -171,6 +175,8 @@ return {
 test('normalizeEmailGenerator and label support icloud', () => {
   const api = createApi();
   assert.equal(api.normalizeEmailGenerator('icloud'), 'icloud');
+  assert.equal(api.normalizeIcloudGenerationStrategy('local-macos'), 'local-macos');
+  assert.equal(api.normalizeIcloudGenerationStrategy('bad-value'), 'web');
   assert.equal(api.getEmailGeneratorLabel('icloud'), 'iCloud 隐私邮箱');
 });
 
@@ -178,6 +184,9 @@ test('normalizePersistentSettingValue handles icloud settings', () => {
   const api = createApi();
   assert.equal(api.normalizePersistentSettingValue('icloudHostPreference', 'icloud.com'), 'icloud.com');
   assert.equal(api.normalizePersistentSettingValue('icloudHostPreference', 'bad-host'), 'auto');
+  assert.equal(api.normalizePersistentSettingValue('icloudGenerationStrategy', 'local-macos'), 'local-macos');
+  assert.equal(api.normalizePersistentSettingValue('icloudGenerationStrategy', 'legacy'), 'web');
+  assert.equal(api.normalizePersistentSettingValue('icloudAppleIdPassword', ' secret '), ' secret ');
   assert.equal(api.normalizePersistentSettingValue('autoDeleteUsedIcloudAlias', 1), true);
   assert.equal(api.normalizePersistentSettingValue('verificationResendCount', '6'), 6);
   assert.equal(api.normalizePersistentSettingValue('verificationResendCount', 99), 20);

--- a/tests/background-step4-icloud-strategy.test.js
+++ b/tests/background-step4-icloud-strategy.test.js
@@ -1,0 +1,100 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const source = fs.readFileSync('background/steps/fetch-signup-code.js', 'utf8');
+const globalScope = {};
+const api = new Function('self', `${source}; return self.MultiPageBackgroundStep4;`)(globalScope);
+
+test('step 4 uses poll-first behavior for iCloud mailboxes', async () => {
+  let capturedOptions = null;
+  const realDateNow = Date.now;
+  Date.now = () => 123456;
+
+  const executor = api.createStep4Executor({
+    addLog: async () => {},
+    chrome: {
+      tabs: {
+        update: async () => {},
+      },
+    },
+    completeStepFromBackground: async () => {},
+    confirmCustomVerificationStepBypass: async () => {},
+    getMailConfig: () => ({
+      provider: 'icloud',
+      label: 'iCloud 邮箱',
+      source: 'icloud-mail',
+      url: 'https://www.icloud.com/mail/',
+      navigateOnReuse: true,
+    }),
+    getTabId: async (sourceName) => (sourceName === 'signup-page' ? 1 : 2),
+    HOTMAIL_PROVIDER: 'hotmail-api',
+    ICLOUD_PROVIDER: 'icloud',
+    isTabAlive: async () => true,
+    LUCKMAIL_PROVIDER: 'luckmail-api',
+    CLOUDFLARE_TEMP_EMAIL_PROVIDER: 'cloudflare-temp-email',
+    resolveVerificationStep: async (_step, _state, _mail, options) => {
+      capturedOptions = options;
+    },
+    reuseOrCreateTab: async () => {},
+    sendToContentScriptResilient: async () => ({}),
+    shouldUseCustomRegistrationEmail: () => false,
+    STANDARD_MAIL_VERIFICATION_RESEND_INTERVAL_MS: 25000,
+    throwIfStopped: () => {},
+  });
+
+  try {
+    await executor.executeStep4({
+      email: 'user@example.com',
+      password: 'secret',
+    });
+  } finally {
+    Date.now = realDateNow;
+  }
+
+  assert.equal(capturedOptions.requestFreshCodeFirst, false);
+  assert.equal(capturedOptions.filterAfterTimestamp, 123456);
+  assert.equal(capturedOptions.resendIntervalMs, 25000);
+});
+
+test('step 4 keeps resend-first behavior for generic webmail providers', async () => {
+  let capturedOptions = null;
+
+  const executor = api.createStep4Executor({
+    addLog: async () => {},
+    chrome: {
+      tabs: {
+        update: async () => {},
+      },
+    },
+    completeStepFromBackground: async () => {},
+    confirmCustomVerificationStepBypass: async () => {},
+    getMailConfig: () => ({
+      provider: 'qq',
+      label: 'QQ 邮箱',
+      source: 'qq-mail',
+      url: 'https://wx.mail.qq.com/',
+    }),
+    getTabId: async (sourceName) => (sourceName === 'signup-page' ? 1 : 2),
+    HOTMAIL_PROVIDER: 'hotmail-api',
+    ICLOUD_PROVIDER: 'icloud',
+    isTabAlive: async () => true,
+    LUCKMAIL_PROVIDER: 'luckmail-api',
+    CLOUDFLARE_TEMP_EMAIL_PROVIDER: 'cloudflare-temp-email',
+    resolveVerificationStep: async (_step, _state, _mail, options) => {
+      capturedOptions = options;
+    },
+    reuseOrCreateTab: async () => {},
+    sendToContentScriptResilient: async () => ({}),
+    shouldUseCustomRegistrationEmail: () => false,
+    STANDARD_MAIL_VERIFICATION_RESEND_INTERVAL_MS: 25000,
+    throwIfStopped: () => {},
+  });
+
+  await executor.executeStep4({
+    email: 'user@example.com',
+    password: 'secret',
+  });
+
+  assert.equal(capturedOptions.requestFreshCodeFirst, true);
+});

--- a/tests/background-tab-runtime-module.test.js
+++ b/tests/background-tab-runtime-module.test.js
@@ -2,30 +2,181 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 
+const source = fs.readFileSync('background/tab-runtime.js', 'utf8');
+const globalScope = {};
+const api = new Function('self', `${source}; return self.MultiPageBackgroundTabRuntime;`)(globalScope);
+
+function cloneState(state) {
+  return {
+    ...state,
+    tabRegistry: { ...(state.tabRegistry || {}) },
+    sourceLastUrls: { ...(state.sourceLastUrls || {}) },
+    retainedTabOwnership: { ...(state.retainedTabOwnership || {}) },
+  };
+}
+
+function createHarness(options = {}) {
+  const initialState = options.state || {};
+  let currentState = cloneState({
+    tabRegistry: {},
+    sourceLastUrls: {},
+    retainedTabOwnership: {},
+    ...initialState,
+  });
+
+  const logs = [];
+  const createCalls = [];
+  const updateCalls = [];
+  const reloadCalls = [];
+  const removedTabIds = [];
+  const tabs = new Map();
+  const updateListeners = new Set();
+
+  const initialTabs = Array.isArray(options.tabs) ? options.tabs : [];
+  let nextTabId = 1;
+  for (const tab of initialTabs) {
+    const normalized = {
+      id: tab.id,
+      url: tab.url || 'https://example.com',
+      status: tab.status || 'complete',
+      active: Boolean(tab.active),
+    };
+    tabs.set(normalized.id, normalized);
+    nextTabId = Math.max(nextTabId, normalized.id + 1);
+  }
+
+  function emitTabComplete(tabId) {
+    setTimeout(() => {
+      for (const listener of updateListeners) {
+        listener(tabId, { status: 'complete' });
+      }
+    }, 0);
+  }
+
+  const runtime = api.createTabRuntime({
+    LOG_PREFIX: '[test]',
+    addLog: async (message, level = 'info') => {
+      logs.push({ message, level });
+    },
+    chrome: {
+      tabs: {
+        get: async (tabId) => {
+          const tab = tabs.get(tabId);
+          if (!tab) {
+            throw new Error(`No tab ${tabId}`);
+          }
+          return { ...tab };
+        },
+        query: async () => Array.from(tabs.values()).map((tab) => ({ ...tab })),
+        create: async ({ url, active }) => {
+          const tab = {
+            id: nextTabId,
+            url,
+            status: 'complete',
+            active: Boolean(active),
+          };
+          nextTabId += 1;
+          tabs.set(tab.id, tab);
+          createCalls.push({ url, active: Boolean(active), tabId: tab.id });
+          return { ...tab };
+        },
+        remove: async (tabIds) => {
+          for (const tabId of Array.isArray(tabIds) ? tabIds : [tabIds]) {
+            removedTabIds.push(tabId);
+            tabs.delete(tabId);
+          }
+        },
+        update: async (tabId, updates = {}) => {
+          const existing = tabs.get(tabId);
+          if (!existing) {
+            throw new Error(`No tab ${tabId}`);
+          }
+          const next = { ...existing, ...updates };
+          if (Object.prototype.hasOwnProperty.call(updates, 'url')) {
+            next.status = 'complete';
+            emitTabComplete(tabId);
+          }
+          tabs.set(tabId, next);
+          updateCalls.push({ tabId, updates: { ...updates } });
+          return { ...next };
+        },
+        reload: async (tabId) => {
+          const existing = tabs.get(tabId);
+          if (!existing) {
+            throw new Error(`No tab ${tabId}`);
+          }
+          tabs.set(tabId, { ...existing, status: 'complete' });
+          reloadCalls.push(tabId);
+          emitTabComplete(tabId);
+        },
+        sendMessage: async () => ({ ok: true }),
+        onUpdated: {
+          addListener(listener) {
+            updateListeners.add(listener);
+          },
+          removeListener(listener) {
+            updateListeners.delete(listener);
+          },
+        },
+      },
+      scripting: {
+        executeScript: async () => {},
+      },
+    },
+    getSourceLabel: (sourceName) => sourceName || 'unknown',
+    getState: async () => cloneState(currentState),
+    isLocalhostOAuthCallbackUrl: () => false,
+    isRetryableContentScriptTransportError: () => false,
+    matchesSourceUrlFamily: (sourceName, candidateUrl, referenceUrl) => {
+      if (sourceName !== 'icloud-mail') return false;
+      return new URL(candidateUrl).hostname === new URL(referenceUrl).hostname;
+    },
+    setState: async (updates = {}) => {
+      currentState = cloneState({
+        ...currentState,
+        ...updates,
+        tabRegistry: Object.prototype.hasOwnProperty.call(updates, 'tabRegistry')
+          ? updates.tabRegistry
+          : currentState.tabRegistry,
+        sourceLastUrls: Object.prototype.hasOwnProperty.call(updates, 'sourceLastUrls')
+          ? updates.sourceLastUrls
+          : currentState.sourceLastUrls,
+        retainedTabOwnership: Object.prototype.hasOwnProperty.call(updates, 'retainedTabOwnership')
+          ? updates.retainedTabOwnership
+          : currentState.retainedTabOwnership,
+      });
+    },
+    sleepWithStop: async () => {},
+    STOP_ERROR_MESSAGE: 'Flow stopped.',
+    throwIfStopped: () => {},
+  });
+
+  return {
+    runtime,
+    logs,
+    createCalls,
+    updateCalls,
+    reloadCalls,
+    removedTabIds,
+    tabs,
+    snapshot: () => cloneState(currentState),
+  };
+}
+
 test('background imports tab runtime module', () => {
-  const source = fs.readFileSync('background.js', 'utf8');
-  assert.match(source, /background\/tab-runtime\.js/);
+  const backgroundSource = fs.readFileSync('background.js', 'utf8');
+  assert.match(backgroundSource, /background\/tab-runtime\.js/);
 });
 
 test('tab runtime module exposes a factory', () => {
-  const source = fs.readFileSync('background/tab-runtime.js', 'utf8');
-  const globalScope = {};
-
-  const api = new Function('self', `${source}; return self.MultiPageBackgroundTabRuntime;`)(globalScope);
-
   assert.equal(typeof api?.createTabRuntime, 'function');
 });
 
 test('tab runtime waitForTabComplete waits until tab status becomes complete', async () => {
-  const source = fs.readFileSync('background/tab-runtime.js', 'utf8');
-  const globalScope = {};
-  const api = new Function('self', `${source}; return self.MultiPageBackgroundTabRuntime;`)(globalScope);
-
   let getCalls = 0;
   const runtime = api.createTabRuntime({
     LOG_PREFIX: '[test]',
     addLog: async () => {},
-    buildLocalhostCleanupPrefix: () => '',
     chrome: {
       tabs: {
         get: async () => {
@@ -39,14 +190,10 @@ test('tab runtime waitForTabComplete waits until tab status becomes complete', a
         query: async () => [],
       },
     },
-    getSourceLabel: (source) => source || 'unknown',
-    getState: async () => ({ tabRegistry: {}, sourceLastUrls: {} }),
+    getSourceLabel: (sourceName) => sourceName || 'unknown',
+    getState: async () => ({ tabRegistry: {}, sourceLastUrls: {}, retainedTabOwnership: {} }),
     matchesSourceUrlFamily: () => false,
-    normalizeLocalCpaStep9Mode: () => 'submit',
-    parseUrlSafely: () => null,
-    registerTab: async () => {},
     setState: async () => {},
-    shouldBypassStep9ForLocalCpa: () => false,
     throwIfStopped: () => {},
   });
 
@@ -60,10 +207,6 @@ test('tab runtime waitForTabComplete waits until tab status becomes complete', a
 });
 
 test('tab runtime waitForTabComplete aborts promptly when stop is requested', async () => {
-  const source = fs.readFileSync('background/tab-runtime.js', 'utf8');
-  const globalScope = {};
-  const api = new Function('self', `${source}; return self.MultiPageBackgroundTabRuntime;`)(globalScope);
-
   let throwCalls = 0;
   const runtime = api.createTabRuntime({
     LOG_PREFIX: '[test]',
@@ -79,7 +222,7 @@ test('tab runtime waitForTabComplete aborts promptly when stop is requested', as
       },
     },
     getSourceLabel: (sourceName) => sourceName || 'unknown',
-    getState: async () => ({ tabRegistry: {}, sourceLastUrls: {} }),
+    getState: async () => ({ tabRegistry: {}, sourceLastUrls: {}, retainedTabOwnership: {} }),
     matchesSourceUrlFamily: () => false,
     setState: async () => {},
     throwIfStopped: () => {
@@ -97,4 +240,152 @@ test('tab runtime waitForTabComplete aborts promptly when stop is requested', as
     }),
     /Flow stopped\./
   );
+});
+
+test('iCloud ownership-missing path creates a dedicated owned tab without adopting user tab', async () => {
+  const harness = createHarness({
+    tabs: [
+      { id: 9, url: 'https://www.icloud.com/mail/' },
+    ],
+  });
+
+  const tabId = await harness.runtime.reuseOrCreateTab('icloud-mail', 'https://www.icloud.com/mail/');
+  const snapshot = harness.snapshot();
+
+  assert.notEqual(tabId, 9, 'runtime must not adopt a user-opened iCloud tab');
+  assert.equal(harness.createCalls.length, 1, 'runtime should create exactly one automation-owned tab');
+  assert.deepEqual(harness.removedTabIds, [], 'runtime must not close the user-opened iCloud tab');
+  assert.ok(harness.tabs.has(9), 'user-opened iCloud tab should remain open');
+  assert.equal(snapshot.retainedTabOwnership['icloud-mail']?.tabId, tabId, 'owned tab should be retained outside generic registry state');
+  assert.deepEqual(snapshot.tabRegistry['icloud-mail'], { tabId, ready: true }, 'owned tab should be mirrored into active registry state');
+  assert.deepEqual(
+    harness.logs.map((entry) => entry.message),
+    [
+      'icloud-mail ownership-missing-create-new',
+      'icloud-mail create-owned-tab',
+      'icloud-mail mirror-owned-tab-into-registry',
+    ],
+  );
+});
+
+test('closeConflictingTabsForSource never closes iCloud tabs without ownership', async () => {
+  const harness = createHarness({
+    state: {
+      sourceLastUrls: {
+        'icloud-mail': 'https://www.icloud.com/mail/',
+      },
+    },
+    tabs: [
+      { id: 9, url: 'https://www.icloud.com/mail/' },
+    ],
+  });
+
+  await harness.runtime.closeConflictingTabsForSource('icloud-mail', 'https://www.icloud.com/mail/');
+
+  assert.deepEqual(harness.removedTabIds, []);
+  assert.ok(harness.tabs.has(9));
+});
+
+test('iCloud retained ownership survives registry reset and reuses the same owned tab', async () => {
+  const harness = createHarness({
+    state: {
+      retainedTabOwnership: {
+        'icloud-mail': { tabId: 21, url: 'https://www.icloud.com/mail/' },
+      },
+    },
+    tabs: [
+      { id: 21, url: 'https://www.icloud.com/mail/' },
+    ],
+  });
+
+  const tabId = await harness.runtime.reuseOrCreateTab('icloud-mail', 'https://www.icloud.com/mail/');
+  const snapshot = harness.snapshot();
+
+  assert.equal(tabId, 21, 'runtime should reuse the retained owned tab');
+  assert.equal(harness.createCalls.length, 0, 'reusing retained ownership must not create a new tab');
+  assert.deepEqual(snapshot.tabRegistry['icloud-mail'], { tabId: 21, ready: true }, 'retained owned tab should be mirrored back into registry');
+  assert.deepEqual(
+    harness.logs.map((entry) => entry.message),
+    [
+      'icloud-mail mirror-owned-tab-into-registry',
+      'icloud-mail reuse-owned-tab',
+    ],
+  );
+});
+
+test('iCloud retained ownership recovers by navigation instead of creating a second tab', async () => {
+  const harness = createHarness({
+    state: {
+      retainedTabOwnership: {
+        'icloud-mail': { tabId: 21, url: 'https://www.icloud.com/' },
+      },
+    },
+    tabs: [
+      { id: 21, url: 'https://www.icloud.com/' },
+    ],
+  });
+
+  const tabId = await harness.runtime.reuseOrCreateTab('icloud-mail', 'https://www.icloud.com/mail/');
+  const snapshot = harness.snapshot();
+
+  assert.equal(tabId, 21);
+  assert.equal(harness.createCalls.length, 0, 'navigation recovery should not create a replacement tab');
+  assert.deepEqual(harness.updateCalls, [
+    { tabId: 21, updates: { active: true } },
+    { tabId: 21, updates: { url: 'https://www.icloud.com/mail/', active: true } },
+  ]);
+  assert.equal(snapshot.retainedTabOwnership['icloud-mail']?.url, 'https://www.icloud.com/mail/');
+  assert.deepEqual(
+    harness.logs.map((entry) => entry.message),
+    [
+      'icloud-mail mirror-owned-tab-into-registry',
+      'icloud-mail recover-owned-tab-via-navigation',
+    ],
+  );
+});
+
+test('manually closed owned iCloud tab is replaced exactly once and then reused', async () => {
+  const harness = createHarness({
+    state: {
+      retainedTabOwnership: {
+        'icloud-mail': { tabId: 77, url: 'https://www.icloud.com/mail/' },
+      },
+    },
+  });
+
+  const replacementTabId = await harness.runtime.reuseOrCreateTab('icloud-mail', 'https://www.icloud.com/mail/');
+  const reusedReplacementTabId = await harness.runtime.reuseOrCreateTab('icloud-mail', 'https://www.icloud.com/mail/');
+
+  assert.equal(harness.createCalls.length, 1, 'manual close should produce exactly one replacement tab');
+  assert.equal(replacementTabId, reusedReplacementTabId, 'later runs should reuse the replacement tab');
+  assert.equal(harness.snapshot().retainedTabOwnership['icloud-mail']?.tabId, replacementTabId);
+  assert.deepEqual(
+    harness.logs.map((entry) => entry.message),
+    [
+      'icloud-mail create-owned-tab',
+      'icloud-mail mirror-owned-tab-into-registry',
+      'icloud-mail mirror-owned-tab-into-registry',
+      'icloud-mail reuse-owned-tab',
+    ],
+  );
+});
+
+test('runtime logs iCloud manual-inspection preservation only when an owned tab is still open', async () => {
+  const harness = createHarness({
+    state: {
+      retainedTabOwnership: {
+        'icloud-mail': { tabId: 42, url: 'https://www.icloud.com/mail/' },
+      },
+    },
+    tabs: [
+      { id: 42, url: 'https://www.icloud.com/mail/' },
+    ],
+  });
+
+  const preserved = await harness.runtime.logOwnedTabPreserved('icloud-mail');
+
+  assert.equal(preserved, true);
+  assert.deepEqual(harness.logs.map((entry) => entry.message), [
+    'icloud-mail preserve-for-manual-inspection',
+  ]);
 });

--- a/tests/native-host-install-scripts.test.js
+++ b/tests/native-host-install-scripts.test.js
@@ -1,0 +1,55 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const HOST_NAME = 'com.qlhazycoder.codex_oauth_automation_extension';
+const EXTENSION_ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+test('native messaging host self-check returns protocol and host metadata', () => {
+  const stdout = execFileSync('python3', ['scripts/native_messaging_host.py', '--self-check'], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+  const payload = JSON.parse(stdout);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.hostName, HOST_NAME);
+  assert.equal(payload.protocolVersion, 1);
+  assert.ok(typeof payload.swiftScriptPath === 'string' && payload.swiftScriptPath.length > 0);
+});
+
+test('native messaging host install/uninstall scripts manage manifest contents', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-native-host-'));
+  const manifestPath = path.join(tempDir, `${HOST_NAME}.json`);
+
+  execFileSync('python3', [
+    'scripts/install_native_messaging_host.py',
+    '--extension-id',
+    EXTENSION_ID,
+    '--output-dir',
+    tempDir,
+  ], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  assert.equal(manifest.name, HOST_NAME);
+  assert.equal(manifest.type, 'stdio');
+  assert.equal(manifest.protocol_version, 1);
+  assert.deepEqual(manifest.allowed_origins, [`chrome-extension://${EXTENSION_ID}/`]);
+  assert.match(manifest.path, /scripts\/native_messaging_host\.py$/);
+
+  execFileSync('python3', [
+    'scripts/uninstall_native_messaging_host.py',
+    '--output-dir',
+    tempDir,
+  ], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+
+  assert.equal(fs.existsSync(manifestPath), false);
+});

--- a/tests/sidepanel-auto-run-waiting-email.test.js
+++ b/tests/sidepanel-auto-run-waiting-email.test.js
@@ -1,0 +1,87 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const source = fs.readFileSync('sidepanel/sidepanel.js', 'utf8');
+
+function extractFunction(name) {
+  const markers = [`async function ${name}(`, `function ${name}(`];
+  const start = markers
+    .map((marker) => source.indexOf(marker))
+    .find((index) => index >= 0);
+  if (start < 0) {
+    throw new Error(`missing function ${name}`);
+  }
+
+  let parenDepth = 0;
+  let signatureEnded = false;
+  let braceStart = -1;
+  for (let i = start; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === '(') {
+      parenDepth += 1;
+    } else if (ch === ')') {
+      parenDepth -= 1;
+      if (parenDepth === 0) {
+        signatureEnded = true;
+      }
+    } else if (ch === '{' && signatureEnded) {
+      braceStart = i;
+      break;
+    }
+  }
+  if (braceStart < 0) {
+    throw new Error(`missing body for function ${name}`);
+  }
+
+  let depth = 0;
+  let end = braceStart;
+  for (; end < source.length; end += 1) {
+    const ch = source[end];
+    if (ch === '{') depth += 1;
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        end += 1;
+        break;
+      }
+    }
+  }
+
+  return source.slice(start, end);
+}
+
+test('sidepanel exposes waiting-email summary helpers for auto-run observability', () => {
+  const html = fs.readFileSync('sidepanel/sidepanel.html', 'utf8');
+  assert.match(html, /id="auto-continue-hint"/);
+
+  const bundle = [
+    extractFunction('getAutoRunLabel'),
+    extractFunction('getAutoRunWaitingEmailHintText'),
+    extractFunction('getAutoRunPausedStatusText'),
+  ].join('\n');
+
+  const api = new Function(`
+let currentAutoRun = {
+  phase: 'waiting_email',
+  currentRun: 2,
+  totalRuns: 5,
+  attemptRun: 3,
+  failureSummary: 'iCloud 本地生成失败：未找到已注册的本地宿主。',
+};
+${bundle}
+return {
+  getAutoRunPausedStatusText,
+  getAutoRunWaitingEmailHintText,
+};
+`)();
+
+  assert.equal(
+    api.getAutoRunWaitingEmailHintText(),
+    '最近失败：iCloud 本地生成失败：未找到已注册的本地宿主。'
+  );
+  assert.equal(
+    api.getAutoRunPausedStatusText(),
+    '自动已暂停 (2/5 · 尝试3)，等待邮箱后继续：iCloud 本地生成失败：未找到已注册的本地宿主。'
+  );
+});

--- a/tests/sidepanel-icloud-local-settings.test.js
+++ b/tests/sidepanel-icloud-local-settings.test.js
@@ -1,0 +1,128 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const source = fs.readFileSync('sidepanel/sidepanel.js', 'utf8');
+
+function extractFunction(name) {
+  const markers = [`async function ${name}(`, `function ${name}(`];
+  const start = markers
+    .map((marker) => source.indexOf(marker))
+    .find((index) => index >= 0);
+  if (start < 0) {
+    throw new Error(`missing function ${name}`);
+  }
+
+  let parenDepth = 0;
+  let signatureEnded = false;
+  let braceStart = -1;
+  for (let i = start; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === '(') {
+      parenDepth += 1;
+    } else if (ch === ')') {
+      parenDepth -= 1;
+      if (parenDepth === 0) {
+        signatureEnded = true;
+      }
+    } else if (ch === '{' && signatureEnded) {
+      braceStart = i;
+      break;
+    }
+  }
+  if (braceStart < 0) {
+    throw new Error(`missing body for function ${name}`);
+  }
+
+  let depth = 0;
+  let end = braceStart;
+  for (; end < source.length; end += 1) {
+    const ch = source[end];
+    if (ch === '{') depth += 1;
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        end += 1;
+        break;
+      }
+    }
+  }
+
+  return source.slice(start, end);
+}
+
+test('sidepanel html contains icloud local strategy controls', () => {
+  const html = fs.readFileSync('sidepanel/sidepanel.html', 'utf8');
+  assert.match(html, /id="select-icloud-generation-strategy"/);
+  assert.match(html, /id="row-icloud-apple-id-password"/);
+  assert.match(html, /id="input-icloud-apple-id-password"/);
+  assert.match(html, /id="btn-toggle-icloud-apple-id-password"/);
+});
+
+test('sidepanel icloud local strategy helpers collect and restore settings without forcing web refresh', () => {
+  const bundle = [
+    extractFunction('normalizeIcloudGenerationStrategy'),
+    extractFunction('getSelectedIcloudGenerationStrategy'),
+    extractFunction('setIcloudGenerationStrategy'),
+    extractFunction('buildIcloudGenerationSettingsPayload'),
+    extractFunction('updateIcloudGenerationSettingsUI'),
+    extractFunction('applyIcloudGenerationSettings'),
+    extractFunction('shouldAutoRefreshIcloudAliases'),
+    extractFunction('handleIcloudAliasesChangedMessage'),
+  ].join('\n');
+
+  const api = new Function(`
+const ICLOUD_PROVIDER = 'icloud';
+const ICLOUD_GENERATION_STRATEGY_WEB = 'web';
+const ICLOUD_GENERATION_STRATEGY_LOCAL_MACOS = 'local-macos';
+const latestState = { mailProvider: '163', icloudGenerationStrategy: 'web' };
+const selectIcloudGenerationStrategy = { value: 'web' };
+const rowIcloudAppleIdPassword = { style: { display: 'none' } };
+const inputIcloudAppleIdPassword = { value: '' };
+const selectEmailGenerator = { value: 'icloud' };
+let refreshCount = 0;
+function getSelectedEmailGenerator() {
+  return String(selectEmailGenerator.value || '').trim().toLowerCase();
+}
+function isIcloudMailProvider(provider = '') {
+  return String(provider || '').trim() === ICLOUD_PROVIDER;
+}
+function queueIcloudAliasRefresh() {
+  refreshCount += 1;
+}
+${bundle}
+return {
+  applyIcloudGenerationSettings,
+  buildIcloudGenerationSettingsPayload,
+  handleIcloudAliasesChangedMessage,
+  normalizeIcloudGenerationStrategy,
+  rowIcloudAppleIdPassword,
+  selectEmailGenerator,
+  selectIcloudGenerationStrategy,
+  inputIcloudAppleIdPassword,
+  refreshCount: () => refreshCount,
+  shouldAutoRefreshIcloudAliases,
+};
+`)();
+
+  api.applyIcloudGenerationSettings({
+    icloudGenerationStrategy: 'local-macos',
+    icloudAppleIdPassword: 'apple-secret',
+  });
+  assert.equal(api.selectIcloudGenerationStrategy.value, 'local-macos');
+  assert.equal(api.inputIcloudAppleIdPassword.value, 'apple-secret');
+  assert.equal(api.rowIcloudAppleIdPassword.style.display, '');
+  assert.deepEqual(api.buildIcloudGenerationSettingsPayload(), {
+    icloudGenerationStrategy: 'local-macos',
+    icloudAppleIdPassword: 'apple-secret',
+  });
+  assert.equal(api.shouldAutoRefreshIcloudAliases({ mailProvider: '163', icloudGenerationStrategy: 'local-macos' }), false);
+  assert.equal(api.shouldAutoRefreshIcloudAliases({ mailProvider: '163', icloudGenerationStrategy: 'web' }), true);
+  assert.equal(api.shouldAutoRefreshIcloudAliases({ mailProvider: 'icloud', icloudGenerationStrategy: 'local-macos' }), true);
+  assert.equal(api.handleIcloudAliasesChangedMessage(), false);
+  assert.equal(api.refreshCount(), 0);
+
+  api.selectIcloudGenerationStrategy.value = 'web';
+  assert.equal(api.handleIcloudAliasesChangedMessage(), true);
+  assert.equal(api.refreshCount(), 1);
+});

--- a/tests/sidepanel-run-count.test.js
+++ b/tests/sidepanel-run-count.test.js
@@ -1,0 +1,66 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const source = fs.readFileSync('sidepanel/sidepanel.js', 'utf8');
+
+function extractFunction(name) {
+  const markers = [`async function ${name}(`, `function ${name}(`];
+  const start = markers
+    .map((marker) => source.indexOf(marker))
+    .find((index) => index >= 0);
+  if (start < 0) {
+    throw new Error(`missing function ${name}`);
+  }
+
+  let parenDepth = 0;
+  let signatureEnded = false;
+  let braceStart = -1;
+  for (let i = start; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === '(') {
+      parenDepth += 1;
+    } else if (ch === ')') {
+      parenDepth -= 1;
+      if (parenDepth === 0) {
+        signatureEnded = true;
+      }
+    } else if (ch === '{' && signatureEnded) {
+      braceStart = i;
+      break;
+    }
+  }
+  if (braceStart < 0) {
+    throw new Error(`missing body for function ${name}`);
+  }
+
+  let depth = 0;
+  let end = braceStart;
+  for (; end < source.length; end += 1) {
+    const ch = source[end];
+    if (ch === '{') depth += 1;
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        end += 1;
+        break;
+      }
+    }
+  }
+
+  return source.slice(start, end);
+}
+
+test('sidepanel run count input preserves values above 50', () => {
+  const html = fs.readFileSync('sidepanel/sidepanel.html', 'utf8');
+  assert.doesNotMatch(html, /id="input-run-count"[^>]*max="50"/);
+
+  const bundle = extractFunction('getRunCountValue');
+  const api = new Function(`
+let inputRunCount = { value: '75' };
+${bundle}
+return { getRunCountValue };
+`)();
+
+  assert.equal(api.getRunCountValue(), 75);
+});

--- a/tests/step8-stop-cleanup.test.js
+++ b/tests/step8-stop-cleanup.test.js
@@ -54,6 +54,7 @@ function extractFunction(source, name) {
 const helperBundle = [
   extractFunction(helperSource, 'normalizeAutoRunSessionId'),
   extractFunction(helperSource, 'clearCurrentAutoRunSessionId'),
+  extractFunction(helperSource, 'preserveIcloudMailTabForManualInspection'),
   extractFunction(helperSource, 'throwIfStopped'),
   extractFunction(helperSource, 'cleanupStep8NavigationListeners'),
   extractFunction(helperSource, 'rejectPendingStep8'),
@@ -96,6 +97,11 @@ const removed = {
 const sentMessages = [];
 let clickCount = 0;
 let resolveTabId = null;
+const tabRuntime = {
+  async logOwnedTabPreserved() {
+    return false;
+  },
+};
 
 const chrome = {
   webNavigation: {

--- a/uninstall-native-host.command
+++ b/uninstall-native-host.command
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+TARGET="${1:-chrome}"
+
+if command -v python3 >/dev/null 2>&1; then
+  exec python3 scripts/uninstall_native_messaging_host.py --target "$TARGET"
+fi
+
+echo "Python 3 not found. Please install Python 3.10+ and try again."
+read -r -p "Press Enter to exit..."

--- a/项目完整链路说明.md
+++ b/项目完整链路说明.md
@@ -386,7 +386,7 @@
   - UI 文案输出
 
 - `background/generated-email-helpers.js`
-  在原有 Duck / Cloudflare / iCloud / Cloudflare Temp Email 生成链路之外，新增 Gmail / 2925 的共享生成接入。
+  在原有 Duck / Cloudflare / iCloud / Cloudflare Temp Email 生成链路之外，新增 Gmail / 2925 的共享生成接入；iCloud 生成入口现在会在“网页方案”和“本地 macOS System Settings 方案”之间做轻量分流。
 
 - `background/signup-flow-helpers.js`
   负责在真正提交注册邮箱前做“复用已有完整邮箱 / 重新生成”的最终决策。
@@ -419,7 +419,7 @@
 
 补充：
 
-- 本地 helper 除了收信与验证码读取，还提供邮箱记录 JSON 快照同步接口。
+- 本地 helper 除了收信与验证码读取，还提供 iCloud 本地 Hide My Email 生成与邮箱记录 JSON 快照同步接口。
 - 账号运行历史本地同步由独立配置控制，不再绑定 Hotmail 的本地助手模式。
 
 ### 7.3 LuckMail
@@ -435,6 +435,13 @@
 
 - [icloud-utils.js](c:/Users/projectf/Downloads/codex注册扩展/icloud-utils.js)
 - [content/icloud-mail.js](c:/Users/projectf/Downloads/codex注册扩展/content/icloud-mail.js)
+- [scripts/create_hide_my_email_ax.swift](c:/Users/projectf/Downloads/codex注册扩展/scripts/create_hide_my_email_ax.swift)
+
+说明：
+
+- 网页 iCloud 方案仍负责列表、复用、已用、保留与删除管理。
+- 本地 `local-macos` 方案只替换“生成并回填注册邮箱”这一步，通过本地 helper 调用 macOS System Settings 创建新的 Hide My Email 地址。
+- 本地方案成功后不会强制触发依赖网页会话的 iCloud 别名刷新；网页管理面仍可由用户手动刷新，或在切回网页策略/使用 iCloud 邮箱 provider 时继续沿用原逻辑。
 
 ## 8. 自动运行完整链路
 

--- a/项目完整链路说明.md
+++ b/项目完整链路说明.md
@@ -436,11 +436,14 @@
 - [icloud-utils.js](c:/Users/projectf/Downloads/codex注册扩展/icloud-utils.js)
 - [content/icloud-mail.js](c:/Users/projectf/Downloads/codex注册扩展/content/icloud-mail.js)
 - [scripts/create_hide_my_email_ax.swift](c:/Users/projectf/Downloads/codex注册扩展/scripts/create_hide_my_email_ax.swift)
+- [scripts/native_messaging_host.py](c:/Users/projectf/Downloads/codex注册扩展/scripts/native_messaging_host.py)
 
 说明：
 
 - 网页 iCloud 方案仍负责列表、复用、已用、保留与删除管理。
-- 本地 `local-macos` 方案只替换“生成并回填注册邮箱”这一步，通过本地 helper 调用 macOS System Settings 创建新的 Hide My Email 地址。
+- 本地 `local-macos` 方案只替换“生成并回填注册邮箱”这一步，通过 Chrome Native Messaging host 按需拉起 macOS System Settings 创建新的 Hide My Email 地址。
+- Native Messaging host 安装是一次性动作；安装完成后，浏览器调用本地生成时不需要用户手动常驻启动 helper。
+- `scripts/hotmail_helper.py` 仍保留给 Hotmail 本地收信与账号记录快照同步；iCloud 本地生成不再以 localhost helper 作为默认主路径。
 - 本地方案成功后不会强制触发依赖网页会话的 iCloud 别名刷新；网页管理面仍可由用户手动刷新，或在切回网页策略/使用 iCloud 邮箱 provider 时继续沿用原逻辑。
 
 ## 8. 自动运行完整链路

--- a/项目文件结构说明.md
+++ b/项目文件结构说明.md
@@ -31,8 +31,10 @@
 - `microsoft-email.js`：Microsoft Graph / Outlook 邮件读取辅助模块，负责刷新令牌换 token、邮箱夹轮询和验证码提取。
 - `package.json`：仓库最小 Node 包配置，目前主要提供测试脚本定义。
 - `rules.json`：静态 DNR 规则，主要处理 iCloud 相关请求头。
+- `install-native-host.command`：macOS 下安装 Chrome Native Messaging host 的便捷脚本，会转调 Python 安装器并绑定当前扩展 ID。
 - `start-hotmail-helper.bat`：Windows 下启动本地 helper 的脚本；当前既服务于 Hotmail 本地收信，也服务于邮箱记录快照同步。
 - `start-hotmail-helper.command`：macOS 下启动本地 helper 的脚本；当前既服务于 Hotmail 本地收信，也服务于邮箱记录快照同步。
+- `uninstall-native-host.command`：macOS 下卸载 Chrome Native Messaging host 的便捷脚本。
 - `开发者AI开发与PR提交流程.md`：仓库现有的 AI 开发与 PR 提交流程说明。
 - `项目文件结构说明.md`：当前文件，维护整个仓库非忽略文件的结构与职责索引。
 - `项目完整链路说明.md`：面向 AI/开发者的完整功能链路说明，用于快速理解系统整体运行过程。
@@ -106,7 +108,10 @@
 ## `scripts/`
 
 - `scripts/create_hide_my_email_ax.swift`：macOS System Settings 的 Hide My Email Accessibility 脚本，负责本地创建 iCloud 隐私邮箱，并在需要时自动处理 Apple ID 密码确认框。
-- `scripts/hotmail_helper.py`：本地 helper 服务，负责通过本地接口协助 Hotmail 获取邮件和验证码，同时承接 iCloud 本地 Hide My Email 生成与邮箱记录 JSON 快照同步接口；旧的文本追加接口仍保留作兼容。
+- `scripts/hotmail_helper.py`：本地 helper 服务，负责通过本地接口协助 Hotmail 获取邮件和验证码，同时承接账号记录 JSON 快照同步，并保留旧的 localhost iCloud 创建端点作短期兼容。
+- `scripts/install_native_messaging_host.py`：Chrome Native Messaging host 安装脚本，负责自检宿主、生成 manifest 并写入浏览器注册目录。
+- `scripts/native_messaging_host.py`：iCloud `local-macos` 默认使用的 Native Messaging host，按需处理扩展发来的宿主请求。
+- `scripts/uninstall_native_messaging_host.py`：Chrome Native Messaging host 卸载脚本，负责删除已安装的 manifest。
 
 ## `sidepanel/`
 
@@ -116,7 +121,7 @@
 - `sidepanel/account-records-manager.js`：侧边栏邮箱记录面板管理器，负责“记录”按钮、覆盖层开关、分页列表、成功/失败/停止统计摘要和清理确认。
 - `sidepanel/sidepanel.css`：侧边栏样式文件。
 - `sidepanel/sidepanel.html`：侧边栏页面结构；当前步骤列表已改为动态容器，日志区提供“记录”按钮并挂接邮箱记录覆盖层，同时新增共享“验证码重发”次数输入，并加载 `managed-alias-utils.js`，把旧的“邮箱前缀”字段语义改为“别名基邮箱”；iCloud 区域新增了网页 / 本地 macOS 生成策略与 Apple ID 密码配置入口。
-- `sidepanel/sidepanel.js`：侧边栏主入口脚本，负责 UI 状态同步、动态步骤渲染、按钮交互、独立本地同步配置、共享验证码自动重发次数配置与广播接收，并装配 Hotmail / iCloud / LuckMail / 邮箱记录面板 manager；同时把 Gmail / 2925 的基邮箱输入、完整注册邮箱输入、自动生成按钮与兼容性校验统一接到共享别名逻辑上，并接管 iCloud 本地生成策略/Apple ID 密码的保存、恢复与“本地成功后不强制刷新网页 iCloud 管理器”的 UI 边界。
+- `sidepanel/sidepanel.js`：侧边栏主入口脚本，负责 UI 状态同步、动态步骤渲染、按钮交互、独立本地同步配置、共享验证码自动重发次数配置与广播接收，并装配 Hotmail / iCloud / LuckMail / 邮箱记录面板 manager；同时把 Gmail / 2925 的基邮箱输入、完整注册邮箱输入、自动生成按钮与兼容性校验统一接到共享别名逻辑上，并接管 iCloud 本地生成策略/Apple ID 密码的保存、恢复、“本地成功后不强制刷新网页 iCloud 管理器”的 UI 边界，以及 `waiting_email` 阶段的最近失败原因摘要展示。
 - `sidepanel/update-service.js`：侧边栏更新检查服务，负责 GitHub Releases 查询与版本展示。
 
 ## `tests/`
@@ -132,7 +137,7 @@
 - `tests/background-account-run-history-module.test.js`：测试邮箱记录模块已接入、导出工厂，能够保留并归一化停止记录、归一化失败标签、计算自动重试次数，并支持清理后同步完整快照。
 - `tests/background-account-history-settings.test.js`：测试账号运行历史的独立配置项归一化，不再复用 Hotmail 模式作为启停条件。
 - `tests/background-generated-email-module.test.js`：测试生成邮箱辅助模块已接入且导出工厂，并覆盖 iCloud 网页 / 本地策略分流与“本地失败不回退网页”的约束。
-- `tests/background-icloud-local-helper.test.js`：测试 iCloud 本地 helper 调用的成功、非 macOS、helper 不可达与 Apple ID 密码缺失错误路径。
+- `tests/background-icloud-local-helper.test.js`：测试 iCloud `local-macos` 主路径通过 Native Messaging host 创建别名，并覆盖宿主缺失、协议不匹配、超时与 Apple ID 密码缺失错误路径。
 - `tests/background-icloud.test.js`：测试 iCloud 相关后台纯函数与别名收尾逻辑。
 - `tests/background-icloud-mail-provider.test.js`：测试 iCloud 邮箱 provider 配置解析。
 - `tests/background-logging-status-module.test.js`：测试日志 / 状态模块已接入且导出工厂。
@@ -161,8 +166,10 @@
 - `tests/luckmail-utils.test.js`：测试 LuckMail 工具层的购买记录、邮件、游标和验证码匹配逻辑。
 - `tests/managed-alias-utils.test.js`：覆盖 Gmail / 2925 共享别名工具的解析、生成、兼容性判断。
 - `tests/microsoft-email.test.js`：测试 Microsoft 邮件拉取与验证码提取逻辑。
+- `tests/native-host-install-scripts.test.js`：测试 Native Messaging host 的自检、manifest 安装与卸载脚本。
 - `tests/sidepanel-hotmail-manager.test.js`：测试侧边栏 Hotmail 管理器模块接线与空态渲染。
 - `tests/sidepanel-account-records-manager.test.js`：测试侧边栏邮箱记录覆盖层的 HTML 接入、helper 地址归一化与 manager 渲染逻辑。
+- `tests/sidepanel-auto-run-waiting-email.test.js`：测试 sidepanel 在 `waiting_email` 阶段展示最近一次自动获取失败原因摘要。
 - `tests/sidepanel-icloud-manager.test.js`：测试侧边栏 iCloud 管理器模块接线与空态渲染。
 - `tests/sidepanel-icloud-provider.test.js`：测试侧边栏 iCloud 登录地址解析逻辑。
 - `tests/sidepanel-icloud-local-settings.test.js`：测试侧边栏 iCloud 本地生成策略配置、Apple ID 密码恢复，以及本地策略下不强制网页 iCloud 别名刷新。

--- a/项目文件结构说明.md
+++ b/项目文件结构说明.md
@@ -105,7 +105,8 @@
 
 ## `scripts/`
 
-- `scripts/hotmail_helper.py`：本地 helper 服务，负责通过本地接口协助 Hotmail 获取邮件和验证码，并提供邮箱记录 JSON 快照同步接口；旧的文本追加接口仍保留作兼容。
+- `scripts/create_hide_my_email_ax.swift`：macOS System Settings 的 Hide My Email Accessibility 脚本，负责本地创建 iCloud 隐私邮箱，并在需要时自动处理 Apple ID 密码确认框。
+- `scripts/hotmail_helper.py`：本地 helper 服务，负责通过本地接口协助 Hotmail 获取邮件和验证码，同时承接 iCloud 本地 Hide My Email 生成与邮箱记录 JSON 快照同步接口；旧的文本追加接口仍保留作兼容。
 
 ## `sidepanel/`
 
@@ -114,8 +115,8 @@
 - `sidepanel/luckmail-manager.js`：侧边栏 LuckMail 管理器，负责邮箱列表、筛选、启停、保留与批量操作。
 - `sidepanel/account-records-manager.js`：侧边栏邮箱记录面板管理器，负责“记录”按钮、覆盖层开关、分页列表、成功/失败/停止统计摘要和清理确认。
 - `sidepanel/sidepanel.css`：侧边栏样式文件。
-- `sidepanel/sidepanel.html`：侧边栏页面结构；当前步骤列表已改为动态容器，日志区提供“记录”按钮并挂接邮箱记录覆盖层，同时新增共享“验证码重发”次数输入，并加载 `managed-alias-utils.js`，把旧的“邮箱前缀”字段语义改为“别名基邮箱”。
-- `sidepanel/sidepanel.js`：侧边栏主入口脚本，负责 UI 状态同步、动态步骤渲染、按钮交互、独立本地同步配置、共享验证码自动重发次数配置与广播接收，并装配 Hotmail / iCloud / LuckMail / 邮箱记录面板 manager；同时把 Gmail / 2925 的基邮箱输入、完整注册邮箱输入、自动生成按钮与兼容性校验统一接到共享别名逻辑上。
+- `sidepanel/sidepanel.html`：侧边栏页面结构；当前步骤列表已改为动态容器，日志区提供“记录”按钮并挂接邮箱记录覆盖层，同时新增共享“验证码重发”次数输入，并加载 `managed-alias-utils.js`，把旧的“邮箱前缀”字段语义改为“别名基邮箱”；iCloud 区域新增了网页 / 本地 macOS 生成策略与 Apple ID 密码配置入口。
+- `sidepanel/sidepanel.js`：侧边栏主入口脚本，负责 UI 状态同步、动态步骤渲染、按钮交互、独立本地同步配置、共享验证码自动重发次数配置与广播接收，并装配 Hotmail / iCloud / LuckMail / 邮箱记录面板 manager；同时把 Gmail / 2925 的基邮箱输入、完整注册邮箱输入、自动生成按钮与兼容性校验统一接到共享别名逻辑上，并接管 iCloud 本地生成策略/Apple ID 密码的保存、恢复与“本地成功后不强制刷新网页 iCloud 管理器”的 UI 边界。
 - `sidepanel/update-service.js`：侧边栏更新检查服务，负责 GitHub Releases 查询与版本展示。
 
 ## `tests/`
@@ -130,7 +131,8 @@
 - `tests/background-auto-run-module.test.js`：测试自动运行控制器模块已接入且导出工厂。
 - `tests/background-account-run-history-module.test.js`：测试邮箱记录模块已接入、导出工厂，能够保留并归一化停止记录、归一化失败标签、计算自动重试次数，并支持清理后同步完整快照。
 - `tests/background-account-history-settings.test.js`：测试账号运行历史的独立配置项归一化，不再复用 Hotmail 模式作为启停条件。
-- `tests/background-generated-email-module.test.js`：测试生成邮箱辅助模块已接入且导出工厂。
+- `tests/background-generated-email-module.test.js`：测试生成邮箱辅助模块已接入且导出工厂，并覆盖 iCloud 网页 / 本地策略分流与“本地失败不回退网页”的约束。
+- `tests/background-icloud-local-helper.test.js`：测试 iCloud 本地 helper 调用的成功、非 macOS、helper 不可达与 Apple ID 密码缺失错误路径。
 - `tests/background-icloud.test.js`：测试 iCloud 相关后台纯函数与别名收尾逻辑。
 - `tests/background-icloud-mail-provider.test.js`：测试 iCloud 邮箱 provider 配置解析。
 - `tests/background-logging-status-module.test.js`：测试日志 / 状态模块已接入且导出工厂。
@@ -163,6 +165,7 @@
 - `tests/sidepanel-account-records-manager.test.js`：测试侧边栏邮箱记录覆盖层的 HTML 接入、helper 地址归一化与 manager 渲染逻辑。
 - `tests/sidepanel-icloud-manager.test.js`：测试侧边栏 iCloud 管理器模块接线与空态渲染。
 - `tests/sidepanel-icloud-provider.test.js`：测试侧边栏 iCloud 登录地址解析逻辑。
+- `tests/sidepanel-icloud-local-settings.test.js`：测试侧边栏 iCloud 本地生成策略配置、Apple ID 密码恢复，以及本地策略下不强制网页 iCloud 别名刷新。
 - `tests/sidepanel-luckmail-manager.test.js`：测试侧边栏 LuckMail 管理器模块接线与空态渲染。
 - `tests/signup-entry-diagnostics.test.js`：测试注册入口诊断快照输出。
 - `tests/signup-page-tab-cleanup.test.js`：测试注册页来源标签的冲突清理逻辑。


### PR DESCRIPTION
## 摘要
- 稳定 iCloud 邮箱标签页生命周期：自动流程只复用自己拥有的 iCloud 邮箱标签页，不接管也不关闭用户手动打开的标签页
- 在重新开始新一轮尝试后，保留自动化拥有的 iCloud 邮箱标签页归属信息，并在运行时把活动标签页重新镜像回 `tabRegistry`
- 在停止、失败或中断时保留自动化拥有的 iCloud 邮箱标签页，便于人工检查
- 补充修复 iCloud 在步骤 4 的验证码策略：不再在首次检查邮箱前先点“重新发送验证码”，而是先轮询邮箱
- 增加回归测试，覆盖 iCloud 标签页归属生命周期、步骤 4 的 iCloud 先轮询邮箱策略，以及 iCloud 邮箱配置的 `provider` 边界

## 根因
### 1. iCloud 邮箱标签页生命周期问题
原来的 iCloud 邮箱流程主要依赖瞬时的 `tabRegistry` 和 `sourceLastUrls` 运行态。重新开始新一轮尝试时会清掉这部分状态，通用的复用 / 清理逻辑也区分不了“自动化自己打开的 iCloud 标签页”和“用户手动打开的 iCloud 标签页”，于是会出现重复打开、错误接管或误关闭的问题。

### 2. iCloud 步骤 4 验证码问题
iCloud 邮箱配置没有返回 `provider`，而步骤 4 又使用“不是 Hotmail 就先请求新验证码”的默认策略。这样会让 iCloud 在第一次检查邮箱前就先触发“重新发送验证码”。连续操作时很容易堆出多封验证码，而步骤 8 因为固定为先轮询邮箱，所以表现看起来反而更稳定。

## 主要改动
- 为 iCloud 引入基于归属信息的标签页生命周期策略，只复用自动化拥有的 iCloud 邮箱标签页
- 保留自动化拥有的 iCloud 标签页归属信息，跨重新开始的新一轮尝试继续复用
- 在停止、失败或中断时保留自动化拥有的 iCloud 标签页，方便人工检查
- 为 iCloud 邮箱配置补上 `provider`
- 将步骤 4 的 iCloud 验证码策略改为先轮询邮箱，避免在首次检查邮箱前先点“重新发送验证码”
- 增加对应回归测试

## 影响
- 重复进入步骤 4 / 步骤 8 时，会收敛到单个自动化拥有的 iCloud 邮箱标签页
- 用户自己打开的 iCloud 邮箱标签页不会被自动流程接管或关闭
- iCloud 步骤 4 不会再一上来先点“重新发送验证码”，可以减少连续操作时堆出多封验证码的问题
- 停止、失败或中断后，自动化拥有的 iCloud 邮箱标签页会保留，方便人工排查

## 验证
- `node --test tests/background-tab-runtime-module.test.js`
- `node --test tests/background-icloud-mail-provider.test.js`
- `node --test tests/auto-run-fresh-attempt-reset.test.js`
- `node --test tests/step8-stop-cleanup.test.js`
- `node --test tests/background-step4-icloud-strategy.test.js`
- `node --test tests/background-step7-recovery.test.js`
- `node --test tests/verification-flow-polling.test.js`
- `node --test tests/*.test.js`

## 风险与边界
这次只把 iCloud 从步骤 4 的错误默认分支里拉回到“先轮询邮箱”，没有顺手重做所有网页邮箱的验证码策略表。这样可以保持当前 PR 的范围集中，但如果后续发现其他网页邮箱也更适合先轮询邮箱，还需要再单独梳理一次各个 provider 的策略。
