### PR TITLE
feat: support icloud forward mailbox provider config

### DIFF
--- a/background.js
+++ b/background.js
@@ -279,6 +279,8 @@ const PERSISTED_SETTING_DEFAULTS = {
   customEmailPool: [],
   autoDeleteUsedIcloudAlias: false,
   icloudHostPreference: 'auto',
+  icloudTargetMailboxType: 'icloud-inbox',
+  icloudForwardMailProvider: 'qq',
   icloudFetchMode: 'reuse_existing',
   accountRunHistoryTextEnabled: true,
   accountRunHistoryHelperBaseUrl: DEFAULT_ACCOUNT_RUN_HISTORY_HELPER_BASE_URL,
@@ -692,6 +694,19 @@ function normalizeIcloudFetchMode(value = '') {
   return normalized === 'always_new' ? 'always_new' : 'reuse_existing';
 }
 
+function normalizeIcloudTargetMailboxType(value = '') {
+  return String(value || '').trim().toLowerCase() === 'forward-mailbox'
+    ? 'forward-mailbox'
+    : 'icloud-inbox';
+}
+
+function normalizeIcloudForwardMailProvider(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  return ['qq', '163', '163-vip', '126', 'gmail'].includes(normalized)
+    ? normalized
+    : 'qq';
+}
+
 function normalizeCustomEmailPool(value = []) {
   const source = Array.isArray(value)
     ? value
@@ -1002,6 +1017,10 @@ function normalizePersistentSettingValue(key, value) {
       return Boolean(value);
     case 'icloudHostPreference':
       return normalizeIcloudHost(value) || 'auto';
+    case 'icloudTargetMailboxType':
+      return normalizeIcloudTargetMailboxType(value);
+    case 'icloudForwardMailProvider':
+      return normalizeIcloudForwardMailProvider(value);
     case 'icloudFetchMode':
       return normalizeIcloudFetchMode(value);
     case 'accountRunHistoryHelperBaseUrl':
@@ -6875,6 +6894,29 @@ async function executeStep3(state) {
 // Step 4: Get Signup Verification Code (qq-mail.js polls, then fills in signup-page.js)
 // ============================================================
 
+function getIcloudForwardMailConfig(state = {}, provider = 'qq') {
+  const normalizedProvider = normalizeIcloudForwardMailProvider(provider);
+  if (normalizedProvider === GMAIL_PROVIDER) {
+    return {
+      source: 'gmail-mail',
+      url: 'https://mail.google.com/mail/u/0/#inbox',
+      label: 'Gmail 邮箱',
+      inject: ['content/activation-utils.js', 'content/utils.js', 'content/gmail-mail.js'],
+      injectSource: 'gmail-mail',
+    };
+  }
+  if (normalizedProvider === '163') {
+    return { source: 'mail-163', url: 'https://mail.163.com/js6/main.jsp?df=mail163_letter#module=mbox.ListModule%7C%7B%22fid%22%3A1%2C%22order%22%3A%22date%22%2C%22desc%22%3Atrue%7D', label: '163 邮箱' };
+  }
+  if (normalizedProvider === '163-vip') {
+    return { source: 'mail-163', url: 'https://webmail.vip.163.com/js6/main.jsp?df=mail163_letter#module=mbox.ListModule%7C%7B%22fid%22%3A1%2C%22order%22%3A%22date%22%2C%22desc%22%3Atrue%7D', label: '163 VIP 邮箱' };
+  }
+  if (normalizedProvider === '126') {
+    return { source: 'mail-163', url: 'https://mail.126.com/js6/main.jsp?df=mail163_letter#module=mbox.ListModule%7C%7B%22fid%22%3A1%2C%22order%22%3A%22date%22%2C%22desc%22%3Atrue%7D', label: '126 邮箱' };
+  }
+  return { source: 'qq-mail', url: 'https://wx.mail.qq.com/', label: 'QQ 邮箱' };
+}
+
 function getMailConfig(state) {
   const provider = state.mailProvider || 'qq';
   if (provider === 'custom') {
@@ -6887,6 +6929,17 @@ function getMailConfig(state) {
     const configuredHost = getConfiguredIcloudHostPreference(state)
       || normalizeIcloudHost(state?.preferredIcloudHost)
       || 'icloud.com';
+    const targetMailboxType = normalizeIcloudTargetMailboxType(state?.icloudTargetMailboxType);
+    const useForwardMailbox = configuredHost === 'icloud.com.cn' || targetMailboxType === 'forward-mailbox';
+    if (useForwardMailbox) {
+      const forwardProvider = normalizeIcloudForwardMailProvider(state?.icloudForwardMailProvider);
+      const forwardConfig = getIcloudForwardMailConfig(state, forwardProvider);
+      return {
+        ...forwardConfig,
+        label: `iCloud 转发（${forwardConfig.label}）`,
+        icloudForwarding: true,
+      };
+    }
     const loginUrl = getIcloudLoginUrlForHost(configuredHost) || 'https://www.icloud.com/';
     const mailUrl = getIcloudMailUrlForHost(configuredHost) || loginUrl;
     return {

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -663,6 +663,23 @@
           <option value="icloud.com.cn">iCloud.com.cn</option>
         </select>
       </div>
+      <div class="data-row" id="row-icloud-target-mailbox-type">
+        <span class="data-label">目标邮箱类型</span>
+        <select id="select-icloud-target-mailbox-type" class="data-select">
+          <option value="icloud-inbox">iCloud 收件箱</option>
+          <option value="forward-mailbox">转发到其他邮箱</option>
+        </select>
+      </div>
+      <div class="data-row" id="row-icloud-forward-mail-provider" style="display:none;">
+        <span class="data-label">转发邮箱</span>
+        <select id="select-icloud-forward-mail-provider" class="data-select">
+          <option value="qq">QQ 邮箱</option>
+          <option value="163">163 邮箱</option>
+          <option value="163-vip">163 VIP 邮箱</option>
+          <option value="126">126 邮箱</option>
+          <option value="gmail">Gmail 邮箱</option>
+        </select>
+      </div>
       <div class="data-row">
         <span class="data-label">获取策略</span>
         <select id="select-icloud-fetch-mode" class="data-select">

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -140,6 +140,10 @@ const btnIcloudLoginDone = document.getElementById('btn-icloud-login-done');
 const btnIcloudRefresh = document.getElementById('btn-icloud-refresh');
 const btnIcloudDeleteUsed = document.getElementById('btn-icloud-delete-used');
 const selectIcloudHostPreference = document.getElementById('select-icloud-host-preference');
+const rowIcloudTargetMailboxType = document.getElementById('row-icloud-target-mailbox-type');
+const selectIcloudTargetMailboxType = document.getElementById('select-icloud-target-mailbox-type');
+const rowIcloudForwardMailProvider = document.getElementById('row-icloud-forward-mail-provider');
+const selectIcloudForwardMailProvider = document.getElementById('select-icloud-forward-mail-provider');
 const selectIcloudFetchMode = document.getElementById('select-icloud-fetch-mode');
 const checkboxAutoDeleteIcloud = document.getElementById('checkbox-auto-delete-icloud');
 const inputIcloudSearch = document.getElementById('input-icloud-search');
@@ -577,6 +581,17 @@ const normalizeIcloudHost = window.IcloudUtils?.normalizeIcloudHost
 const normalizeIcloudFetchMode = (value) => {
   const normalized = String(value || '').trim().toLowerCase();
   return normalized === 'always_new' ? 'always_new' : 'reuse_existing';
+};
+const normalizeIcloudTargetMailboxType = (value) => {
+  return String(value || '').trim().toLowerCase() === 'forward-mailbox'
+    ? 'forward-mailbox'
+    : 'icloud-inbox';
+};
+const normalizeIcloudForwardMailProvider = (value) => {
+  const normalized = String(value || '').trim().toLowerCase();
+  return ['qq', '163', '163-vip', '126', 'gmail'].includes(normalized)
+    ? normalized
+    : 'qq';
 };
 const getIcloudLoginUrlForHost = window.IcloudUtils?.getIcloudLoginUrlForHost
   || ((host) => host === 'icloud.com.cn' ? 'https://www.icloud.com.cn/' : (host === 'icloud.com' ? 'https://www.icloud.com/' : ''));
@@ -1666,6 +1681,22 @@ function collectSettingsPayload() {
   const icloudFetchModeRawValue = typeof selectIcloudFetchMode !== 'undefined'
     ? String(selectIcloudFetchMode?.value || '')
     : '';
+  const icloudTargetMailboxTypeValue = typeof selectIcloudTargetMailboxType !== 'undefined'
+    ? selectIcloudTargetMailboxType?.value
+    : '';
+  const icloudForwardMailProviderValue = typeof selectIcloudForwardMailProvider !== 'undefined'
+    ? selectIcloudForwardMailProvider?.value
+    : '';
+  const normalizedIcloudTargetMailboxType = typeof normalizeIcloudTargetMailboxType === 'function'
+    ? normalizeIcloudTargetMailboxType(icloudTargetMailboxTypeValue)
+    : (String(icloudTargetMailboxTypeValue || '').trim().toLowerCase() === 'forward-mailbox'
+      ? 'forward-mailbox'
+      : 'icloud-inbox');
+  const normalizedIcloudForwardMailProvider = typeof normalizeIcloudForwardMailProvider === 'function'
+    ? normalizeIcloudForwardMailProvider(icloudForwardMailProviderValue)
+    : (['qq', '163', '163-vip', '126', 'gmail'].includes(String(icloudForwardMailProviderValue || '').trim().toLowerCase())
+      ? String(icloudForwardMailProviderValue || '').trim().toLowerCase()
+      : 'qq');
   const mail2925UseAccountPool = typeof inputMail2925UseAccountPool !== 'undefined'
     ? Boolean(inputMail2925UseAccountPool?.checked)
     : Boolean(latestState?.mail2925UseAccountPool);
@@ -1706,6 +1737,8 @@ function collectSettingsPayload() {
       : [],
     autoDeleteUsedIcloudAlias: checkboxAutoDeleteIcloud?.checked,
     icloudHostPreference: selectIcloudHostPreference?.value || 'auto',
+    icloudTargetMailboxType: normalizedIcloudTargetMailboxType,
+    icloudForwardMailProvider: normalizedIcloudForwardMailProvider,
     icloudFetchMode: (icloudFetchModeRawValue.trim().toLowerCase() === 'always_new'
       ? 'always_new'
       : 'reuse_existing'),
@@ -2204,6 +2237,12 @@ function applySettingsState(state) {
   }
   if (selectIcloudFetchMode) {
     selectIcloudFetchMode.value = normalizeIcloudFetchMode(state?.icloudFetchMode);
+  }
+  if (selectIcloudTargetMailboxType) {
+    selectIcloudTargetMailboxType.value = normalizeIcloudTargetMailboxType(state?.icloudTargetMailboxType);
+  }
+  if (selectIcloudForwardMailProvider) {
+    selectIcloudForwardMailProvider.value = normalizeIcloudForwardMailProvider(state?.icloudForwardMailProvider);
   }
   if (checkboxAutoDeleteIcloud) {
     checkboxAutoDeleteIcloud.checked = Boolean(state?.autoDeleteUsedIcloudAlias);
@@ -3109,6 +3148,21 @@ function updateMailLoginButtonState() {
 }
 
 function updateMailProviderUI() {
+  const normalizeIcloudHostValue = typeof normalizeIcloudHost === 'function'
+    ? normalizeIcloudHost
+    : ((value) => {
+      const normalized = String(value || '').trim().toLowerCase();
+      return normalized === 'icloud.com' || normalized === 'icloud.com.cn' ? normalized : '';
+    });
+  const icloudTargetMailboxTypeValue = typeof selectIcloudTargetMailboxType !== 'undefined'
+    ? selectIcloudTargetMailboxType?.value
+    : latestState?.icloudTargetMailboxType;
+  const icloudForwardMailProviderValue = typeof selectIcloudForwardMailProvider !== 'undefined'
+    ? selectIcloudForwardMailProvider?.value
+    : latestState?.icloudForwardMailProvider;
+  const icloudHostPreferenceValue = typeof selectIcloudHostPreference !== 'undefined'
+    ? selectIcloudHostPreference?.value
+    : latestState?.icloudHostPreference;
   const use2925 = selectMailProvider.value === '2925';
   const useGmail = selectMailProvider.value === GMAIL_PROVIDER;
   const useMail2925 = selectMailProvider.value === '2925';
@@ -3170,6 +3224,19 @@ function updateMailProviderUI() {
   const showCloudflareDomain = useEmailGenerator && useCloudflare;
   const showCloudflareTempEmailSettings = useCloudflareTempEmailProvider || (useEmailGenerator && useCloudflareTempEmailGenerator);
   const showCloudflareTempEmailReceiveMailbox = useCloudflareTempEmailProvider && !useCloudflareTempEmailGenerator;
+  const selectedIcloudHost = typeof getSelectedIcloudHostPreference === 'function'
+    ? getSelectedIcloudHostPreference()
+    : (normalizeIcloudHostValue(icloudHostPreferenceValue || latestState?.icloudHostPreference || '')
+      || normalizeIcloudHostValue(latestState?.preferredIcloudHost)
+      || 'icloud.com');
+  const icloudTargetMailboxType = typeof normalizeIcloudTargetMailboxType === 'function'
+    ? normalizeIcloudTargetMailboxType(icloudTargetMailboxTypeValue)
+    : (String(icloudTargetMailboxTypeValue || '').trim().toLowerCase() === 'forward-mailbox'
+      ? 'forward-mailbox'
+      : 'icloud-inbox');
+  const isIcloudComCnHost = selectedIcloudHost === 'icloud.com.cn';
+  const showIcloudTargetMailboxType = useIcloudProvider;
+  const showIcloudForwardMailProvider = useIcloudProvider && (icloudTargetMailboxType === 'forward-mailbox' || isIcloudComCnHost);
   const showCloudflareTempEmailRandomSubdomainToggle = useEmailGenerator && useCloudflareTempEmailGenerator;
   const showCloudflareTempEmailDomain = useEmailGenerator && useCloudflareTempEmailGenerator;
   if (rowEmailGenerator) {
@@ -3190,6 +3257,12 @@ function updateMailProviderUI() {
     if (!showIcloudSection) {
       hideIcloudLoginHelp();
     }
+  }
+  if (typeof rowIcloudTargetMailboxType !== 'undefined' && rowIcloudTargetMailboxType) {
+    rowIcloudTargetMailboxType.style.display = showIcloudTargetMailboxType ? '' : 'none';
+  }
+  if (typeof rowIcloudForwardMailProvider !== 'undefined' && rowIcloudForwardMailProvider) {
+    rowIcloudForwardMailProvider.style.display = showIcloudForwardMailProvider ? '' : 'none';
   }
   rowCfDomain.style.display = showCloudflareDomain ? '' : 'none';
   const { domains } = getCloudflareDomainsFromState();
@@ -3305,6 +3378,15 @@ function updateMailProviderUI() {
   }
   if (autoHintText && showCloudflareTempEmailRandomSubdomainToggle && inputTempEmailUseRandomSubdomain?.checked) {
     autoHintText.textContent = '已启用随机子域名：扩展会按当前选中的 Temp 域名提交，并额外携带 enableRandomSubdomain；是否生效取决于后端 RANDOM_SUBDOMAIN_DOMAINS 配置。';
+  }
+  if (autoHintText && useIcloudProvider && showIcloudForwardMailProvider) {
+    const forwardProvider = typeof normalizeIcloudForwardMailProvider === 'function'
+      ? normalizeIcloudForwardMailProvider(icloudForwardMailProviderValue)
+      : (['qq', '163', '163-vip', '126', 'gmail'].includes(String(icloudForwardMailProviderValue || '').trim().toLowerCase())
+        ? String(icloudForwardMailProviderValue || '').trim().toLowerCase()
+        : 'qq');
+    const forwardProviderLabel = MAIL_PROVIDER_LOGIN_CONFIGS[forwardProvider]?.label || '目标邮箱';
+    autoHintText.textContent = `iCloud ${isIcloudComCnHost ? 'com.cn' : ''} 当前使用转发收码：第 4/8 步会从 ${forwardProviderLabel} 轮询验证码。`;
   }
   if (useHotmail) {
     inputEmail.value = getCurrentHotmailEmail();
@@ -3451,6 +3533,18 @@ function updateButtonStates() {
   const anyRunning = Object.values(statuses).some(s => s === 'running');
   const autoLocked = isAutoRunLockedPhase();
   const autoScheduled = isAutoRunScheduledPhase();
+  const normalizeIcloudHostValue = typeof normalizeIcloudHost === 'function'
+    ? normalizeIcloudHost
+    : ((value) => {
+      const normalized = String(value || '').trim().toLowerCase();
+      return normalized === 'icloud.com' || normalized === 'icloud.com.cn' ? normalized : '';
+    });
+  const icloudTargetMailboxTypeValue = typeof selectIcloudTargetMailboxType !== 'undefined'
+    ? selectIcloudTargetMailboxType?.value
+    : latestState?.icloudTargetMailboxType;
+  const icloudHostPreferenceValue = typeof selectIcloudHostPreference !== 'undefined'
+    ? selectIcloudHostPreference?.value
+    : latestState?.icloudHostPreference;
 
   for (const step of STEP_IDS) {
     const btn = document.querySelector(`.step-btn[data-step="${step}"]`);
@@ -3500,6 +3594,25 @@ function updateButtonStates() {
   if (btnIcloudRefresh) btnIcloudRefresh.disabled = disableIcloudControls;
   if (btnIcloudDeleteUsed) btnIcloudDeleteUsed.disabled = disableIcloudControls || !hasDeletableUsedIcloudAliases();
   if (selectIcloudHostPreference) selectIcloudHostPreference.disabled = disableIcloudControls;
+  if (typeof selectIcloudTargetMailboxType !== 'undefined' && selectIcloudTargetMailboxType) {
+    selectIcloudTargetMailboxType.disabled = disableIcloudControls;
+  }
+  if (typeof selectIcloudForwardMailProvider !== 'undefined' && selectIcloudForwardMailProvider) {
+    const normalizedIcloudTargetMailboxType = typeof normalizeIcloudTargetMailboxType === 'function'
+      ? normalizeIcloudTargetMailboxType(icloudTargetMailboxTypeValue)
+      : (String(icloudTargetMailboxTypeValue || '').trim().toLowerCase() === 'forward-mailbox'
+        ? 'forward-mailbox'
+        : 'icloud-inbox');
+    const currentIcloudHostPreference = typeof getSelectedIcloudHostPreference === 'function'
+      ? getSelectedIcloudHostPreference()
+      : (normalizeIcloudHostValue(icloudHostPreferenceValue || latestState?.icloudHostPreference || '')
+        || normalizeIcloudHostValue(latestState?.preferredIcloudHost)
+        || 'icloud.com');
+    const allowIcloudForwardMailProvider = isIcloudMailProvider()
+      && (normalizedIcloudTargetMailboxType === 'forward-mailbox'
+        || currentIcloudHostPreference === 'icloud.com.cn');
+    selectIcloudForwardMailProvider.disabled = disableIcloudControls || !allowIcloudForwardMailProvider;
+  }
   if (selectIcloudFetchMode) {
     const allowIcloudFetchMode = getSelectedEmailGenerator() === ICLOUD_PROVIDER
       && !isCustomMailProvider()
@@ -4718,11 +4831,24 @@ selectEmailGenerator.addEventListener('change', () => {
 });
 
 selectIcloudHostPreference?.addEventListener('change', () => {
+  updateMailProviderUI();
   markSettingsDirty(true);
   saveSettings({ silent: true }).catch(() => { });
   if (getSelectedEmailGenerator() === 'icloud') {
     queueIcloudAliasRefresh();
   }
+});
+
+selectIcloudTargetMailboxType?.addEventListener('change', () => {
+  updateMailProviderUI();
+  markSettingsDirty(true);
+  saveSettings({ silent: true }).catch(() => { });
+});
+
+selectIcloudForwardMailProvider?.addEventListener('change', () => {
+  updateMailProviderUI();
+  markSettingsDirty(true);
+  saveSettings({ silent: true }).catch(() => { });
 });
 
 selectIcloudFetchMode?.addEventListener('change', () => {
@@ -5309,6 +5435,15 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         selectIcloudHostPreference.value = hostPreference === 'icloud.com'
           ? 'icloud.com'
           : (hostPreference === 'icloud.com.cn' ? 'icloud.com.cn' : 'auto');
+        updateMailProviderUI();
+      }
+      if (message.payload.icloudTargetMailboxType !== undefined && selectIcloudTargetMailboxType) {
+        selectIcloudTargetMailboxType.value = normalizeIcloudTargetMailboxType(message.payload.icloudTargetMailboxType);
+        updateMailProviderUI();
+      }
+      if (message.payload.icloudForwardMailProvider !== undefined && selectIcloudForwardMailProvider) {
+        selectIcloudForwardMailProvider.value = normalizeIcloudForwardMailProvider(message.payload.icloudForwardMailProvider);
+        updateMailProviderUI();
       }
       if (message.payload.icloudFetchMode !== undefined && selectIcloudFetchMode) {
         selectIcloudFetchMode.value = normalizeIcloudFetchMode(message.payload.icloudFetchMode);

--- a/tests/background-icloud-mail-provider.test.js
+++ b/tests/background-icloud-mail-provider.test.js
@@ -69,7 +69,7 @@ return { normalizeMailProvider };
 });
 
 test('getMailConfig returns icloud mail tab config with host preference', () => {
-  const bundle = extractFunction('getMailConfig');
+  const bundle = `${extractFunction('getIcloudForwardMailConfig')}\n${extractFunction('getMailConfig')}`;
   const api = new Function(`
 const ICLOUD_PROVIDER = 'icloud';
 const GMAIL_PROVIDER = 'gmail';
@@ -91,23 +91,30 @@ function getIcloudLoginUrlForHost(host) {
 function getIcloudMailUrlForHost(host) {
   return host === 'icloud.com.cn' ? 'https://www.icloud.com.cn/mail/' : 'https://www.icloud.com/mail/';
 }
+function normalizeIcloudTargetMailboxType(value = '') {
+  return String(value || '').trim().toLowerCase() === 'forward-mailbox' ? 'forward-mailbox' : 'icloud-inbox';
+}
+function normalizeIcloudForwardMailProvider(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  return ['qq', '163', '163-vip', '126', 'gmail'].includes(normalized) ? normalized : 'qq';
+}
 ${bundle}
 return { getMailConfig };
 `)();
 
   assert.deepEqual(api.getMailConfig({
     mailProvider: 'icloud',
-    icloudHostPreference: 'icloud.com.cn',
+    icloudHostPreference: 'icloud.com',
   }), {
     source: 'icloud-mail',
-    url: 'https://www.icloud.com.cn/mail/',
+    url: 'https://www.icloud.com/mail/',
     label: 'iCloud 邮箱',
     navigateOnReuse: true,
   });
 });
 
 test('getMailConfig reuses preferred icloud host when preference is auto', () => {
-  const bundle = extractFunction('getMailConfig');
+  const bundle = `${extractFunction('getIcloudForwardMailConfig')}\n${extractFunction('getMailConfig')}`;
   const api = new Function(`
 const ICLOUD_PROVIDER = 'icloud';
 const GMAIL_PROVIDER = 'gmail';
@@ -128,6 +135,13 @@ function getIcloudLoginUrlForHost(host) {
 function getIcloudMailUrlForHost(host) {
   return host === 'icloud.com.cn' ? 'https://www.icloud.com.cn/mail/' : 'https://www.icloud.com/mail/';
 }
+function normalizeIcloudTargetMailboxType(value = '') {
+  return String(value || '').trim().toLowerCase() === 'forward-mailbox' ? 'forward-mailbox' : 'icloud-inbox';
+}
+function normalizeIcloudForwardMailProvider(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  return ['qq', '163', '163-vip', '126', 'gmail'].includes(normalized) ? normalized : 'qq';
+}
 ${bundle}
 return { getMailConfig };
 `)();
@@ -135,17 +149,17 @@ return { getMailConfig };
   assert.deepEqual(api.getMailConfig({
     mailProvider: 'icloud',
     icloudHostPreference: 'auto',
-    preferredIcloudHost: 'icloud.com.cn',
+    preferredIcloudHost: 'icloud.com',
   }), {
     source: 'icloud-mail',
-    url: 'https://www.icloud.com.cn/mail/',
+    url: 'https://www.icloud.com/mail/',
     label: 'iCloud 邮箱',
     navigateOnReuse: true,
   });
 });
 
 test('getMailConfig keeps provider metadata for 2925 mailboxes', () => {
-  const bundle = extractFunction('getMailConfig');
+  const bundle = `${extractFunction('getIcloudForwardMailConfig')}\n${extractFunction('getMailConfig')}`;
   const api = new Function(`
 const ICLOUD_PROVIDER = 'icloud';
 const GMAIL_PROVIDER = 'gmail';
@@ -157,6 +171,13 @@ function normalizeInbucketOrigin(value) { return String(value || '').trim(); }
 function getConfiguredIcloudHostPreference() { return ''; }
 function getIcloudLoginUrlForHost(host) { return host; }
 function getIcloudMailUrlForHost(host) { return host; }
+function normalizeIcloudTargetMailboxType(value = '') {
+  return String(value || '').trim().toLowerCase() === 'forward-mailbox' ? 'forward-mailbox' : 'icloud-inbox';
+}
+function normalizeIcloudForwardMailProvider(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  return ['qq', '163', '163-vip', '126', 'gmail'].includes(normalized) ? normalized : 'qq';
+}
 ${bundle}
 return { getMailConfig };
 `)();
@@ -170,5 +191,53 @@ return { getMailConfig };
     label: '2925 邮箱',
     inject: ['content/utils.js', 'content/mail-2925.js'],
     injectSource: 'mail-2925',
+  });
+});
+
+test('getMailConfig uses forward mailbox config when icloud host is com.cn', () => {
+  const bundle = `${extractFunction('getIcloudForwardMailConfig')}\n${extractFunction('getMailConfig')}`;
+  const api = new Function(`
+const ICLOUD_PROVIDER = 'icloud';
+const GMAIL_PROVIDER = 'gmail';
+const HOTMAIL_PROVIDER = 'hotmail-api';
+const LUCKMAIL_PROVIDER = 'luckmail-api';
+const CLOUDFLARE_TEMP_EMAIL_PROVIDER = 'cloudflare-temp-email';
+function normalizeIcloudHost(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  return normalized === 'icloud.com' || normalized === 'icloud.com.cn' ? normalized : '';
+}
+function normalizeInbucketOrigin(value) { return String(value || '').trim(); }
+function getConfiguredIcloudHostPreference(state) {
+  const normalized = String(state?.icloudHostPreference || '').trim().toLowerCase();
+  return normalized === 'icloud.com' || normalized === 'icloud.com.cn' ? normalized : '';
+}
+function getIcloudLoginUrlForHost(host) {
+  return host === 'icloud.com.cn' ? 'https://www.icloud.com.cn/' : 'https://www.icloud.com/';
+}
+function getIcloudMailUrlForHost(host) {
+  return host === 'icloud.com.cn' ? 'https://www.icloud.com.cn/mail/' : 'https://www.icloud.com/mail/';
+}
+function normalizeIcloudTargetMailboxType(value = '') {
+  return String(value || '').trim().toLowerCase() === 'forward-mailbox' ? 'forward-mailbox' : 'icloud-inbox';
+}
+function normalizeIcloudForwardMailProvider(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  return ['qq', '163', '163-vip', '126', 'gmail'].includes(normalized) ? normalized : 'qq';
+}
+${bundle}
+return { getMailConfig };
+`)();
+
+  assert.deepEqual(api.getMailConfig({
+    mailProvider: 'icloud',
+    icloudHostPreference: 'icloud.com.cn',
+    icloudForwardMailProvider: 'gmail',
+  }), {
+    source: 'gmail-mail',
+    url: 'https://mail.google.com/mail/u/0/#inbox',
+    label: 'iCloud 转发（Gmail 邮箱）',
+    inject: ['content/activation-utils.js', 'content/utils.js', 'content/gmail-mail.js'],
+    injectSource: 'gmail-mail',
+    icloudForwarding: true,
   });
 });

--- a/tests/background-icloud.test.js
+++ b/tests/background-icloud.test.js
@@ -55,6 +55,8 @@ const bundle = [
   extractFunction('normalizeEmailGenerator'),
   extractFunction('getEmailGeneratorLabel'),
   extractFunction('normalizeVerificationResendCount'),
+  extractFunction('normalizeIcloudTargetMailboxType'),
+  extractFunction('normalizeIcloudForwardMailProvider'),
   extractFunction('normalizePersistentSettingValue'),
   extractFunction('finalizeIcloudAliasAfterSuccessfulFlow'),
 ].join('\n');
@@ -178,6 +180,10 @@ test('normalizePersistentSettingValue handles icloud settings', () => {
   const api = createApi();
   assert.equal(api.normalizePersistentSettingValue('icloudHostPreference', 'icloud.com'), 'icloud.com');
   assert.equal(api.normalizePersistentSettingValue('icloudHostPreference', 'bad-host'), 'auto');
+  assert.equal(api.normalizePersistentSettingValue('icloudTargetMailboxType', 'forward-mailbox'), 'forward-mailbox');
+  assert.equal(api.normalizePersistentSettingValue('icloudTargetMailboxType', 'wrong'), 'icloud-inbox');
+  assert.equal(api.normalizePersistentSettingValue('icloudForwardMailProvider', 'GMAIL'), 'gmail');
+  assert.equal(api.normalizePersistentSettingValue('icloudForwardMailProvider', 'unknown'), 'qq');
   assert.equal(api.normalizePersistentSettingValue('autoDeleteUsedIcloudAlias', 1), true);
   assert.equal(api.normalizePersistentSettingValue('verificationResendCount', '6'), 6);
   assert.equal(api.normalizePersistentSettingValue('verificationResendCount', 99), 20);


### PR DESCRIPTION
  ## 变更说明

 本 PR 为 iCloud 邮箱场景新增“目标邮箱类型/转发邮箱提供商”配置能力(主要是国内iCloud情况)，支持在特定条件下从转发邮箱收取验证码，同时保持原有流程兼容。

  ### 主要改动

  - 新增持久化设置字段：
      - icloudTargetMailboxType（默认 icloud-inbox）
      - icloudForwardMailProvider（默认 qq）
  - sidepanel 新增配置项与联动显示：
      - 目标邮箱类型：iCloud 收件箱 / 转发到其他邮箱
      - 转发邮箱：qq / 163 / 163-vip / 126 / gmail
  - background 邮箱配置选择逻辑增强：
      - 当 host 为 icloud.com.cn 或目标类型为 forward-mailbox 时，走转发邮箱收码配置
      - 新增 getIcloudForwardMailConfig()，统一返回不同转发邮箱的抓码配置
  - 补充与更新相关测试用例（iCloud 配置归一化、mail provider 选择分支等）

  ## 兼容性与风险控制

  - 默认值保持旧行为：默认仍为 iCloud 收件箱路径，不改变原始用户流程。
  - 新增字段均做了 normalize 与兜底处理，异常输入回退到安全默认值。
  - 审查中发现并修复一处潜在回归（updateButtonStates 作用域变量引用问题），避免侧边栏状态更新时报错。

  ## 测试结果

  - 全量测试通过：npm test
  - 结果：108/108 通过，0 失败

  ## 影响范围

  - background.js
  - sidepanel/sidepanel.html
  - sidepanel/sidepanel.js
  - tests/background-icloud-mail-provider.test.js
  - tests/background-icloud.test.js

 ## 自测反馈
 - 基于iCloud+(6rmb/m)隐私邮箱注册，注册流程非常流畅，单IP可以完成注册10个左右
 - web端生成邮箱有频率限制，限制后可以直接iphone的iCloud+/隐私邮箱里面手动创建10左右继续流程
 - 通过切换web自建、iPhone端手动创建，整个流程非常稳定