### PR TITLE
fix(pro7.5): stabilize iCloud flow and logged-in signup skip path

### DIFF
--- a/background.js
+++ b/background.js
@@ -5992,7 +5992,7 @@ async function ensureAutoEmailReady(targetRun, totalRuns, attemptRuns) {
         await addLog(`${generatorLabel}：正在进行第 ${attempt}/${EMAIL_FETCH_MAX_ATTEMPTS} 次自动获取重试...`, 'warn');
       }
       const generatedEmail = await fetchGeneratedEmail(currentState, {
-        generateNew: generator !== 'icloud',
+        generateNew: generator !== 'icloud' || normalizeIcloudFetchMode(currentState.icloudFetchMode) === 'always_new',
         generator,
       });
       await addLog(
@@ -6141,7 +6141,7 @@ async function ensureAutoEmailReady(targetRun, totalRuns, attemptRuns) {
         await addLog(`${generatorLabel}：正在进行第 ${attempt}/${EMAIL_FETCH_MAX_ATTEMPTS} 次自动获取重试...`, 'warn');
       }
       const generatedEmail = await fetchGeneratedEmail(currentState, {
-        generateNew: generator !== 'icloud',
+        generateNew: generator !== 'icloud' || normalizeIcloudFetchMode(currentState.icloudFetchMode) === 'always_new',
         generator,
       });
       await addLog(

--- a/background.js
+++ b/background.js
@@ -272,6 +272,7 @@ const PERSISTED_SETTING_DEFAULTS = {
   customEmailPool: [],
   autoDeleteUsedIcloudAlias: false,
   icloudHostPreference: 'auto',
+  icloudFetchMode: 'reuse_existing',
   accountRunHistoryTextEnabled: false,
   accountRunHistoryHelperBaseUrl: DEFAULT_ACCOUNT_RUN_HISTORY_HELPER_BASE_URL,
   gmailBaseEmail: '',
@@ -674,6 +675,11 @@ function normalizeEmailGenerator(value = '') {
   return 'duck';
 }
 
+function normalizeIcloudFetchMode(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  return normalized === 'always_new' ? 'always_new' : 'reuse_existing';
+}
+
 function normalizeCustomEmailPool(value = []) {
   const source = Array.isArray(value)
     ? value
@@ -978,6 +984,8 @@ function normalizePersistentSettingValue(key, value) {
       return Boolean(value);
     case 'icloudHostPreference':
       return normalizeIcloudHost(value) || 'auto';
+    case 'icloudFetchMode':
+      return normalizeIcloudFetchMode(value);
     case 'accountRunHistoryHelperBaseUrl':
       return normalizeAccountRunHistoryHelperBaseUrl(value);
     case 'gmailBaseEmail':
@@ -3448,10 +3456,16 @@ async function validateIcloudSession(setupUrl) {
   return data;
 }
 
-async function resolveIcloudPremiumMailService() {
+async function resolveIcloudPremiumMailService(options = {}) {
   const errors = [];
   const state = await getState();
-  const setupUrls = await getPreferredIcloudSetupUrls(state);
+  const explicitHost = normalizeIcloudHost(options?.hostPreference || options?.preferredHost || '');
+  const setupUrls = explicitHost
+    ? (() => {
+        const forcedSetupUrl = getIcloudSetupUrlForHost(explicitHost);
+        return forcedSetupUrl ? [forcedSetupUrl] : [];
+      })()
+    : await getPreferredIcloudSetupUrls(state);
 
   for (const setupUrl of setupUrls) {
     try {
@@ -3480,17 +3494,19 @@ function getIcloudAliasLabel() {
   return `MultiPage ${dateStr}`;
 }
 
-async function checkIcloudSession() {
-  return withIcloudLoginHelp('检查 iCloud 会话', async () => {
-    const { setupUrl } = await resolveIcloudPremiumMailService();
+async function checkIcloudSession(options = {}) {
+  const actionLabel = String(options?.actionLabel || '检查 iCloud 会话').trim() || '检查 iCloud 会话';
+  const { actionLabel: _ignoredActionLabel, ...resolveOptions } = options || {};
+  return withIcloudLoginHelp(actionLabel, async () => {
+    const { setupUrl } = await resolveIcloudPremiumMailService(resolveOptions);
     await addLog(`iCloud：会话校验通过（${new URL(setupUrl).host}）`, 'ok');
     return { ok: true, setupUrl };
   });
 }
 
-async function listIcloudAliases() {
+async function listIcloudAliases(options = {}) {
   return withIcloudLoginHelp('加载 iCloud 隐私邮箱列表', async () => {
-    const { serviceUrl } = await resolveIcloudPremiumMailService();
+    const { serviceUrl } = await resolveIcloudPremiumMailService(options);
     const response = await icloudRequest('GET', `${serviceUrl}/v2/hme/list`);
     const state = await getState();
     return normalizeIcloudAliasList(response, {
@@ -3580,9 +3596,10 @@ async function deleteUsedIcloudAliases() {
   return { deleted, skipped };
 }
 
-async function fetchIcloudHideMyEmail() {
+async function fetchIcloudHideMyEmail(options = {}) {
   return withIcloudLoginHelp('获取 iCloud 隐私邮箱', async () => {
     throwIfStopped();
+    const generateNew = Boolean(options?.generateNew);
     await addLog('iCloud：正在校验当前浏览器登录状态...', 'info');
 
     const { serviceUrl, setupUrl } = await resolveIcloudPremiumMailService();
@@ -3595,12 +3612,16 @@ async function fetchIcloudHideMyEmail() {
       preservedEmails: getPreservedAliasMap(state),
     });
 
-    const reusableAlias = pickReusableIcloudAlias(existingAliases);
-    if (reusableAlias) {
-      await setEmailState(reusableAlias.email);
-      await addLog(`iCloud：复用未使用别名 ${reusableAlias.email}`, 'ok');
-      broadcastIcloudAliasesChanged({ reason: 'selected', email: reusableAlias.email });
-      return reusableAlias.email;
+    if (!generateNew) {
+      const reusableAlias = pickReusableIcloudAlias(existingAliases);
+      if (reusableAlias) {
+        await setEmailState(reusableAlias.email);
+        await addLog(`iCloud：复用未使用别名 ${reusableAlias.email}`, 'ok');
+        broadcastIcloudAliasesChanged({ reason: 'selected', email: reusableAlias.email });
+        return reusableAlias.email;
+      }
+    } else {
+      await addLog('iCloud：已启用“始终创建新别名”，本次将跳过复用。', 'info');
     }
 
     await addLog('iCloud：没有可复用别名，开始生成新的 Hide My Email 地址...', 'warn');
@@ -5970,7 +5991,10 @@ async function ensureAutoEmailReady(targetRun, totalRuns, attemptRuns) {
       if (attempt > 1) {
         await addLog(`${generatorLabel}：正在进行第 ${attempt}/${EMAIL_FETCH_MAX_ATTEMPTS} 次自动获取重试...`, 'warn');
       }
-      const generatedEmail = await fetchGeneratedEmail(currentState, { generateNew: true, generator });
+      const generatedEmail = await fetchGeneratedEmail(currentState, {
+        generateNew: generator !== 'icloud',
+        generator,
+      });
       await addLog(
         `=== 目标 ${targetRun}/${totalRuns} 轮：${generatorLabel}已就绪：${generatedEmail}（第 ${attemptRuns} 次尝试，第 ${attempt}/${EMAIL_FETCH_MAX_ATTEMPTS} 次获取）===`,
         'ok'
@@ -6116,7 +6140,10 @@ async function ensureAutoEmailReady(targetRun, totalRuns, attemptRuns) {
       if (attempt > 1) {
         await addLog(`${generatorLabel}：正在进行第 ${attempt}/${EMAIL_FETCH_MAX_ATTEMPTS} 次自动获取重试...`, 'warn');
       }
-      const generatedEmail = await fetchGeneratedEmail(currentState, { generateNew: true, generator });
+      const generatedEmail = await fetchGeneratedEmail(currentState, {
+        generateNew: generator !== 'icloud',
+        generator,
+      });
       await addLog(
         `=== 目标 ${targetRun}/${totalRuns} 轮：${generatorLabel}已就绪：${generatedEmail}（第 ${attemptRuns} 次尝试，第 ${attempt}/${EMAIL_FETCH_MAX_ATTEMPTS} 次获取）===`,
         'ok'
@@ -6201,9 +6228,15 @@ async function runAutoSequenceFromStep(startStep, context = {}) {
   let restartFromStep1WithCurrentEmail = false;
   let step = Math.max(currentStartStep, 4);
   while (step <= LAST_STEP_ID) {
+    const latestState = await getState();
+    const currentStatus = latestState.stepStatuses?.[step] || 'pending';
+    if (isStepDoneStatus(currentStatus)) {
+      await addLog(`自动运行：步骤 ${step} 当前状态为 ${currentStatus}，将直接继续后续流程。`, 'info');
+      step += 1;
+      continue;
+    }
     try {
       await executeStepAndWait(step, AUTO_STEP_DELAYS[step]);
-      const latestState = await getState();
       step += 1;
     } catch (err) {
       if (isStopError(err)) {
@@ -6442,6 +6475,7 @@ const verificationFlowHelpers = self.MultiPageBackgroundVerificationFlow?.create
   getTabId,
   HOTMAIL_PROVIDER,
   isMail2925LimitReachedError,
+  isRetryableContentScriptTransportError,
   isStopError,
   LUCKMAIL_PROVIDER,
   MAIL_2925_VERIFICATION_INTERVAL_MS,
@@ -6450,6 +6484,7 @@ const verificationFlowHelpers = self.MultiPageBackgroundVerificationFlow?.create
   pollHotmailVerificationCode,
   pollLuckmailVerificationCode,
   sendToContentScript,
+  sendToContentScriptResilient,
   sendToMailContentScriptResilient,
   setState,
   setStepStatus,
@@ -6467,6 +6502,7 @@ const step2Executor = self.MultiPageBackgroundStep2?.createStep2Executor({
   chrome,
   completeStepFromBackground,
   ensureContentScriptReadyOnTab,
+  ensureSignupAuthEntryPageReady,
   ensureSignupEntryPageReady,
   ensureSignupPostEmailPageReadyInTab,
   getTabId,
@@ -6487,12 +6523,24 @@ const step3Executor = self.MultiPageBackgroundStep3?.createStep3Executor({
   setState,
   SIGNUP_PAGE_INJECT_FILES,
 });
+
+async function ensureIcloudMailSessionForVerification(options = {}) {
+  const flowState = options?.state || await getState().catch(() => ({}));
+  const hostPreference = getConfiguredIcloudHostPreference(flowState)
+    || normalizeIcloudHost(flowState?.preferredIcloudHost);
+  return checkIcloudSession({
+    ...(hostPreference ? { hostPreference } : {}),
+    actionLabel: options?.actionLabel || '检查 iCloud 会话',
+  });
+}
+
 const step4Executor = self.MultiPageBackgroundStep4?.createStep4Executor({
   addLog,
   chrome,
   completeStepFromBackground,
   confirmCustomVerificationStepBypass: verificationFlowHelpers.confirmCustomVerificationStepBypass,
   ensureMail2925MailboxSession,
+  ensureIcloudMailSession: ensureIcloudMailSessionForVerification,
   getMailConfig,
   getTabId,
   HOTMAIL_PROVIDER,
@@ -6539,6 +6587,7 @@ const step8Executor = self.MultiPageBackgroundStep8?.createStep8Executor({
   CLOUDFLARE_TEMP_EMAIL_PROVIDER,
   confirmCustomVerificationStepBypass: verificationFlowHelpers.confirmCustomVerificationStepBypass,
   ensureMail2925MailboxSession,
+  ensureIcloudMailSession: ensureIcloudMailSessionForVerification,
   ensureStep8VerificationPageReady,
   getOAuthFlowRemainingMs,
   getOAuthFlowStepTimeoutMs,
@@ -6718,6 +6767,10 @@ async function openSignupEntryTab(step = 1) {
 }
 
 async function ensureSignupEntryPageReady(step = 1) {
+  return signupFlowHelpers.ensureSignupEntryPageReady(step);
+}
+
+async function ensureSignupAuthEntryPageReady(step = 1) {
   return signupFlowHelpers.ensureSignupEntryPageReady(step);
 }
 

--- a/background/generated-email-helpers.js
+++ b/background/generated-email-helpers.js
@@ -283,8 +283,9 @@
         return fetchManagedAliasEmail(mergedState, options);
       }
       if (generator === 'icloud') {
+        const stateFetchMode = String(mergedState.icloudFetchMode || '').trim().toLowerCase();
         return fetchIcloudHideMyEmail({
-          generateNew: Boolean(options.generateNew),
+          generateNew: Boolean(options.generateNew) || stateFetchMode === 'always_new',
         });
       }
       if (generator === 'cloudflare') {

--- a/background/generated-email-helpers.js
+++ b/background/generated-email-helpers.js
@@ -283,7 +283,9 @@
         return fetchManagedAliasEmail(mergedState, options);
       }
       if (generator === 'icloud') {
-        return fetchIcloudHideMyEmail();
+        return fetchIcloudHideMyEmail({
+          generateNew: Boolean(options.generateNew),
+        });
       }
       if (generator === 'cloudflare') {
         return fetchCloudflareEmail(mergedState, options);

--- a/background/message-router.js
+++ b/background/message-router.js
@@ -151,6 +151,18 @@
           if (payload.email) {
             await setEmailState(payload.email);
           }
+          if (payload.skipRegistrationFlow) {
+            const latestState = await getState();
+            for (const skipStep of [3, 4, 5]) {
+              const status = latestState.stepStatuses?.[skipStep];
+              if (status === 'running' || status === 'completed' || status === 'manual_completed') {
+                continue;
+              }
+              await setStepStatus(skipStep, 'skipped');
+            }
+            await addLog('步骤 2：检测到当前已登录会话，已自动跳过步骤 3/4/5，流程将直接进入步骤 6。', 'warn');
+            break;
+          }
           if (payload.skippedPasswordStep) {
             const latestState = await getState();
             const step3Status = latestState.stepStatuses?.[3];

--- a/background/message-router.js
+++ b/background/message-router.js
@@ -191,6 +191,14 @@
             lastEmailTimestamp: payload.emailTimestamp || null,
             signupVerificationRequestedAt: null,
           });
+          if (payload.skipProfileStep) {
+            const latestState = await getState();
+            const step5Status = latestState.stepStatuses?.[5];
+            if (step5Status !== 'running' && step5Status !== 'completed' && step5Status !== 'manual_completed') {
+              await setStepStatus(5, 'skipped');
+              await addLog('步骤 4：检测到账号已直接进入已登录态，已自动跳过步骤 5。', 'warn');
+            }
+          }
           break;
         case 8:
           await setState({

--- a/background/steps/fetch-login-code.js
+++ b/background/steps/fetch-login-code.js
@@ -10,6 +10,7 @@
       CLOUDFLARE_TEMP_EMAIL_PROVIDER,
       confirmCustomVerificationStepBypass,
       ensureMail2925MailboxSession,
+      ensureIcloudMailSession,
       ensureStep8VerificationPageReady,
       getOAuthFlowRemainingMs,
       getOAuthFlowStepTimeoutMs,
@@ -138,6 +139,15 @@
       if (shouldUseCustomRegistrationEmail(state)) {
         await confirmCustomVerificationStepBypass(8);
         return;
+      }
+
+      if (mail.source === 'icloud-mail' && typeof ensureIcloudMailSession === 'function') {
+        await addLog('步骤 8：正在确认 iCloud 邮箱登录态...', 'info');
+        await ensureIcloudMailSession({
+          state,
+          step: 8,
+          actionLabel: '步骤 8：确认 iCloud 邮箱登录态',
+        });
       }
 
       throwIfStopped();

--- a/background/steps/fetch-signup-code.js
+++ b/background/steps/fetch-signup-code.js
@@ -10,6 +10,7 @@
       completeStepFromBackground,
       confirmCustomVerificationStepBypass,
       ensureMail2925MailboxSession,
+      ensureIcloudMailSession,
       getMailConfig,
       getTabId,
       HOTMAIL_PROVIDER,
@@ -109,6 +110,15 @@
       if (shouldUseCustomRegistrationEmail(state)) {
         await confirmCustomVerificationStepBypass(4);
         return;
+      }
+
+      if (mail.source === 'icloud-mail' && typeof ensureIcloudMailSession === 'function') {
+        await addLog('步骤 4：正在确认 iCloud 邮箱登录态...', 'info');
+        await ensureIcloudMailSession({
+          state,
+          step: 4,
+          actionLabel: '步骤 4：确认 iCloud 邮箱登录态',
+        });
       }
 
       throwIfStopped();

--- a/background/steps/submit-signup-email.js
+++ b/background/steps/submit-signup-email.js
@@ -7,6 +7,7 @@
       chrome,
       completeStepFromBackground,
       ensureContentScriptReadyOnTab,
+      ensureSignupAuthEntryPageReady,
       ensureSignupEntryPageReady,
       ensureSignupPostEmailPageReadyInTab,
       getTabId,
@@ -15,6 +16,107 @@
       sendToContentScriptResilient,
       SIGNUP_PAGE_INJECT_FILES,
     } = deps;
+
+    function getErrorMessage(error) {
+      return String(typeof error === 'string' ? error : error?.message || '');
+    }
+
+    function isSignupEntryUnavailableErrorMessage(errorLike) {
+      const message = getErrorMessage(errorLike);
+      return /未找到可用的邮箱输入入口|当前页面没有可用的注册入口，也不在邮箱\/密码页/.test(message);
+    }
+
+    function isRetryableStep2TransportErrorMessage(errorLike) {
+      const message = getErrorMessage(errorLike);
+      return /Content script on signup-page did not respond in \d+s|Receiving end does not exist|message channel closed|A listener indicated an asynchronous response|port closed before a response was received|did not respond in \d+s/i.test(message);
+    }
+
+    function isLikelyLoggedInChatgptHomeUrl(rawUrl) {
+      const url = String(rawUrl || '').trim();
+      if (!url) {
+        return false;
+      }
+      try {
+        const parsed = new URL(url);
+        const host = String(parsed.hostname || '').toLowerCase();
+        if (!['chatgpt.com', 'www.chatgpt.com'].includes(host)) {
+          return false;
+        }
+        const path = String(parsed.pathname || '');
+        if (/^\/(?:auth\/|create-account\/|email-verification|log-in|add-phone)(?:[/?#]|$)/i.test(path)) {
+          return false;
+        }
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    async function shouldForceAuthEntryRetry(tabId) {
+      if (!Number.isInteger(tabId) || typeof chrome?.tabs?.get !== 'function') {
+        return false;
+      }
+      try {
+        const tab = await chrome.tabs.get(tabId);
+        const currentUrl = String(tab?.url || '');
+        return isLikelyLoggedInChatgptHomeUrl(currentUrl);
+      } catch {
+        return false;
+      }
+    }
+
+    async function getTabUrl(tabId) {
+      if (!Number.isInteger(tabId) || typeof chrome?.tabs?.get !== 'function') {
+        return '';
+      }
+      try {
+        const tab = await chrome.tabs.get(tabId);
+        return String(tab?.url || '');
+      } catch {
+        return '';
+      }
+    }
+
+    async function completeStep2AsLoggedInSession(tabId, resolvedEmail, reasonMessage = '') {
+      const currentUrl = await getTabUrl(tabId);
+      if (!isLikelyLoggedInChatgptHomeUrl(currentUrl)) {
+        return false;
+      }
+      const reasonText = getErrorMessage(reasonMessage);
+      const reasonSuffix = reasonText ? `（触发原因：${reasonText}）` : '';
+      await addLog(`步骤 2：检测到当前会话已登录 ChatGPT，已跳过注册链路（步骤 3/4/5），将直接进入步骤 6。${reasonSuffix}`, 'warn');
+      await completeStepFromBackground(2, {
+        email: resolvedEmail,
+        nextSignupState: 'already_logged_in_home',
+        nextSignupUrl: currentUrl || 'https://chatgpt.com/',
+        skippedPasswordStep: true,
+        skipRegistrationFlow: true,
+      });
+      return true;
+    }
+
+    async function submitSignupEmail(resolvedEmail, options = {}) {
+      const {
+        timeoutMs = 35000,
+        retryDelayMs = 700,
+        logMessage = '步骤 2：官网注册入口正在切换，等待页面恢复后继续输入邮箱...',
+      } = options;
+
+      try {
+        return await sendToContentScriptResilient('signup-page', {
+          type: 'EXECUTE_STEP',
+          step: 2,
+          source: 'background',
+          payload: { email: resolvedEmail },
+        }, {
+          timeoutMs,
+          retryDelayMs,
+          logMessage,
+        });
+      } catch (error) {
+        return { error: getErrorMessage(error) };
+      }
+    }
 
     async function executeStep2(state) {
       const resolvedEmail = await resolveSignupEmailForFlow(state);
@@ -34,19 +136,73 @@
         });
       }
 
-      const step2Result = await sendToContentScriptResilient('signup-page', {
-        type: 'EXECUTE_STEP',
-        step: 2,
-        source: 'background',
-        payload: { email: resolvedEmail },
-      }, {
-        timeoutMs: 20000,
+      if (await shouldForceAuthEntryRetry(signupTabId)) {
+        await addLog('步骤 2：检测到当前位于已登录 ChatGPT 首页，先切换认证入口页再提交邮箱。', 'warn');
+        try {
+          signupTabId = (await ensureSignupAuthEntryPageReady(2)).tabId;
+        } catch (entryError) {
+          const entryErrorMessage = getErrorMessage(entryError);
+          if (await completeStep2AsLoggedInSession(signupTabId, resolvedEmail, entryErrorMessage)) {
+            return;
+          }
+          await addLog('步骤 2：切换认证入口失败，正在重新打开官网入口并重试提交邮箱...', 'warn');
+          signupTabId = (await ensureSignupEntryPageReady(2)).tabId;
+        }
+      }
+
+      let step2Result = await submitSignupEmail(resolvedEmail, {
+        timeoutMs: 35000,
         retryDelayMs: 700,
         logMessage: '步骤 2：官网注册入口正在切换，等待页面恢复后继续输入邮箱...',
       });
 
       if (step2Result?.error) {
-        throw new Error(step2Result.error);
+        const errorMessage = getErrorMessage(step2Result.error);
+        if (isSignupEntryUnavailableErrorMessage(errorMessage)) {
+          await addLog('步骤 2：未找到邮箱输入入口，正在切换认证入口页后重试一次...', 'warn');
+          signupTabId = (await ensureSignupAuthEntryPageReady(2)).tabId;
+          step2Result = await submitSignupEmail(resolvedEmail, {
+            timeoutMs: 35000,
+            retryDelayMs: 700,
+            logMessage: '步骤 2：认证入口页已打开，正在重新提交邮箱...',
+          });
+
+          if (step2Result?.error) {
+            const retryErrorMessage = getErrorMessage(step2Result.error);
+            if (isSignupEntryUnavailableErrorMessage(retryErrorMessage)) {
+              if (await completeStep2AsLoggedInSession(signupTabId, resolvedEmail, retryErrorMessage)) {
+                return;
+              }
+              await addLog('步骤 2：认证入口仍不可用，正在重新进入官网注册入口再重试一次...', 'warn');
+              signupTabId = (await ensureSignupEntryPageReady(2)).tabId;
+              step2Result = await submitSignupEmail(resolvedEmail, {
+                timeoutMs: 35000,
+                retryDelayMs: 700,
+                logMessage: '步骤 2：重试官网注册入口后正在重新提交邮箱...',
+              });
+            }
+          }
+        } else if (isRetryableStep2TransportErrorMessage(errorMessage)) {
+          await addLog('步骤 2：注册入口页通信超时，正在切换认证入口页并重试提交邮箱...', 'warn');
+          signupTabId = (await ensureSignupAuthEntryPageReady(2)).tabId;
+          step2Result = await submitSignupEmail(resolvedEmail, {
+            timeoutMs: 45000,
+            retryDelayMs: 700,
+            logMessage: '步骤 2：认证入口页已打开，正在重新提交邮箱...',
+          });
+        }
+      }
+
+      if (step2Result?.error) {
+        const finalErrorMessage = getErrorMessage(step2Result.error);
+        if (
+          (isSignupEntryUnavailableErrorMessage(finalErrorMessage)
+            || isRetryableStep2TransportErrorMessage(finalErrorMessage))
+          && await completeStep2AsLoggedInSession(signupTabId, resolvedEmail, finalErrorMessage)
+        ) {
+          return;
+        }
+        throw new Error(finalErrorMessage);
       }
 
       if (!step2Result?.alreadyOnPasswordPage) {

--- a/background/verification-flow.js
+++ b/background/verification-flow.js
@@ -23,6 +23,7 @@
       pollHotmailVerificationCode,
       pollLuckmailVerificationCode,
       sendToContentScript,
+      sendToContentScriptResilient,
       sendToMailContentScriptResilient,
       setState,
       sleepWithStop,
@@ -30,12 +31,101 @@
       VERIFICATION_POLL_MAX_ROUNDS,
     } = deps;
 
+    const isRetryableVerificationTransportError = typeof deps.isRetryableContentScriptTransportError === 'function'
+      ? deps.isRetryableContentScriptTransportError
+      : ((error) => /back\/forward cache|message channel is closed|Receiving end does not exist|port closed before a response was received|A listener indicated an asynchronous response|did not respond in \d+s/i.test(
+        String(typeof error === 'string' ? error : error?.message || '')
+      ));
+
     function getVerificationCodeStateKey(step) {
       return step === 4 ? 'lastSignupCode' : 'lastLoginCode';
     }
 
     function getVerificationCodeLabel(step) {
       return step === 4 ? '注册' : '登录';
+    }
+
+    function isLikelyLoggedInChatgptHomeUrl(rawUrl) {
+      const url = String(rawUrl || '').trim();
+      if (!url) return false;
+
+      try {
+        const parsed = new URL(url);
+        const host = String(parsed.hostname || '').toLowerCase();
+        if (!['chatgpt.com', 'www.chatgpt.com'].includes(host)) {
+          return false;
+        }
+        const path = String(parsed.pathname || '');
+        if (/^\/(?:auth\/|create-account\/|email-verification|log-in|add-phone)(?:[/?#]|$)/i.test(path)) {
+          return false;
+        }
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    function isSignupProfilePageUrl(rawUrl) {
+      const url = String(rawUrl || '').trim();
+      if (!url) return false;
+
+      try {
+        const parsed = new URL(url);
+        const host = String(parsed.hostname || '').toLowerCase();
+        if (!['auth.openai.com', 'auth0.openai.com', 'accounts.openai.com'].includes(host)) {
+          return false;
+        }
+        return /\/create-account\/profile(?:[/?#]|$)/i.test(String(parsed.pathname || ''));
+      } catch {
+        return false;
+      }
+    }
+
+    async function detectStep4PostSubmitFallback(tabId, options = {}) {
+      const timeoutMs = Math.max(1000, Number(options.timeoutMs) || 8000);
+      const pollIntervalMs = Math.max(100, Number(options.pollIntervalMs) || 250);
+      const startedAt = Date.now();
+      let lastUrl = '';
+
+      while (Date.now() - startedAt < timeoutMs) {
+        throwIfStopped();
+        try {
+          const tab = await chrome.tabs.get(tabId);
+          const currentUrl = String(tab?.url || '').trim();
+          if (currentUrl) {
+            lastUrl = currentUrl;
+          }
+
+          if (isLikelyLoggedInChatgptHomeUrl(currentUrl)) {
+            return {
+              success: true,
+              reason: 'chatgpt_home',
+              skipProfileStep: true,
+              url: currentUrl,
+            };
+          }
+
+          if (isSignupProfilePageUrl(currentUrl)) {
+            return {
+              success: true,
+              reason: 'signup_profile',
+              skipProfileStep: false,
+              url: currentUrl,
+            };
+          }
+        } catch {
+          // Keep polling until timeout; tab may be mid-navigation.
+        }
+
+        await sleepWithStop(pollIntervalMs);
+      }
+
+      return {
+        success: false,
+        reason: 'unknown',
+        skipProfileStep: false,
+        url: lastUrl,
+      };
     }
 
     function getVerificationResendStateKey() {
@@ -448,6 +538,17 @@
               `步骤 ${step}：距离下次重新发送验证码还差 ${Math.ceil(remainingBeforeResendMs / 1000)} 秒，继续刷新邮箱（第 ${round}/${maxRounds} 轮）...`,
               'info'
             );
+            const configuredIntervalMs = Math.max(
+              1,
+              Number(payloadOverrides.intervalMs)
+                || Number(pollOverrides.intervalMs)
+                || 3000
+            );
+            const cooldownSleepMs = Math.min(
+              remainingBeforeResendMs,
+              Math.max(1000, Math.min(configuredIntervalMs, 3000))
+            );
+            await sleepWithStop(cooldownSleepMs);
             continue;
           }
 
@@ -597,19 +698,54 @@
       }
 
       await chrome.tabs.update(signupTabId, { active: true });
-      const result = await sendToContentScript('signup-page', {
+      const baseResponseTimeoutMs = await getResponseTimeoutMsForStep(
+        step,
+        options,
+        step === 7 ? 45000 : 30000,
+        `填写${getVerificationCodeLabel(step)}验证码`
+      );
+      const message = {
         type: 'FILL_CODE',
         step,
         source: 'background',
         payload: { code },
-      }, {
-        responseTimeoutMs: await getResponseTimeoutMsForStep(
-          step,
-          options,
-          step === 7 ? 45000 : 30000,
-          `填写${getVerificationCodeLabel(step)}验证码`
-        ),
-      });
+      };
+      let result;
+      if (typeof sendToContentScriptResilient === 'function') {
+        try {
+          result = await sendToContentScriptResilient('signup-page', message, {
+            timeoutMs: Math.max(baseResponseTimeoutMs + 15000, 30000),
+            retryDelayMs: 700,
+            responseTimeoutMs: baseResponseTimeoutMs,
+            logMessage: `步骤 ${step}：认证页正在切换，等待页面重新就绪后继续确认验证码提交结果...`,
+          });
+        } catch (err) {
+          if (step === 4 && isRetryableVerificationTransportError(err)) {
+            const fallback = await detectStep4PostSubmitFallback(signupTabId, {
+              timeoutMs: 9000,
+              pollIntervalMs: 300,
+            });
+            if (fallback.success) {
+              const fallbackLabel = fallback.reason === 'chatgpt_home'
+                ? 'ChatGPT 已登录首页'
+                : '注册资料页';
+              await addLog(`步骤 4：验证码提交后页面已切换到${fallbackLabel}，按提交成功继续。`, 'warn');
+              return {
+                success: true,
+                assumed: true,
+                transportRecovered: true,
+                skipProfileStep: Boolean(fallback.skipProfileStep),
+                url: fallback.url,
+              };
+            }
+          }
+          throw err;
+        }
+      } else {
+        result = await sendToContentScript('signup-page', message, {
+          responseTimeoutMs: baseResponseTimeoutMs,
+        });
+      }
 
       if (result && result.error) {
         throw new Error(result.error);
@@ -735,6 +871,7 @@
                 `步骤 ${step}：提交失败后距离下次重新发送验证码还差 ${Math.ceil(remainingBeforeResendMs / 1000)} 秒，先继续刷新邮箱（${attempt + 1}/${maxSubmitAttempts}）...`,
                 'warn'
               );
+              await sleepWithStop(Math.min(remainingBeforeResendMs, 2000));
               continue;
             }
 
@@ -763,6 +900,7 @@
           await completeStepFromBackground(step, {
             emailTimestamp: result.emailTimestamp,
             code: result.code,
+            ...(step === 4 && submitResult?.skipProfileStep ? { skipProfileStep: true } : {}),
           });
           triggerPostSuccessMailboxCleanup(step, mail);
           return;

--- a/content/signup-page.js
+++ b/content/signup-page.js
@@ -2122,6 +2122,20 @@ async function fillVerificationCode(step, payload) {
   const { code } = payload;
   if (!code) throw new Error('未提供验证码。');
 
+  if (step === 4 && isStep5Ready()) {
+    log(`步骤 ${step}：检测到页面已进入下一阶段，本次验证码提交按成功处理。`, 'ok');
+    return { success: true, assumed: true, alreadyAdvanced: true };
+  }
+  if (step === 8) {
+    if (isStep8Ready()) {
+      log(`步骤 ${step}：检测到页面已进入 OAuth 同意页，本次验证码提交按成功处理。`, 'ok');
+      return { success: true, assumed: true, alreadyAdvanced: true };
+    }
+    if (isAddPhonePageReady()) {
+      return { success: true, addPhonePage: true, url: location.href };
+    }
+  }
+
   log(`步骤 ${step}：正在填写验证码：${code}`);
 
   if (step === 8) {

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -632,6 +632,13 @@
         </select>
       </div>
       <div class="data-row">
+        <span class="data-label">获取策略</span>
+        <select id="select-icloud-fetch-mode" class="data-select">
+          <option value="reuse_existing">优先复用已有未用别名</option>
+          <option value="always_new">始终创建新别名</option>
+        </select>
+      </div>
+      <div class="data-row">
         <span class="data-label">自动删除</span>
         <label class="option-toggle" for="checkbox-auto-delete-icloud">
           <input type="checkbox" id="checkbox-auto-delete-icloud" />

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -562,6 +562,10 @@ const normalizeIcloudHost = window.IcloudUtils?.normalizeIcloudHost
     const normalized = String(value || '').trim().toLowerCase();
     return normalized === 'icloud.com' || normalized === 'icloud.com.cn' ? normalized : '';
   });
+const normalizeIcloudFetchMode = (value) => {
+  const normalized = String(value || '').trim().toLowerCase();
+  return normalized === 'always_new' ? 'always_new' : 'reuse_existing';
+};
 const getIcloudLoginUrlForHost = window.IcloudUtils?.getIcloudLoginUrlForHost
   || ((host) => host === 'icloud.com.cn' ? 'https://www.icloud.com.cn/' : (host === 'icloud.com' ? 'https://www.icloud.com/' : ''));
 
@@ -1644,6 +1648,9 @@ function collectSettingsPayload() {
     !cloudflareTempEmailDomainEditMode ? selectTempEmailDomain.value : tempEmailActiveDomain
   ) || tempEmailActiveDomain;
   const contributionModeEnabled = Boolean(latestState?.contributionMode);
+  const icloudFetchModeRawValue = typeof selectIcloudFetchMode !== 'undefined'
+    ? String(selectIcloudFetchMode?.value || '')
+    : '';
   const mail2925UseAccountPool = typeof inputMail2925UseAccountPool !== 'undefined'
     ? Boolean(inputMail2925UseAccountPool?.checked)
     : Boolean(latestState?.mail2925UseAccountPool);
@@ -1675,6 +1682,9 @@ function collectSettingsPayload() {
       : [],
     autoDeleteUsedIcloudAlias: checkboxAutoDeleteIcloud?.checked,
     icloudHostPreference: selectIcloudHostPreference?.value || 'auto',
+    icloudFetchMode: (icloudFetchModeRawValue.trim().toLowerCase() === 'always_new'
+      ? 'always_new'
+      : 'reuse_existing'),
     ...(contributionModeEnabled ? {} : {
       accountRunHistoryTextEnabled: Boolean(inputAccountRunHistoryTextEnabled?.checked),
       accountRunHistoryHelperBaseUrl: normalizeAccountRunHistoryHelperBaseUrlValue(inputAccountRunHistoryHelperBaseUrl?.value),
@@ -2080,6 +2090,9 @@ function applySettingsState(state) {
     selectIcloudHostPreference.value = String(state?.icloudHostPreference || '').trim().toLowerCase() === 'icloud.com'
       ? 'icloud.com'
       : (String(state?.icloudHostPreference || '').trim().toLowerCase() === 'icloud.com.cn' ? 'icloud.com.cn' : 'auto');
+  }
+  if (selectIcloudFetchMode) {
+    selectIcloudFetchMode.value = normalizeIcloudFetchMode(state?.icloudFetchMode);
   }
   if (checkboxAutoDeleteIcloud) {
     checkboxAutoDeleteIcloud.checked = Boolean(state?.autoDeleteUsedIcloudAlias);
@@ -3396,6 +3409,12 @@ function updateButtonStates() {
   if (btnIcloudRefresh) btnIcloudRefresh.disabled = disableIcloudControls;
   if (btnIcloudDeleteUsed) btnIcloudDeleteUsed.disabled = disableIcloudControls || !hasDeletableUsedIcloudAliases();
   if (selectIcloudHostPreference) selectIcloudHostPreference.disabled = disableIcloudControls;
+  if (selectIcloudFetchMode) {
+    const allowIcloudFetchMode = getSelectedEmailGenerator() === ICLOUD_PROVIDER
+      && !isCustomMailProvider()
+      && !isManagedAliasProvider();
+    selectIcloudFetchMode.disabled = disableIcloudControls || !allowIcloudFetchMode;
+  }
   if (checkboxAutoDeleteIcloud) checkboxAutoDeleteIcloud.disabled = disableIcloudControls;
   if (btnContributionMode) btnContributionMode.disabled = isContributionButtonLocked();
   updateStopButtonState(anyRunning || autoScheduled || isAutoRunPausedPhase() || autoLocked);
@@ -4614,6 +4633,11 @@ selectIcloudHostPreference?.addEventListener('change', () => {
   }
 });
 
+selectIcloudFetchMode?.addEventListener('change', () => {
+  markSettingsDirty(true);
+  saveSettings({ silent: true }).catch(() => { });
+});
+
 checkboxAutoDeleteIcloud?.addEventListener('change', () => {
   markSettingsDirty(true);
   saveSettings({ silent: true }).catch(() => { });
@@ -5182,6 +5206,9 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         selectIcloudHostPreference.value = hostPreference === 'icloud.com'
           ? 'icloud.com'
           : (hostPreference === 'icloud.com.cn' ? 'icloud.com.cn' : 'auto');
+      }
+      if (message.payload.icloudFetchMode !== undefined && selectIcloudFetchMode) {
+        selectIcloudFetchMode.value = normalizeIcloudFetchMode(message.payload.icloudFetchMode);
       }
       if (message.payload.autoRunSkipFailures !== undefined) {
         inputAutoSkipFailures.checked = Boolean(message.payload.autoRunSkipFailures);

--- a/tests/auto-run-step4-restart.test.js
+++ b/tests/auto-run-step4-restart.test.js
@@ -330,3 +330,124 @@ return {
   assert.deepStrictEqual(result.events.steps, [1, 2, 3, 4]);
   assert.equal(result.events.logs.some(({ message }) => /沿用当前邮箱回到步骤 1 重新开始/.test(message)), false);
 });
+
+test('auto-run skips steps 4/5 when step 2 has already marked registration chain as skipped', async () => {
+  const api = new Function(`
+const AUTO_STEP_DELAYS = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0, 9: 0, 10: 0 };
+const LAST_STEP_ID = 10;
+const FINAL_OAUTH_CHAIN_START_STEP = 7;
+const chrome = {
+  tabs: {
+    update: async () => {},
+  },
+  runtime: {
+    sendMessage: async () => {},
+  },
+};
+
+let currentState = {
+  email: 'already@login.example',
+  password: 'Secret123!',
+  mailProvider: 'icloud',
+  stepStatuses: {
+    1: 'pending',
+    2: 'pending',
+    3: 'pending',
+    4: 'pending',
+    5: 'pending',
+    6: 'pending',
+    7: 'pending',
+    8: 'pending',
+    9: 'pending',
+    10: 'pending',
+  },
+};
+const events = {
+  steps: [],
+  logs: [],
+};
+
+async function addLog(message, level = 'info') {
+  events.logs.push({ message, level });
+}
+
+async function ensureAutoEmailReady() {
+  return currentState.email;
+}
+
+async function broadcastAutoRunStatus() {}
+
+async function getState() {
+  return currentState;
+}
+
+async function setState(updates) {
+  currentState = {
+    ...currentState,
+    ...updates,
+    stepStatuses: updates.stepStatuses ? { ...updates.stepStatuses } : currentState.stepStatuses,
+  };
+}
+
+function isStopError(error) {
+  return (error?.message || String(error || '')) === '流程已被用户停止。';
+}
+
+function isStepDoneStatus(status) {
+  return status === 'completed' || status === 'manual_completed' || status === 'skipped';
+}
+
+async function executeStepAndWait(step) {
+  events.steps.push(step);
+  if (step === 2) {
+    currentState = {
+      ...currentState,
+      stepStatuses: {
+        ...currentState.stepStatuses,
+        3: 'skipped',
+        4: 'skipped',
+        5: 'skipped',
+      },
+    };
+  }
+}
+
+async function getTabId() {
+  return 1;
+}
+
+async function invalidateDownstreamAfterStepRestart() {}
+
+function getLoginAuthStateLabel(state) {
+  return state || 'unknown';
+}
+
+function getErrorMessage(error) {
+  return error?.message || String(error || '');
+}
+
+async function getLoginAuthStateFromContent() {
+  return { state: 'password_page', url: 'https://auth.openai.com/log-in' };
+}
+
+${bundle}
+
+return {
+  async run() {
+    await runAutoSequenceFromStep(1, {
+      targetRun: 1,
+      totalRuns: 1,
+      attemptRuns: 1,
+      continued: false,
+    });
+    return { events, currentState };
+  },
+};
+`)();
+
+  const { events } = await api.run();
+
+  assert.deepStrictEqual(events.steps, [1, 2, 6, 7, 8, 9, 10]);
+  assert.equal(events.logs.some(({ message }) => /步骤 4 当前状态为 skipped/.test(message)), true);
+  assert.equal(events.logs.some(({ message }) => /步骤 5 当前状态为 skipped/.test(message)), true);
+});

--- a/tests/background-generated-email-module.test.js
+++ b/tests/background-generated-email-module.test.js
@@ -361,3 +361,55 @@ test('generated email helper requests random subdomain creation while preserving
     domain: 'mail.example.com',
   });
 });
+
+test('generated email helper honors iCloud always-new fetch mode', async () => {
+  const api = loadGeneratedEmailHelpersApi();
+  const icloudOptions = [];
+
+  const helpers = api.createGeneratedEmailHelpers({
+    addLog: async () => {},
+    buildGeneratedAliasEmail: () => {
+      throw new Error('should not build managed alias');
+    },
+    buildCloudflareTempEmailHeaders: () => ({}),
+    CLOUDFLARE_TEMP_EMAIL_GENERATOR: 'cloudflare-temp-email',
+    DUCK_AUTOFILL_URL: 'https://duckduckgo.com/email',
+    fetch: async () => ({ ok: true, text: async () => '{}' }),
+    fetchIcloudHideMyEmail: async (options) => {
+      icloudOptions.push(options);
+      return 'fresh@icloud.example.com';
+    },
+    getCloudflareTempEmailAddressFromResponse: () => '',
+    getCloudflareTempEmailConfig: () => ({ baseUrl: '', adminAuth: '', domain: '' }),
+    getState: async () => ({
+      emailGenerator: 'icloud',
+      icloudFetchMode: 'always_new',
+      mailProvider: 'gmail',
+    }),
+    ensureMail2925AccountForFlow: async () => {
+      throw new Error('should not allocate mail2925 account');
+    },
+    joinCloudflareTempEmailUrl: () => '',
+    normalizeCloudflareDomain: () => '',
+    normalizeCloudflareTempEmailAddress: () => '',
+    normalizeEmailGenerator: (value) => String(value || '').trim().toLowerCase(),
+    isGeneratedAliasProvider: () => false,
+    reuseOrCreateTab: async () => {},
+    sendToContentScript: async () => {
+      throw new Error('should not use duck generator');
+    },
+    setEmailState: async () => {},
+    throwIfStopped: () => {},
+  });
+
+  const email = await helpers.fetchGeneratedEmail({
+    emailGenerator: 'icloud',
+    icloudFetchMode: 'always_new',
+    mailProvider: 'gmail',
+  }, {
+    generator: 'icloud',
+  });
+
+  assert.equal(email, 'fresh@icloud.example.com');
+  assert.deepEqual(icloudOptions, [{ generateNew: true }]);
+});

--- a/tests/background-message-router-step2-skip.test.js
+++ b/tests/background-message-router-step2-skip.test.js
@@ -151,6 +151,25 @@ test('message router does not overwrite a completed step 3 when step 2 is replay
   assert.deepStrictEqual(events.stepStatuses, []);
 });
 
+test('message router skips steps 3/4/5 when step 2 detects already logged-in session', async () => {
+  const { router, events } = createRouter({
+    state: { stepStatuses: { 3: 'pending', 4: 'completed', 5: 'pending' } },
+  });
+
+  await router.handleStepData(2, {
+    email: 'user@example.com',
+    skipRegistrationFlow: true,
+    skippedPasswordStep: true,
+  });
+
+  assert.deepStrictEqual(events.emailStates, ['user@example.com']);
+  assert.deepStrictEqual(events.stepStatuses, [
+    { step: 3, status: 'skipped' },
+    { step: 5, status: 'skipped' },
+  ]);
+  assert.equal(events.logs[0]?.message, '步骤 2：检测到当前已登录会话，已自动跳过步骤 3/4/5，流程将直接进入步骤 6。');
+});
+
 test('message router finalizes step 3 before marking it completed', async () => {
   const { router, events } = createRouter();
 

--- a/tests/background-message-router-step2-skip.test.js
+++ b/tests/background-message-router-step2-skip.test.js
@@ -170,6 +170,20 @@ test('message router skips steps 3/4/5 when step 2 detects already logged-in ses
   assert.equal(events.logs[0]?.message, '步骤 2：检测到当前已登录会话，已自动跳过步骤 3/4/5，流程将直接进入步骤 6。');
 });
 
+test('message router skips step 5 when step 4 reports already logged-in transition', async () => {
+  const { router, events } = createRouter({
+    state: { stepStatuses: { 5: 'pending' } },
+  });
+
+  await router.handleStepData(4, {
+    emailTimestamp: 123,
+    skipProfileStep: true,
+  });
+
+  assert.deepStrictEqual(events.stepStatuses, [{ step: 5, status: 'skipped' }]);
+  assert.equal(events.logs[0]?.message, '步骤 4：检测到账号已直接进入已登录态，已自动跳过步骤 5。');
+});
+
 test('message router finalizes step 3 before marking it completed', async () => {
   const { router, events } = createRouter();
 

--- a/tests/background-signup-step2-branching.test.js
+++ b/tests/background-signup-step2-branching.test.js
@@ -84,6 +84,55 @@ test('step 2 keeps password flow when landing on password page', async () => {
   ]);
 });
 
+test('step 2 falls back to already-logged-in branch when auth entry recovery fails on chatgpt home', async () => {
+  const completedPayloads = [];
+  const logs = [];
+
+  const executor = step2Api.createStep2Executor({
+    addLog: async (message, level = 'info') => {
+      logs.push({ message, level });
+    },
+    chrome: {
+      tabs: {
+        update: async () => {},
+        get: async () => ({ url: 'https://chatgpt.com/' }),
+      },
+    },
+    completeStepFromBackground: async (step, payload) => {
+      completedPayloads.push({ step, payload });
+    },
+    ensureContentScriptReadyOnTab: async () => {},
+    ensureSignupAuthEntryPageReady: async () => {
+      throw new Error('当前页面没有可用的注册入口，也不在邮箱/密码页。URL: https://chatgpt.com/');
+    },
+    ensureSignupEntryPageReady: async () => ({ tabId: 13 }),
+    ensureSignupPostEmailPageReadyInTab: async () => ({
+      state: 'password_page',
+      url: 'https://auth.openai.com/create-account/password',
+    }),
+    getTabId: async () => 13,
+    isTabAlive: async () => true,
+    resolveSignupEmailForFlow: async () => 'user@example.com',
+    sendToContentScriptResilient: async () => ({ submitted: true }),
+    SIGNUP_PAGE_INJECT_FILES: [],
+  });
+
+  await executor.executeStep2({ email: 'user@example.com' });
+
+  assert.equal(completedPayloads.length, 1);
+  assert.deepStrictEqual(completedPayloads[0], {
+    step: 2,
+    payload: {
+      email: 'user@example.com',
+      nextSignupState: 'already_logged_in_home',
+      nextSignupUrl: 'https://chatgpt.com/',
+      skippedPasswordStep: true,
+      skipRegistrationFlow: true,
+    },
+  });
+  assert.ok(logs.some((item) => /已跳过注册链路/.test(item.message)));
+});
+
 test('signup flow helper recognizes email verification page as post-email landing page', async () => {
   let ensureCalls = 0;
   let passwordReadyChecks = 0;

--- a/tests/background-step4-filter-window.test.js
+++ b/tests/background-step4-filter-window.test.js
@@ -119,3 +119,49 @@ test('step 4 does not request a fresh code first for Cloudflare temp mail', asyn
   assert.equal(capturedOptions.requestFreshCodeFirst, false);
   assert.equal(capturedOptions.resendIntervalMs, 25000);
 });
+
+test('step 4 checks iCloud session before polling iCloud mailbox', async () => {
+  let icloudChecks = 0;
+  let resolved = false;
+
+  const executor = api.createStep4Executor({
+    addLog: async () => {},
+    chrome: {
+      tabs: {
+        update: async () => {},
+      },
+    },
+    completeStepFromBackground: async () => {},
+    confirmCustomVerificationStepBypass: async () => {},
+    ensureIcloudMailSession: async () => {
+      icloudChecks += 1;
+    },
+    ensureMail2925MailboxSession: async () => {},
+    getMailConfig: () => ({
+      source: 'icloud-mail',
+      url: 'https://www.icloud.com/mail/',
+      label: 'iCloud 邮箱',
+    }),
+    getTabId: async () => 1,
+    HOTMAIL_PROVIDER: 'hotmail-api',
+    isTabAlive: async () => true,
+    LUCKMAIL_PROVIDER: 'luckmail-api',
+    CLOUDFLARE_TEMP_EMAIL_PROVIDER: 'cloudflare-temp-email',
+    resolveVerificationStep: async () => {
+      resolved = true;
+    },
+    reuseOrCreateTab: async () => {},
+    sendToContentScriptResilient: async () => ({}),
+    shouldUseCustomRegistrationEmail: () => false,
+    STANDARD_MAIL_VERIFICATION_RESEND_INTERVAL_MS: 25000,
+    throwIfStopped: () => {},
+  });
+
+  await executor.executeStep4({
+    email: 'user@example.com',
+    password: 'secret',
+  });
+
+  assert.equal(icloudChecks, 1);
+  assert.equal(resolved, true);
+});

--- a/tests/background-step7-recovery.test.js
+++ b/tests/background-step7-recovery.test.js
@@ -296,3 +296,57 @@ test('step 8 does not rerun step 7 when verification submit lands on add-phone',
   assert.equal(calls.rerunStep7, 0);
   assert.ok(!calls.logs.some(({ message }) => /准备从步骤 7 重新开始/.test(message)));
 });
+
+test('step 8 checks iCloud session before polling iCloud mailbox', async () => {
+  let icloudChecks = 0;
+  let resolved = false;
+
+  const executor = api.createStep8Executor({
+    addLog: async () => {},
+    chrome: {
+      tabs: {
+        update: async () => {},
+      },
+    },
+    CLOUDFLARE_TEMP_EMAIL_PROVIDER: 'cloudflare-temp-email',
+    confirmCustomVerificationStepBypass: async () => {},
+    ensureIcloudMailSession: async () => {
+      icloudChecks += 1;
+    },
+    ensureStep8VerificationPageReady: async () => ({ state: 'verification_page', displayedEmail: '' }),
+    rerunStep7ForStep8Recovery: async () => {},
+    getOAuthFlowRemainingMs: async () => 8000,
+    getOAuthFlowStepTimeoutMs: async (defaultTimeoutMs) => Math.min(defaultTimeoutMs, 8000),
+    getMailConfig: () => ({
+      source: 'icloud-mail',
+      url: 'https://www.icloud.com/mail/',
+      label: 'iCloud 邮箱',
+      navigateOnReuse: true,
+    }),
+    getState: async () => ({ email: 'user@example.com', password: 'secret' }),
+    getTabId: async (sourceName) => (sourceName === 'signup-page' ? 1 : 2),
+    HOTMAIL_PROVIDER: 'hotmail-api',
+    isTabAlive: async () => true,
+    isVerificationMailPollingError: () => false,
+    LUCKMAIL_PROVIDER: 'luckmail-api',
+    resolveVerificationStep: async () => {
+      resolved = true;
+    },
+    reuseOrCreateTab: async () => {},
+    setState: async () => {},
+    setStepStatus: async () => {},
+    shouldUseCustomRegistrationEmail: () => false,
+    STANDARD_MAIL_VERIFICATION_RESEND_INTERVAL_MS: 25000,
+    STEP7_MAIL_POLLING_RECOVERY_MAX_ATTEMPTS: 8,
+    throwIfStopped: () => {},
+  });
+
+  await executor.executeStep8({
+    email: 'user@example.com',
+    password: 'secret',
+    oauthUrl: 'https://oauth.example/latest',
+  });
+
+  assert.equal(icloudChecks, 1);
+  assert.equal(resolved, true);
+});

--- a/tests/step4-split-code-submit.test.js
+++ b/tests/step4-split-code-submit.test.js
@@ -115,6 +115,9 @@ function fillInput(el, value) {
   filledValues.push(value);
 }
 async function sleep() {}
+function isStep5Ready() { return false; }
+function isStep8Ready() { return false; }
+function isAddPhonePageReady() { return false; }
 function isVisibleElement() { return true; }
 function isActionEnabled(el) { return Boolean(el) && !el.disabled; }
 function getActionText(el) { return el.textContent || ''; }

--- a/tests/verification-flow-polling.test.js
+++ b/tests/verification-flow-polling.test.js
@@ -758,3 +758,165 @@ test('verification flow uses configured login resend count for step 8', async ()
   assert.deepStrictEqual(resendSteps, [8, 8]);
   assert.equal(pollCalls, 3);
 });
+
+test('verification flow waits during resend cooldown instead of tight-looping', async () => {
+  const sleepCalls = [];
+  let pollCalls = 0;
+
+  const helpers = api.createVerificationFlowHelpers({
+    addLog: async () => {},
+    chrome: { tabs: { update: async () => {} } },
+    CLOUDFLARE_TEMP_EMAIL_PROVIDER: 'cloudflare-temp-email',
+    completeStepFromBackground: async () => {},
+    confirmCustomVerificationStepBypassRequest: async () => ({ confirmed: true }),
+    getHotmailVerificationPollConfig: () => ({}),
+    getHotmailVerificationRequestTimestamp: () => 0,
+    getState: async () => ({}),
+    getTabId: async () => 1,
+    HOTMAIL_PROVIDER: 'hotmail-api',
+    isStopError: () => false,
+    LUCKMAIL_PROVIDER: 'luckmail-api',
+    MAIL_2925_VERIFICATION_INTERVAL_MS: 15000,
+    MAIL_2925_VERIFICATION_MAX_ATTEMPTS: 15,
+    pollCloudflareTempEmailVerificationCode: async () => ({}),
+    pollHotmailVerificationCode: async () => ({}),
+    pollLuckmailVerificationCode: async () => ({}),
+    sendToContentScript: async () => ({}),
+    sendToMailContentScriptResilient: async (_mail, message) => {
+      if (message.type !== 'POLL_EMAIL') {
+        return {};
+      }
+      pollCalls += 1;
+      return pollCalls === 1
+        ? {}
+        : { code: '654321', emailTimestamp: 123 };
+    },
+    setState: async () => {},
+    setStepStatus: async () => {},
+    sleepWithStop: async (ms) => {
+      sleepCalls.push(ms);
+    },
+    throwIfStopped: () => {},
+    VERIFICATION_POLL_MAX_ROUNDS: 5,
+  });
+
+  const result = await helpers.pollFreshVerificationCodeWithResendInterval(
+    4,
+    {
+      email: 'user@example.com',
+      lastSignupCode: null,
+    },
+    { provider: 'qq', label: 'QQ 邮箱' },
+    {
+      maxResendRequests: 0,
+      resendIntervalMs: 25000,
+      lastResendAt: Date.now(),
+    }
+  );
+
+  assert.equal(result.code, '654321');
+  assert.equal(pollCalls, 2);
+  assert.ok(sleepCalls.length >= 1);
+  assert.ok(sleepCalls[0] >= 1000);
+});
+
+test('verification flow uses resilient signup-page transport when submitting verification code', async () => {
+  const resilientCalls = [];
+
+  const helpers = api.createVerificationFlowHelpers({
+    addLog: async () => {},
+    chrome: {
+      tabs: {
+        update: async () => {},
+      },
+    },
+    CLOUDFLARE_TEMP_EMAIL_PROVIDER: 'cloudflare-temp-email',
+    completeStepFromBackground: async () => {},
+    confirmCustomVerificationStepBypassRequest: async () => ({ confirmed: true }),
+    getHotmailVerificationPollConfig: () => ({}),
+    getHotmailVerificationRequestTimestamp: () => 0,
+    getState: async () => ({}),
+    getTabId: async () => 1,
+    HOTMAIL_PROVIDER: 'hotmail-api',
+    isStopError: () => false,
+    LUCKMAIL_PROVIDER: 'luckmail-api',
+    MAIL_2925_VERIFICATION_INTERVAL_MS: 15000,
+    MAIL_2925_VERIFICATION_MAX_ATTEMPTS: 15,
+    pollCloudflareTempEmailVerificationCode: async () => ({}),
+    pollHotmailVerificationCode: async () => ({}),
+    pollLuckmailVerificationCode: async () => ({}),
+    sendToContentScript: async () => {
+      throw new Error('should not use non-resilient channel');
+    },
+    sendToContentScriptResilient: async (_source, message, options) => {
+      resilientCalls.push({ message, options });
+      return { success: true };
+    },
+    sendToMailContentScriptResilient: async () => ({}),
+    setState: async () => {},
+    setStepStatus: async () => {},
+    sleepWithStop: async () => {},
+    throwIfStopped: () => {},
+    VERIFICATION_POLL_MAX_ROUNDS: 5,
+  });
+
+  const result = await helpers.submitVerificationCode(4, '654321');
+
+  assert.deepStrictEqual(result, { success: true });
+  assert.equal(resilientCalls.length, 1);
+  assert.equal(resilientCalls[0].message.type, 'FILL_CODE');
+  assert.equal(resilientCalls[0].message.payload.code, '654321');
+  assert.ok(resilientCalls[0].options.timeoutMs >= 30000);
+});
+
+test('verification flow treats retryable submit transport failure as success when step 4 already redirected to logged-in home', async () => {
+  const logs = [];
+
+  const helpers = api.createVerificationFlowHelpers({
+    addLog: async (message, level = 'info') => {
+      logs.push({ message, level });
+    },
+    chrome: {
+      tabs: {
+        update: async () => {},
+        get: async () => ({ url: 'https://chatgpt.com/' }),
+      },
+    },
+    CLOUDFLARE_TEMP_EMAIL_PROVIDER: 'cloudflare-temp-email',
+    completeStepFromBackground: async () => {},
+    confirmCustomVerificationStepBypassRequest: async () => ({ confirmed: true }),
+    getHotmailVerificationPollConfig: () => ({}),
+    getHotmailVerificationRequestTimestamp: () => 0,
+    getState: async () => ({}),
+    getTabId: async () => 1,
+    HOTMAIL_PROVIDER: 'hotmail-api',
+    isRetryableContentScriptTransportError: (error) => /message channel is closed/i.test(String(error?.message || error || '')),
+    isStopError: () => false,
+    LUCKMAIL_PROVIDER: 'luckmail-api',
+    MAIL_2925_VERIFICATION_INTERVAL_MS: 15000,
+    MAIL_2925_VERIFICATION_MAX_ATTEMPTS: 15,
+    pollCloudflareTempEmailVerificationCode: async () => ({}),
+    pollHotmailVerificationCode: async () => ({}),
+    pollLuckmailVerificationCode: async () => ({}),
+    sendToContentScript: async () => {
+      throw new Error('should not use non-resilient channel');
+    },
+    sendToContentScriptResilient: async () => {
+      throw new Error('The page keeping the extension port is moved into back/forward cache, so the message channel is closed.');
+    },
+    sendToMailContentScriptResilient: async () => ({}),
+    setState: async () => {},
+    setStepStatus: async () => {},
+    sleepWithStop: async () => {},
+    throwIfStopped: () => {},
+    VERIFICATION_POLL_MAX_ROUNDS: 5,
+  });
+
+  const result = await helpers.submitVerificationCode(4, '654321');
+
+  assert.equal(result.success, true);
+  assert.equal(result.skipProfileStep, true);
+  assert.equal(result.assumed, true);
+  assert.equal(result.transportRecovered, true);
+  assert.equal(logs.some(({ message }) => /验证码提交后页面已切换到ChatGPT 已登录首页/.test(message)), true);
+});

--- a/项目文件结构说明.md
+++ b/项目文件结构说明.md
@@ -44,7 +44,7 @@
 - `background/account-run-history.js`：邮箱记录模块，负责以邮箱为主键维护最新记录（同邮箱后续状态覆盖），在步骤 2 设定邮箱后支持先写入“停止/未完成”占位状态，统一归一化成功/失败/停止三态并落地到 `chrome.storage.local`，支持清理记录，并在启用独立本地同步配置后把完整快照同步到本地 helper。
 - `background/auto-run-controller.js`：自动运行主控制器，封装多轮执行、重试、轮次摘要、线程间隔与倒计时恢复逻辑；当前自动流程会绑定 `autoRunSessionId`，手动停止后旧的倒计时计划、旧重试链路和旧恢复入口不会再复活已失效的自动运行；fresh-attempt reset 时会额外保留 `gmailBaseEmail`、`mail2925BaseEmail` 与当前 2925 账号选择，避免自动流程重置后丢失别名基邮箱与 2925 切号上下文。
 - `background/contribution-oauth.js`：贡献模式的公开 OAuth 流程模块，负责调用 `apikey.qzz.io` 的公开贡献接口、保存贡献会话运行态、在主 10 步流程里为步骤 7 提供贡献登录地址、在步骤 9/10 衔接 callback 捕获与兼容提交 `/oauth/api/submit-callback`，并把真实服务端状态映射回 sidepanel 运行态。
-- `background/generated-email-helpers.js`：生成邮箱辅助层，除了 Duck / Cloudflare / iCloud / Cloudflare Temp Email，也统一承接 Gmail / 2925 的别名邮箱生成入口与自定义邮箱池读取；当 provider 为 2925 且 `mail2925Mode = provide` 时，会先确保当前账号池里已有可用账号，再基于该账号生成别名邮箱；若 `mail2925Mode = receive`，则会回退到普通邮箱生成链路；当生成方式为 `custom-pool` 时，会按当前目标轮次读取邮箱池中的对应邮箱。
+- `background/generated-email-helpers.js`：生成邮箱辅助层，除了 Duck / Cloudflare / iCloud / Cloudflare Temp Email，也统一承接 Gmail / 2925 的别名邮箱生成入口与自定义邮箱池读取；当 provider 为 2925 且 `mail2925Mode = provide` 时，会先确保当前账号池里已有可用账号，再基于该账号生成别名邮箱；若 `mail2925Mode = receive`，则会回退到普通邮箱生成链路；当生成方式为 iCloud 且 `icloudFetchMode = always_new` 时，会强制跳过未用别名复用并新建别名；当生成方式为 `custom-pool` 时，会按当前目标轮次读取邮箱池中的对应邮箱。
 - `background/logging-status.js`：后台日志、步骤状态、错误信息和若干状态判断的公共工具层；当前额外承接 `add-phone / 手机号页` 这类认证 fatal 错误的共享判定。
 - `background/mail-2925-session.js`：2925 会话模块，负责 2925 账号池持久化、当前账号切换、cookie 清理登出、自动登录、命中“子邮箱已达上限邮箱”后的 24 小时禁用与自动切号。
 - `background/message-router.js`：后台消息路由层，负责处理 `chrome.runtime.onMessage` 进入的所有业务消息；当前额外接入 2925 账号池的新增、导入、切换、登录、禁用与删除消息。
@@ -141,7 +141,7 @@
 - `tests/background-account-history-settings.test.js`：测试账号运行历史的独立配置项归一化，不再复用 Hotmail 模式作为启停条件。
 - `tests/background-contribution-mode.test.js`：测试贡献模式的后台运行态与公开 OAuth 接入，覆盖 `contributionMode` 只存在于运行态、`SET_CONTRIBUTION_MODE / POLL_CONTRIBUTION_STATUS` 消息接入、reset 保留贡献运行态，以及 callback 自动提交在“无需手动提交”场景下的兼容处理。
 - `tests/background-custom-email-pool.test.js`：测试后台对自定义邮箱池生成方式，以及自定义邮箱服务号池的归一化、标签文案和按轮次取邮箱逻辑。
-- `tests/background-generated-email-module.test.js`：测试生成邮箱辅助模块已接入且导出工厂。
+- `tests/background-generated-email-module.test.js`：测试生成邮箱辅助模块已接入且导出工厂，并覆盖 2925 receive 模式回退普通邮箱生成、自定义邮箱池按轮次取值、2925 provide 模式账号池预热，以及 iCloud `always_new` 传参。
 - `tests/background-icloud.test.js`：测试 iCloud 相关后台纯函数与别名收尾逻辑。
 - `tests/background-icloud-mail-provider.test.js`：测试 iCloud 邮箱 provider 配置解析。
 - `tests/background-logging-status-module.test.js`：测试日志 / 状态模块已接入且导出工厂。


### PR DESCRIPTION
## 背景
本 PR 基于 **Pro7.5 (`master`)** 主线，聚焦修复 iCloud 与已登录会话下的流程稳定性问题，目标是减少误回滚、误重试和“看起来卡死”的情况。

## 变更概览
本次改动集中在以下 4 条主线：
1. iCloud 获取策略与登录态校验
2. Step2 已登录分支与跳步一致性
3. Step4 验证码提交后的通道中断恢复
4. Auto-run 对已完成/已跳过步骤的执行一致性

## 详细改动

### 1) iCloud：旧号优先 / 新建策略 + 登录态确认
- 侧边栏新增 iCloud 获取策略：
  - `优先复用已有未用别名`（默认）
  - `始终创建新别名`
- 取号逻辑按该策略生效（iCloud provider）。
- 在步骤 4/8 轮询 iCloud 邮箱前，先执行 iCloud 会话确认，避免未登录状态继续轮询导致流程假卡住。

涉及文件：
- `sidepanel/sidepanel.html`
- `sidepanel/sidepanel.js`
- `background.js`
- `background/generated-email-helpers.js`
- `background/steps/fetch-signup-code.js`
- `background/steps/fetch-login-code.js`

### 2) Step2：已登录会话分支修复
- 当步骤 2 识别到当前会话已登录 ChatGPT 时，统一标记跳过注册链路步骤 3/4/5，并直接进入步骤 6。
- 增加入口恢复兜底：若认证入口恢复失败但当前页已是登录态主页，直接走已登录分支，不再反复失败重试。

涉及文件：
- `background/steps/submit-signup-email.js`
- `background/message-router.js`
- `background.js`

### 3) Step4：验证码提交后“通道断开”恢复
- Step4 填码提交改为 resilient 通信。
- 对可重试传输错误（如 `message channel closed` / bfcache）增加页面状态兜底判断：
  - 若页面已切换到 ChatGPT 首页或 profile 阶段，则按提交成功继续。
- 当 Step4 判定已直接进入登录态时，自动跳过步骤 5。

涉及文件：
- `background/verification-flow.js`
- `background/message-router.js`
- `content/signup-page.js`

### 4) Auto-run 一致性修复
- 自动运行循环中，若步骤状态已是 `skipped/completed/manual_completed`，则直接跳过，避免重复执行已跳过步骤（例如 4/5）。

涉及文件：
- `background.js`
- `tests/auto-run-step4-restart.test.js`

## 测试
- 执行：`npm test`
- 结果：`371 passed, 0 failed`
- 并补充了与本次改动对应的回归用例（Step2 跳步、Step4 提交恢复、iCloud 会话检查与取号策略）。
