### PR TITLE
fix(icloud): Pro8.0 稳定 iCloud 隐私邮箱获取/保留流程

### DIFF
--- a/background.js
+++ b/background.js
@@ -3357,9 +3357,39 @@ async function getPreferredIcloudSetupUrls(state = null, error = null) {
 
 function isIcloudLoginRequiredError(error) {
   const message = getErrorMessage(error).toLowerCase();
-  return message.includes('could not validate icloud session')
-    || message.includes('hide my email service was unavailable')
-    || /\bstatus (401|403|409|421)\b/.test(message);
+  const hasAuthStatus = /\bstatus (401|403)\b/.test(message);
+  const hasTransientStatus = /\bstatus (409|421|429|5\d\d)\b/.test(message);
+  const hasTransientNetworkHint = message.includes('failed to fetch')
+    || message.includes('networkerror')
+    || message.includes('network request failed')
+    || message.includes('timeout')
+    || message.includes('timed out');
+  const hasValidationError = message.includes('could not validate icloud session');
+  const hasServiceUnavailableHint = message.includes('hide my email service was unavailable');
+
+  if (hasAuthStatus) {
+    return true;
+  }
+
+  if (hasServiceUnavailableHint && !hasTransientStatus) {
+    return true;
+  }
+
+  if (hasValidationError && !hasTransientStatus && !hasTransientNetworkHint) {
+    return true;
+  }
+
+  return false;
+}
+
+function isIcloudTransientContextError(error) {
+  const message = getErrorMessage(error).toLowerCase();
+  return /\bstatus (409|421|429|5\d\d)\b/.test(message)
+    || message.includes('failed to fetch')
+    || message.includes('networkerror')
+    || message.includes('network request failed')
+    || message.includes('timeout')
+    || message.includes('timed out');
 }
 
 let lastIcloudLoginPromptAt = 0;
@@ -3428,6 +3458,10 @@ async function withIcloudLoginHelp(actionLabel, action) {
     if (isIcloudLoginRequiredError(err)) {
       await promptIcloudLogin(err, actionLabel);
       throw new Error('请先在新打开的 iCloud 页面中完成登录，再回来点击“我已登录”。');
+    }
+    if (isIcloudTransientContextError(err)) {
+      await addLog(`iCloud：${actionLabel}受网络/上下文波动影响：${getErrorMessage(err)}`, 'warn');
+      throw new Error('iCloud 别名加载受网络/上下文波动影响，请稍后重试。');
     }
     throw err;
   }

--- a/background.js
+++ b/background.js
@@ -146,6 +146,7 @@ const ICLOUD_TAB_URL_PATTERNS = [
   'https://*.icloud.com/*',
   'https://*.icloud.com.cn/*',
 ];
+const ICLOUD_MAILDOMAINWS_CLIENT_BUILD_NUMBER = '2206Hotfix11';
 const ICLOUD_ALIAS_CACHE_MAX_AGE_MS = 6 * 60 * 60 * 1000;
 const ICLOUD_TRANSIENT_RETRY_MAX_ATTEMPTS = 2;
 const ICLOUD_TRANSIENT_RETRY_DELAY_MS = 1200;
@@ -3654,6 +3655,105 @@ function normalizeIcloudServiceUrl(rawUrl = '') {
   }
 }
 
+function isIcloudMaildomainwsHost(rawHost = '') {
+  const host = String(rawHost || '').trim().toLowerCase().replace(/\.$/, '');
+  if (!host) {
+    return false;
+  }
+  return host.endsWith('maildomainws.icloud.com') || host.endsWith('maildomainws.icloud.com.cn');
+}
+
+function appendIcloudClientQueryParams(rawUrl = '') {
+  const input = String(rawUrl || '').trim();
+  if (!input) {
+    return '';
+  }
+  try {
+    const parsed = new URL(input);
+    if (!isIcloudMaildomainwsHost(parsed.hostname)) {
+      return input;
+    }
+
+    if (!parsed.searchParams.has('clientBuildNumber')) {
+      parsed.searchParams.set('clientBuildNumber', ICLOUD_MAILDOMAINWS_CLIENT_BUILD_NUMBER);
+    }
+    if (!parsed.searchParams.has('clientMasteringNumber')) {
+      parsed.searchParams.set('clientMasteringNumber', ICLOUD_MAILDOMAINWS_CLIENT_BUILD_NUMBER);
+    }
+    if (!parsed.searchParams.has('clientId')) {
+      parsed.searchParams.set('clientId', '');
+    }
+    if (!parsed.searchParams.has('dsid')) {
+      parsed.searchParams.set('dsid', '');
+    }
+    return parsed.toString();
+  } catch {
+    return input;
+  }
+}
+
+function isIcloudMailPageUrl(rawUrl = '') {
+  try {
+    const parsedUrl = new URL(String(rawUrl || '').trim());
+    if (!normalizeIcloudHost(parsedUrl.hostname)) {
+      return false;
+    }
+    const pathname = String(parsedUrl.pathname || '').toLowerCase();
+    return pathname === '/mail' || pathname.startsWith('/mail/');
+  } catch {
+    return false;
+  }
+}
+
+async function waitForIcloudMailTabReady(tabId, timeoutMs = 8000) {
+  if (!Number.isInteger(tabId)) {
+    return false;
+  }
+  const deadline = Date.now() + Math.max(500, Number(timeoutMs) || 8000);
+  while (Date.now() < deadline) {
+    try {
+      const tab = await chrome.tabs.get(tabId);
+      const status = String(tab?.status || '');
+      if (isIcloudMailPageUrl(tab?.url) && status === 'complete') {
+        return true;
+      }
+    } catch {
+      return false;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  return false;
+}
+
+async function ensureIcloudMailContextTab(tabs = [], targetHost = '', preferredHost = '') {
+  const tabList = Array.isArray(tabs) ? tabs : [];
+  if (tabList.some((tab) => isIcloudMailPageUrl(tab?.url))) {
+    return tabList;
+  }
+
+  const fallbackHost = targetHost
+    || preferredHost
+    || await getOpenIcloudHostPreference()
+    || 'icloud.com';
+  const fallbackMailUrl = getIcloudMailUrlForHost(fallbackHost) || getIcloudMailUrlForHost('icloud.com');
+  if (!fallbackMailUrl) {
+    return tabList;
+  }
+
+  try {
+    const created = await chrome.tabs.create({ url: fallbackMailUrl, active: false });
+    await waitForIcloudMailTabReady(created?.id, 9000);
+  } catch {}
+
+  try {
+    return await chrome.tabs.query({
+      url: ICLOUD_TAB_URL_PATTERNS,
+    });
+  } catch {
+    return tabList;
+  }
+}
+
 function shouldTryIcloudRequestPageContextFallback(url, status, errorMessage = '') {
   if (!isIcloudApiUrl(url)) {
     return false;
@@ -3680,17 +3780,21 @@ function shouldTryIcloudRequestPageContextFallback(url, status, errorMessage = '
 }
 
 async function icloudRequestViaPageContext(method, url, options = {}) {
-  const { data } = options;
+  const {
+    data,
+    contentType = '',
+  } = options;
   const state = await getState();
   const targetHost = normalizeIcloudHost(new URL(url).hostname);
   const preferredHost = normalizeIcloudHost(state?.preferredIcloudHost);
 
-  const tabs = await chrome.tabs.query({
+  let tabs = await chrome.tabs.query({
     url: ICLOUD_TAB_URL_PATTERNS,
   });
   if (!tabs.length) {
     throw new Error('page_context:no_icloud_tab');
   }
+  tabs = await ensureIcloudMailContextTab(tabs, targetHost, preferredHost);
 
   const sortedTabs = [...tabs].sort((left, right) => {
     const score = (tab) => {
@@ -3698,15 +3802,18 @@ async function icloudRequestViaPageContext(method, url, options = {}) {
       try {
         tabHost = normalizeIcloudHost(new URL(String(tab?.url || '')).hostname);
       } catch {}
-      return (tab?.active ? 4 : 0)
+      return (isIcloudMailPageUrl(tab?.url) ? 8 : 0)
+        + (tab?.active ? 4 : 0)
         + (tabHost && tabHost === targetHost ? 2 : 0)
         + (tabHost && tabHost === preferredHost ? 1 : 0);
     };
     return score(right) - score(left);
   });
+  const mailTabs = sortedTabs.filter((tab) => isIcloudMailPageUrl(tab?.url));
+  const candidateTabs = mailTabs.length ? mailTabs : sortedTabs;
 
   const errors = [];
-  for (const tab of sortedTabs) {
+  for (const tab of candidateTabs) {
     if (!Number.isInteger(tab?.id)) {
       continue;
     }
@@ -3720,7 +3827,7 @@ async function icloudRequestViaPageContext(method, url, options = {}) {
           const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
           try {
             const headers = requestConfig.hasData
-              ? { 'Content-Type': 'application/json' }
+              ? { 'Content-Type': requestConfig.contentType || 'application/json' }
               : undefined;
             const response = await fetch(requestConfig.url, {
               method: requestConfig.method,
@@ -3754,6 +3861,7 @@ async function icloudRequestViaPageContext(method, url, options = {}) {
           url,
           hasData: data !== undefined,
           data: data === undefined ? null : data,
+          contentType: contentType || '',
         }],
       });
 
@@ -3787,25 +3895,41 @@ async function icloudRequestViaPageContext(method, url, options = {}) {
 
 async function icloudRequest(method, url, options = {}) {
   const { data } = options;
+  const requestUrl = appendIcloudClientQueryParams(url);
+  const requestContentType = (() => {
+    if (data === undefined) {
+      return '';
+    }
+    try {
+      return isIcloudMaildomainwsHost(new URL(requestUrl).hostname)
+        ? 'text/plain;charset=UTF-8'
+        : 'application/json';
+    } catch {
+      return 'application/json';
+    }
+  })();
   let response;
   let directError = '';
   try {
-    response = await fetch(url, {
+    response = await fetch(requestUrl, {
       method,
       credentials: 'include',
-      headers: data !== undefined ? { 'Content-Type': 'application/json' } : undefined,
+      headers: requestContentType ? { 'Content-Type': requestContentType } : undefined,
       body: data !== undefined ? JSON.stringify(data) : undefined,
     });
   } catch (err) {
-    directError = `iCloud 请求失败：${method} ${url}，${err.message}`;
+    directError = `iCloud 请求失败：${method} ${requestUrl}，${err.message}`;
   }
 
   if (!response || !response.ok) {
     const status = Number(response?.status) || 0;
-    const directFailure = directError || `iCloud 请求失败：${method} ${url}，status ${status}`;
-    if (shouldTryIcloudRequestPageContextFallback(url, status, directFailure)) {
+    const directFailure = directError || `iCloud 请求失败：${method} ${requestUrl}，status ${status}`;
+    if (shouldTryIcloudRequestPageContextFallback(requestUrl, status, directFailure)) {
       try {
-        return await icloudRequestViaPageContext(method, url, { data });
+        return await icloudRequestViaPageContext(method, requestUrl, {
+          data,
+          contentType: requestContentType || undefined,
+        });
       } catch (pageContextError) {
         throw new Error(`${directFailure} | page_context:${getErrorMessage(pageContextError)}`);
       }
@@ -3816,7 +3940,7 @@ async function icloudRequest(method, url, options = {}) {
   try {
     return await response.json();
   } catch (err) {
-    throw new Error(`iCloud 返回的 JSON 无法解析：${method} ${url}，${err.message}`);
+    throw new Error(`iCloud 返回的 JSON 无法解析：${method} ${requestUrl}，${err.message}`);
   }
 }
 
@@ -3923,10 +4047,14 @@ async function resolveIcloudPremiumMailServiceViaPageContext(setupUrls, state) {
   }
 
   const preferredHost = normalizeIcloudHost(state?.preferredIcloudHost);
+  tabs = await ensureIcloudMailContextTab(tabs, preferredHost, preferredHost);
   const sortedTabs = [...tabs].sort((left, right) => {
     const leftActive = left?.active ? 1 : 0;
     const rightActive = right?.active ? 1 : 0;
     if (leftActive !== rightActive) return rightActive - leftActive;
+    const leftMail = isIcloudMailPageUrl(left?.url) ? 1 : 0;
+    const rightMail = isIcloudMailPageUrl(right?.url) ? 1 : 0;
+    if (leftMail !== rightMail) return rightMail - leftMail;
     let leftHost = '';
     let rightHost = '';
     try { leftHost = normalizeIcloudHost(new URL(String(left?.url || '')).host); } catch {}
@@ -4150,6 +4278,11 @@ async function fetchIcloudHideMyEmail(options = {}) {
 
     // listIcloudAliases already includes transient fallback (fresh cache -> stale cache -> local records).
     const existingAliases = await listIcloudAliases();
+    const existingAliasEmailSet = new Set(
+      existingAliases
+        .map((aliasItem) => String(aliasItem?.email || '').trim().toLowerCase())
+        .filter(Boolean)
+    );
 
     if (!generateNew) {
       const reusableAlias = pickReusableIcloudAlias(existingAliases);
@@ -4174,19 +4307,80 @@ async function fetchIcloudHideMyEmail(options = {}) {
         throw new Error(generated?.error?.errorMessage || 'iCloud 隐私邮箱生成失败。');
       }
 
-      const reserved = await icloudRequest('POST', `${serviceUrl}/v1/hme/reserve`, {
-        data: {
-          hme: generated.result.hme,
-          label: getIcloudAliasLabel(),
-          note: 'Generated through Multi-Page Automation',
-        },
-      });
+      const generatedHmeRaw = generated.result.hme;
+      const generatedAliasFromResponse = String(
+        (typeof generatedHmeRaw === 'string'
+          ? generatedHmeRaw
+          : generatedHmeRaw?.hme
+            || generatedHmeRaw?.email
+            || generatedHmeRaw?.alias
+            || generatedHmeRaw?.address
+            || '')
+      ).trim().toLowerCase();
+      const reserveData = {
+        ...(generatedHmeRaw && typeof generatedHmeRaw === 'object' && !Array.isArray(generatedHmeRaw)
+          ? generatedHmeRaw
+          : {}),
+        hme: generatedAliasFromResponse || String(generatedHmeRaw || '').trim(),
+        label: getIcloudAliasLabel(),
+        note: 'Generated through Multi-Page Automation',
+      };
 
-      if (!reserved?.success || !reserved?.result?.hme?.hme) {
-        throw new Error(reserved?.error?.errorMessage || 'iCloud 隐私邮箱保留失败。');
+      let alias = '';
+      try {
+        const reserved = await icloudRequest('POST', `${serviceUrl}/v1/hme/reserve`, {
+          data: reserveData,
+        });
+
+        if (!reserved?.success || !reserved?.result?.hme?.hme) {
+          throw new Error(reserved?.error?.errorMessage || 'iCloud 隐私邮箱保留失败。');
+        }
+
+        alias = String(reserved.result.hme.hme || '').trim().toLowerCase();
+      } catch (reserveErr) {
+        const reserveErrMessage = getErrorMessage(reserveErr);
+        const shouldTryListFallback = /\bstatus (?:401|403|409)\b/i.test(reserveErrMessage)
+          || /failed to fetch/i.test(reserveErrMessage);
+        if (!shouldTryListFallback) {
+          throw reserveErr;
+        }
+
+        await addLog('iCloud：保留别名返回鉴权/网络异常，正在回查别名列表确认是否已创建...', 'warn');
+
+        let recoveredAlias = null;
+        try {
+          const refreshedAliasesResponse = await icloudRequest('GET', `${serviceUrl}/v2/hme/list`);
+          const latestState = await getState();
+          const refreshedAliases = normalizeIcloudAliasList(refreshedAliasesResponse, {
+            usedEmails: getEffectiveUsedEmails(latestState),
+            preservedEmails: getPreservedAliasMap(latestState),
+          });
+
+          recoveredAlias = generatedAliasFromResponse
+            ? findIcloudAliasByEmail(refreshedAliases, generatedAliasFromResponse)
+            : null;
+          if (!recoveredAlias) {
+            recoveredAlias = refreshedAliases.find(
+              (aliasItem) => !existingAliasEmailSet.has(String(aliasItem?.email || '').trim().toLowerCase())
+            ) || null;
+          }
+        } catch (refreshErr) {
+          await addLog(`iCloud：保留后回查别名列表失败：${getErrorMessage(refreshErr)}`, 'warn');
+        }
+
+        if (!recoveredAlias?.email) {
+          if (generatedAliasFromResponse) {
+            alias = generatedAliasFromResponse;
+            await addLog(`iCloud：保留请求异常，已回退使用生成别名 ${alias}。`, 'warn');
+          } else {
+            throw new Error(`iCloud 隐私邮箱保留失败：${reserveErrMessage}`);
+          }
+        } else {
+          alias = String(recoveredAlias.email || '').trim().toLowerCase();
+          await addLog(`iCloud：保留请求异常，但已在列表确认别名 ${alias}，继续使用。`, 'warn');
+        }
       }
 
-      const alias = String(reserved.result.hme.hme || '').trim().toLowerCase();
       await setEmailState(alias);
       await addLog(`iCloud：已创建并保留新别名 ${alias}`, 'ok');
       broadcastIcloudAliasesChanged({ reason: 'created', email: alias });

--- a/background.js
+++ b/background.js
@@ -138,6 +138,14 @@ const ICLOUD_LOGIN_URLS = [
   'https://www.icloud.com.cn/',
   'https://www.icloud.com/',
 ];
+const ICLOUD_TAB_URL_PATTERNS = [
+  'https://www.icloud.com/*',
+  'https://www.icloud.com.cn/*',
+  'https://setup.icloud.com/*',
+  'https://setup.icloud.com.cn/*',
+  'https://*.icloud.com/*',
+  'https://*.icloud.com.cn/*',
+];
 const ICLOUD_ALIAS_CACHE_MAX_AGE_MS = 6 * 60 * 60 * 1000;
 const ICLOUD_TRANSIENT_RETRY_MAX_ATTEMPTS = 2;
 const ICLOUD_TRANSIENT_RETRY_DELAY_MS = 1200;
@@ -194,7 +202,12 @@ const HOTMAIL_LOCAL_HELPER_TIMEOUT_MS = 45000;
 const DEFAULT_LUCKMAIL_PROJECT_CODE = 'openai';
 const DISPLAY_TIMEZONE = 'Asia/Shanghai';
 const MICROSOFT_TOKEN_DNR_RULE_ID = 1001;
-const PERSISTENT_ALIAS_STATE_KEYS = ['manualAliasUsage', 'preservedAliases'];
+const PERSISTENT_ALIAS_STATE_KEYS = [
+  'manualAliasUsage',
+  'preservedAliases',
+  'icloudAliasCache',
+  'icloudAliasCacheAt',
+];
 const ACCOUNT_RUN_HISTORY_STORAGE_KEY = 'accountRunHistory';
 const CONTRIBUTION_RUNTIME_DEFAULTS = self.MultiPageBackgroundContributionOAuth?.RUNTIME_DEFAULTS || {
   contributionMode: false,
@@ -1100,15 +1113,24 @@ async function getPersistedSettings() {
 async function getPersistedAliasState() {
   try {
     const stored = await chrome.storage.local.get(PERSISTENT_ALIAS_STATE_KEYS);
+    const manualAliasUsage = normalizeBooleanMap(stored.manualAliasUsage);
+    const preservedAliases = normalizeBooleanMap(stored.preservedAliases);
     return {
-      manualAliasUsage: normalizeBooleanMap(stored.manualAliasUsage),
-      preservedAliases: normalizeBooleanMap(stored.preservedAliases),
+      manualAliasUsage,
+      preservedAliases,
+      icloudAliasCache: normalizeIcloudAliasCacheList(stored.icloudAliasCache, {
+        usedEmails: toNormalizedEmailSet(manualAliasUsage),
+        preservedEmails: toNormalizedEmailSet(preservedAliases),
+      }),
+      icloudAliasCacheAt: Math.max(0, Number(stored.icloudAliasCacheAt) || 0),
     };
   } catch (err) {
     console.warn(LOG_PREFIX, 'Failed to read persisted iCloud alias state:', err?.message || err);
     return {
       manualAliasUsage: {},
       preservedAliases: {},
+      icloudAliasCache: [],
+      icloudAliasCacheAt: 0,
     };
   }
 }
@@ -1146,6 +1168,12 @@ async function setState(updates) {
     }
     if (Object.prototype.hasOwnProperty.call(updates, 'preservedAliases')) {
       persistentAliasUpdates.preservedAliases = normalizeBooleanMap(updates.preservedAliases);
+    }
+    if (Object.prototype.hasOwnProperty.call(updates, 'icloudAliasCache')) {
+      persistentAliasUpdates.icloudAliasCache = normalizeIcloudAliasCacheList(updates.icloudAliasCache);
+    }
+    if (Object.prototype.hasOwnProperty.call(updates, 'icloudAliasCacheAt')) {
+      persistentAliasUpdates.icloudAliasCacheAt = Math.max(0, Number(updates.icloudAliasCacheAt) || 0);
     }
     if (Object.keys(persistentAliasUpdates).length > 0) {
       await chrome.storage.local.set(persistentAliasUpdates);
@@ -1438,6 +1466,51 @@ function getIcloudAliasCacheFromState(state, options = {}) {
   return normalizeIcloudAliasCacheList(state.icloudAliasCache, {
     usedEmails: getEffectiveUsedEmails(state),
     preservedEmails: getPreservedAliasMap(state),
+  });
+}
+
+function isLikelyIcloudAliasEmail(value = '') {
+  const email = String(value || '').trim().toLowerCase();
+  if (!email || !email.includes('@')) {
+    return false;
+  }
+  return /@(icloud\.com|me\.com|mac\.com|privaterelay\.appleid\.com)$/.test(email);
+}
+
+function buildIcloudAliasFallbackFromLocalState(state = {}) {
+  const manualAliasUsage = getManualAliasUsageMap(state);
+  const preservedAliases = getPreservedAliasMap(state);
+  const candidates = new Set();
+
+  for (const email of Object.keys(manualAliasUsage)) {
+    if (isLikelyIcloudAliasEmail(email)) {
+      candidates.add(String(email).trim().toLowerCase());
+    }
+  }
+  for (const email of Object.keys(preservedAliases)) {
+    if (isLikelyIcloudAliasEmail(email)) {
+      candidates.add(String(email).trim().toLowerCase());
+    }
+  }
+
+  const currentEmail = String(state?.email || '').trim().toLowerCase();
+  if (isLikelyIcloudAliasEmail(currentEmail)) {
+    candidates.add(currentEmail);
+  }
+
+  if (!candidates.size) {
+    return [];
+  }
+
+  const aliases = Array.from(candidates, (email) => ({
+    hme: email,
+    email,
+    state: 'active',
+    active: true,
+  }));
+  return normalizeIcloudAliasCacheList(aliases, {
+    usedEmails: getEffectiveUsedEmails(state),
+    preservedEmails: preservedAliases,
   });
 }
 
@@ -3333,10 +3406,7 @@ async function pollCloudflareTempEmailVerificationCode(step, state, pollPayload 
 async function getOpenIcloudHostPreference() {
   try {
     const tabs = await chrome.tabs.query({
-      url: [
-        'https://www.icloud.com/*',
-        'https://www.icloud.com.cn/*',
-      ],
+      url: ICLOUD_TAB_URL_PATTERNS,
     });
 
     const activeTab = tabs.find((tab) => tab.active);
@@ -3359,9 +3429,9 @@ async function getPreferredIcloudLoginUrl(error = null, state = null) {
     return getIcloudLoginUrlForHost(configuredHost);
   }
 
-  const messageHint = getIcloudHostHintFromMessage(getErrorMessage(error));
-  if (messageHint) {
-    return getIcloudLoginUrlForHost(messageHint);
+  const openHost = await getOpenIcloudHostPreference();
+  if (openHost) {
+    return getIcloudLoginUrlForHost(openHost);
   }
 
   const savedHost = normalizeIcloudHost(currentState?.preferredIcloudHost);
@@ -3369,9 +3439,9 @@ async function getPreferredIcloudLoginUrl(error = null, state = null) {
     return getIcloudLoginUrlForHost(savedHost);
   }
 
-  const openHost = await getOpenIcloudHostPreference();
-  if (openHost) {
-    return getIcloudLoginUrlForHost(openHost);
+  const messageHint = getIcloudHostHintFromMessage(getErrorMessage(error));
+  if (messageHint) {
+    return getIcloudLoginUrlForHost(messageHint);
   }
 
   return ICLOUD_LOGIN_URLS[0];
@@ -3392,25 +3462,49 @@ async function getPreferredIcloudSetupUrls(state = null, error = null) {
 
 function isIcloudLoginRequiredError(error) {
   const message = getErrorMessage(error).toLowerCase();
-  const hasAuthStatus = /\bstatus (401|403)\b/.test(message);
+  const hasAuthStatus401 = /\bstatus 401\b/.test(message);
+  const hasAuthStatus403 = /\bstatus 403\b/.test(message);
   const hasTransientStatus = /\bstatus (409|421|429|5\d\d)\b/.test(message);
   const hasTransientNetworkHint = message.includes('failed to fetch')
     || message.includes('networkerror')
     || message.includes('network request failed')
     || message.includes('timeout')
-    || message.includes('timed out');
-  const hasValidationError = message.includes('could not validate icloud session');
-  const hasServiceUnavailableHint = message.includes('hide my email service was unavailable');
+    || message.includes('timed out')
+    || message.includes('cors')
+    || message.includes('address space');
+  const hasExplicitLoginHint = message.includes('please sign in')
+    || message.includes('sign in required')
+    || message.includes('not logged in')
+    || message.includes('login required')
+    || message.includes('re-authentication required')
+    || message.includes('unauthenticated')
+    || message.includes('authentication required')
+    || message.includes('需要先登录')
+    || message.includes('请先登录');
+  const hasSelfPromptHint = message.includes('请先在新打开的 icloud 页面中完成登录')
+    || message.includes('请先在当前浏览器登录');
+  const hasAuthStatusWithExplicitLoginHint = (hasAuthStatus401 || hasAuthStatus403)
+    && hasExplicitLoginHint;
 
-  if (hasAuthStatus) {
+  // Keep transient validate/network/cors errors out of login-required path.
+  if (message.includes('could not validate icloud session')) {
+    return false;
+  }
+  if (message.includes('page_context:')) {
+    return false;
+  }
+  if (hasSelfPromptHint) {
+    return false;
+  }
+  if (hasTransientStatus || hasTransientNetworkHint) {
+    return false;
+  }
+
+  if (hasAuthStatusWithExplicitLoginHint) {
     return true;
   }
 
-  if (hasServiceUnavailableHint && !hasTransientStatus) {
-    return true;
-  }
-
-  if (hasValidationError && !hasTransientStatus && !hasTransientNetworkHint) {
+  if (hasExplicitLoginHint) {
     return true;
   }
 
@@ -3419,10 +3513,14 @@ function isIcloudLoginRequiredError(error) {
 
 function isIcloudTransientContextError(error) {
   const message = getErrorMessage(error).toLowerCase();
-  return /\bstatus (409|421|429|5\d\d)\b/.test(message)
+  return /\bstatus (401|403|409|421|429|5\d\d)\b/.test(message)
+    || message.includes('could not validate icloud session')
+    || message.includes('page_context:')
     || message.includes('failed to fetch')
     || message.includes('networkerror')
     || message.includes('network request failed')
+    || message.includes('cors')
+    || message.includes('address space')
     || message.includes('timeout')
     || message.includes('timed out');
 }
@@ -3431,26 +3529,27 @@ let lastIcloudLoginPromptAt = 0;
 
 async function openIcloudLoginPage(preferredUrl) {
   const tabs = await chrome.tabs.query({
-    url: [
-      'https://www.icloud.com/*',
-      'https://www.icloud.com.cn/*',
-    ],
+    url: ICLOUD_TAB_URL_PATTERNS,
   });
   const preferredHost = new URL(preferredUrl).host;
-  const existing = tabs.find((tab) => {
+  const preferredIcloudHost = normalizeIcloudHost(preferredHost);
+  const existingSameHost = tabs.find((tab) => {
     try {
-      return new URL(tab.url).host === preferredHost;
+      return normalizeIcloudHost(new URL(tab.url).host) === preferredIcloudHost;
     } catch {
       return false;
     }
   });
+  const existingAnyIcloudTab = tabs.find((tab) => Number.isInteger(tab?.id));
 
-  if (existing?.id) {
-    await chrome.tabs.update(existing.id, { active: true });
-    if (existing.url !== preferredUrl) {
-      await chrome.tabs.update(existing.id, { url: preferredUrl });
-    }
-    return existing.id;
+  if (existingSameHost?.id) {
+    await chrome.tabs.update(existingSameHost.id, { active: true });
+    return existingSameHost.id;
+  }
+
+  if (existingAnyIcloudTab?.id) {
+    await chrome.tabs.update(existingAnyIcloudTab.id, { active: true });
+    return existingAnyIcloudTab.id;
   }
 
   const created = await chrome.tabs.create({ url: preferredUrl, active: true });
@@ -3515,9 +3614,181 @@ async function withIcloudLoginHelp(actionLabel, action) {
   throw new Error('iCloud 操作失败：未知错误。');
 }
 
+function isIcloudApiUrl(url = '') {
+  const rawUrl = String(url || '').trim();
+  if (!rawUrl) {
+    return false;
+  }
+  try {
+    const parsedUrl = new URL(rawUrl);
+    if (parsedUrl.protocol !== 'https:') {
+      return false;
+    }
+    const hostname = String(parsedUrl.hostname || '').trim().toLowerCase().replace(/\.$/, '');
+    if (!hostname) {
+      return false;
+    }
+    return hostname === 'icloud.com'
+      || hostname.endsWith('.icloud.com')
+      || hostname === 'icloud.com.cn'
+      || hostname.endsWith('.icloud.com.cn');
+  } catch {
+    return false;
+  }
+}
+
+function normalizeIcloudServiceUrl(rawUrl = '') {
+  const value = String(rawUrl || '').trim();
+  if (!value) {
+    return '';
+  }
+  try {
+    const parsedUrl = new URL(value);
+    if ((parsedUrl.protocol === 'https:' && parsedUrl.port === '443')
+      || (parsedUrl.protocol === 'http:' && parsedUrl.port === '80')) {
+      parsedUrl.port = '';
+    }
+    return parsedUrl.toString().replace(/\/$/, '');
+  } catch {
+    return value.replace(/\/$/, '');
+  }
+}
+
+function shouldTryIcloudRequestPageContextFallback(url, status, errorMessage = '') {
+  if (!isIcloudApiUrl(url)) {
+    return false;
+  }
+
+  const normalizedStatus = Number(status) || 0;
+  if (normalizedStatus === 401
+    || normalizedStatus === 403
+    || normalizedStatus === 409
+    || normalizedStatus === 421
+    || normalizedStatus === 429
+    || normalizedStatus >= 500) {
+    return true;
+  }
+
+  const message = String(errorMessage || '').toLowerCase();
+  return message.includes('failed to fetch')
+    || message.includes('network request failed')
+    || message.includes('networkerror')
+    || message.includes('timed out')
+    || message.includes('timeout')
+    || message.includes('cors')
+    || message.includes('address space');
+}
+
+async function icloudRequestViaPageContext(method, url, options = {}) {
+  const { data } = options;
+  const state = await getState();
+  const targetHost = normalizeIcloudHost(new URL(url).hostname);
+  const preferredHost = normalizeIcloudHost(state?.preferredIcloudHost);
+
+  const tabs = await chrome.tabs.query({
+    url: ICLOUD_TAB_URL_PATTERNS,
+  });
+  if (!tabs.length) {
+    throw new Error('page_context:no_icloud_tab');
+  }
+
+  const sortedTabs = [...tabs].sort((left, right) => {
+    const score = (tab) => {
+      let tabHost = '';
+      try {
+        tabHost = normalizeIcloudHost(new URL(String(tab?.url || '')).hostname);
+      } catch {}
+      return (tab?.active ? 4 : 0)
+        + (tabHost && tabHost === targetHost ? 2 : 0)
+        + (tabHost && tabHost === preferredHost ? 1 : 0);
+    };
+    return score(right) - score(left);
+  });
+
+  const errors = [];
+  for (const tab of sortedTabs) {
+    if (!Number.isInteger(tab?.id)) {
+      continue;
+    }
+    try {
+      const injections = await chrome.scripting.executeScript({
+        target: { tabId: tab.id, allFrames: false },
+        world: 'MAIN',
+        func: async (requestConfig) => {
+          const timeoutMs = 15000;
+          const controller = new AbortController();
+          const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+          try {
+            const headers = requestConfig.hasData
+              ? { 'Content-Type': 'application/json' }
+              : undefined;
+            const response = await fetch(requestConfig.url, {
+              method: requestConfig.method,
+              credentials: 'include',
+              cache: 'no-store',
+              mode: 'cors',
+              headers,
+              body: requestConfig.hasData ? JSON.stringify(requestConfig.data) : undefined,
+              signal: controller.signal,
+            });
+            const text = await response.text();
+            return {
+              ok: Boolean(response.ok),
+              status: Number(response.status) || 0,
+              text,
+              error: '',
+            };
+          } catch (err) {
+            return {
+              ok: false,
+              status: 0,
+              text: '',
+              error: String(err?.message || err || 'unknown error'),
+            };
+          } finally {
+            clearTimeout(timeoutId);
+          }
+        },
+        args: [{
+          method,
+          url,
+          hasData: data !== undefined,
+          data: data === undefined ? null : data,
+        }],
+      });
+
+      const result = injections?.[0]?.result || null;
+      if (!result) {
+        throw new Error('empty result');
+      }
+      if (!result.ok) {
+        if (result.status) {
+          throw new Error(`status ${result.status}`);
+        }
+        throw new Error(result.error || 'page context request failed');
+      }
+
+      if (!String(result.text || '').trim()) {
+        return {};
+      }
+
+      try {
+        return JSON.parse(result.text);
+      } catch (parseErr) {
+        throw new Error(`invalid json: ${getErrorMessage(parseErr)}`);
+      }
+    } catch (err) {
+      errors.push(`tab_${tab.id}:${getErrorMessage(err)}`);
+    }
+  }
+
+  throw new Error(errors.length ? errors.join(' | ') : 'page_context:unknown');
+}
+
 async function icloudRequest(method, url, options = {}) {
   const { data } = options;
   let response;
+  let directError = '';
   try {
     response = await fetch(url, {
       method,
@@ -3526,11 +3797,20 @@ async function icloudRequest(method, url, options = {}) {
       body: data !== undefined ? JSON.stringify(data) : undefined,
     });
   } catch (err) {
-    throw new Error(`iCloud 请求失败：${method} ${url}，${err.message}`);
+    directError = `iCloud 请求失败：${method} ${url}，${err.message}`;
   }
 
-  if (!response.ok) {
-    throw new Error(`iCloud 请求失败：${method} ${url}，status ${response.status}`);
+  if (!response || !response.ok) {
+    const status = Number(response?.status) || 0;
+    const directFailure = directError || `iCloud 请求失败：${method} ${url}，status ${status}`;
+    if (shouldTryIcloudRequestPageContextFallback(url, status, directFailure)) {
+      try {
+        return await icloudRequestViaPageContext(method, url, { data });
+      } catch (pageContextError) {
+        throw new Error(`${directFailure} | page_context:${getErrorMessage(pageContextError)}`);
+      }
+    }
+    throw new Error(directFailure);
   }
 
   try {
@@ -3546,6 +3826,131 @@ async function validateIcloudSession(setupUrl) {
     throw new Error('Could not validate iCloud session. Hide My Email service was unavailable.');
   }
   return data;
+}
+
+function shouldTryIcloudPageContextFallback(errors = []) {
+  const combinedMessage = String((errors || []).join(' | ')).toLowerCase();
+  if (!combinedMessage) {
+    return false;
+  }
+  return combinedMessage.includes('status 401')
+    || combinedMessage.includes('status 403')
+    || combinedMessage.includes('status 421')
+    || combinedMessage.includes('networkerror')
+    || combinedMessage.includes('network request failed')
+    || combinedMessage.includes('failed to fetch')
+    || combinedMessage.includes('timed out')
+    || combinedMessage.includes('timeout')
+    || combinedMessage.includes('cors');
+}
+
+async function validateIcloudSessionViaPageContext(tabId, setupUrl) {
+  const host = new URL(setupUrl).host;
+  try {
+    const injections = await chrome.scripting.executeScript({
+      target: { tabId, allFrames: false },
+      world: 'MAIN',
+      func: async (targetSetupUrl) => {
+        const timeoutMs = 12000;
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+        try {
+          const response = await fetch(`${targetSetupUrl}/validate`, {
+            method: 'POST',
+            credentials: 'include',
+            cache: 'no-store',
+            mode: 'cors',
+            signal: controller.signal,
+          });
+          const text = await response.text();
+          let data = null;
+          try {
+            data = text ? JSON.parse(text) : null;
+          } catch {}
+          return {
+            ok: Boolean(response.ok),
+            status: Number(response.status) || 0,
+            data,
+            error: '',
+          };
+        } catch (err) {
+          return {
+            ok: false,
+            status: 0,
+            data: null,
+            error: String(err?.message || err || 'unknown error'),
+          };
+        } finally {
+          clearTimeout(timeoutId);
+        }
+      },
+      args: [setupUrl],
+    });
+
+    const result = injections?.[0]?.result || null;
+    if (result?.ok && result?.data?.webservices?.premiummailsettings?.url) {
+      return {
+        setupUrl,
+        serviceUrl: normalizeIcloudServiceUrl(result.data.webservices.premiummailsettings.url),
+        resolvedBy: 'page_context',
+      };
+    }
+
+    if (result?.status) {
+      throw new Error(`status ${result.status}`);
+    }
+    throw new Error(result?.error || 'page context validate failed');
+  } catch (err) {
+    throw new Error(`${host}: ${getErrorMessage(err)}`);
+  }
+}
+
+async function resolveIcloudPremiumMailServiceViaPageContext(setupUrls, state) {
+  const errors = [];
+  let tabs = [];
+  try {
+    tabs = await chrome.tabs.query({
+      url: ICLOUD_TAB_URL_PATTERNS,
+    });
+  } catch (err) {
+    errors.push(`page_context:query_tabs:${getErrorMessage(err)}`);
+    return { service: null, errors };
+  }
+
+  if (!tabs.length) {
+    errors.push('page_context:no_icloud_tab');
+    return { service: null, errors };
+  }
+
+  const preferredHost = normalizeIcloudHost(state?.preferredIcloudHost);
+  const sortedTabs = [...tabs].sort((left, right) => {
+    const leftActive = left?.active ? 1 : 0;
+    const rightActive = right?.active ? 1 : 0;
+    if (leftActive !== rightActive) return rightActive - leftActive;
+    let leftHost = '';
+    let rightHost = '';
+    try { leftHost = normalizeIcloudHost(new URL(String(left?.url || '')).host); } catch {}
+    try { rightHost = normalizeIcloudHost(new URL(String(right?.url || '')).host); } catch {}
+    const leftPreferred = leftHost && leftHost === preferredHost ? 1 : 0;
+    const rightPreferred = rightHost && rightHost === preferredHost ? 1 : 0;
+    return rightPreferred - leftPreferred;
+  });
+
+  for (const tab of sortedTabs) {
+    if (!Number.isInteger(tab?.id)) {
+      continue;
+    }
+    for (const setupUrl of setupUrls) {
+      try {
+        const service = await validateIcloudSessionViaPageContext(tab.id, setupUrl);
+        return { service, errors };
+      } catch (err) {
+        errors.push(`page_context:tab_${tab.id}:${getErrorMessage(err)}`);
+      }
+    }
+  }
+
+  return { service: null, errors };
 }
 
 async function resolveIcloudPremiumMailService(options = {}) {
@@ -3568,10 +3973,25 @@ async function resolveIcloudPremiumMailService(options = {}) {
       }
       return {
         setupUrl,
-        serviceUrl: String(data.webservices.premiummailsettings.url || '').replace(/\/$/, ''),
+        serviceUrl: normalizeIcloudServiceUrl(data.webservices.premiummailsettings.url),
       };
     } catch (err) {
       errors.push(`${new URL(setupUrl).host}: ${getErrorMessage(err)}`);
+    }
+  }
+
+  if (shouldTryIcloudPageContextFallback(errors)) {
+    const { service, errors: pageContextErrors } = await resolveIcloudPremiumMailServiceViaPageContext(setupUrls, state);
+    if (service) {
+      const preferredIcloudHost = normalizeIcloudHost(new URL(service.setupUrl).host);
+      if (preferredIcloudHost && preferredIcloudHost !== normalizeIcloudHost(state.preferredIcloudHost)) {
+        await setState({ preferredIcloudHost });
+      }
+      await addLog(`iCloud：后台会话校验失败，已切换页面上下文校验（${new URL(service.setupUrl).host}）。`, 'warn');
+      return service;
+    }
+    if (Array.isArray(pageContextErrors) && pageContextErrors.length) {
+      errors.push(...pageContextErrors);
     }
   }
 
@@ -3620,12 +4040,25 @@ async function listIcloudAliases(options = {}) {
       throw err;
     }
     const state = await getState();
-    const cachedAliases = getIcloudAliasCacheFromState(state);
-    if (!cachedAliases.length) {
-      throw err;
+    const freshCachedAliases = getIcloudAliasCacheFromState(state);
+    if (freshCachedAliases.length) {
+      await addLog(`iCloud：加载别名失败，已回退最近缓存（${freshCachedAliases.length} 条）。`, 'warn');
+      return freshCachedAliases;
     }
-    await addLog(`iCloud：加载别名失败，已回退最近缓存（${cachedAliases.length} 条）。`, 'warn');
-    return cachedAliases;
+
+    const staleCachedAliases = getIcloudAliasCacheFromState(state, { maxAgeMs: 0 });
+    if (staleCachedAliases.length) {
+      await addLog(`iCloud：加载别名失败，已回退历史缓存（${staleCachedAliases.length} 条）。`, 'warn');
+      return staleCachedAliases;
+    }
+
+    const localFallbackAliases = buildIcloudAliasFallbackFromLocalState(state);
+    if (localFallbackAliases.length) {
+      await addLog(`iCloud：加载别名失败，已回退本地别名记录（${localFallbackAliases.length} 条）。`, 'warn');
+      return localFallbackAliases;
+    }
+
+    throw err;
   }
 }
 
@@ -3713,17 +4146,10 @@ async function fetchIcloudHideMyEmail(options = {}) {
   return withIcloudLoginHelp('获取 iCloud 隐私邮箱', async () => {
     throwIfStopped();
     const generateNew = Boolean(options?.generateNew);
-    await addLog('iCloud：正在校验当前浏览器登录状态...', 'info');
+    await addLog('iCloud：正在加载别名列表并校验当前浏览器登录状态...', 'info');
 
-    const { serviceUrl, setupUrl } = await resolveIcloudPremiumMailService();
-    await addLog(`iCloud：已通过 ${new URL(setupUrl).host} 验证会话`, 'ok');
-
-    const existingAliasesResponse = await icloudRequest('GET', `${serviceUrl}/v2/hme/list`);
-    const state = await getState();
-    const existingAliases = normalizeIcloudAliasList(existingAliasesResponse, {
-      usedEmails: getEffectiveUsedEmails(state),
-      preservedEmails: getPreservedAliasMap(state),
-    });
+    // listIcloudAliases already includes transient fallback (fresh cache -> stale cache -> local records).
+    const existingAliases = await listIcloudAliases();
 
     if (!generateNew) {
       const reusableAlias = pickReusableIcloudAlias(existingAliases);
@@ -3739,28 +4165,52 @@ async function fetchIcloudHideMyEmail(options = {}) {
 
     await addLog('iCloud：没有可复用别名，开始生成新的 Hide My Email 地址...', 'warn');
 
-    const generated = await icloudRequest('POST', `${serviceUrl}/v1/hme/generate`);
-    if (!generated?.success || !generated?.result?.hme) {
-      throw new Error(generated?.error?.errorMessage || 'iCloud 隐私邮箱生成失败。');
+    try {
+      const { serviceUrl, setupUrl } = await resolveIcloudPremiumMailService();
+      await addLog(`iCloud：已通过 ${new URL(setupUrl).host} 验证会话`, 'ok');
+
+      const generated = await icloudRequest('POST', `${serviceUrl}/v1/hme/generate`);
+      if (!generated?.success || !generated?.result?.hme) {
+        throw new Error(generated?.error?.errorMessage || 'iCloud 隐私邮箱生成失败。');
+      }
+
+      const reserved = await icloudRequest('POST', `${serviceUrl}/v1/hme/reserve`, {
+        data: {
+          hme: generated.result.hme,
+          label: getIcloudAliasLabel(),
+          note: 'Generated through Multi-Page Automation',
+        },
+      });
+
+      if (!reserved?.success || !reserved?.result?.hme?.hme) {
+        throw new Error(reserved?.error?.errorMessage || 'iCloud 隐私邮箱保留失败。');
+      }
+
+      const alias = String(reserved.result.hme.hme || '').trim().toLowerCase();
+      await setEmailState(alias);
+      await addLog(`iCloud：已创建并保留新别名 ${alias}`, 'ok');
+      broadcastIcloudAliasesChanged({ reason: 'created', email: alias });
+      return alias;
+    } catch (err) {
+      if (!shouldStopIcloudAutoFetchRetries(err)) {
+        throw err;
+      }
+
+      const reusableAlias = pickReusableIcloudAlias(existingAliases);
+      if (reusableAlias) {
+        await setEmailState(reusableAlias.email);
+        await addLog(
+          `iCloud：当前网络/上下文波动，暂无法创建新别名，已临时回退复用 ${reusableAlias.email}。`,
+          'warn'
+        );
+        broadcastIcloudAliasesChanged({ reason: 'selected', email: reusableAlias.email });
+        return reusableAlias.email;
+      }
+
+      throw new Error(
+        `iCloud 当前无法创建新别名：${getErrorMessage(err)}。请先确认 iCloud 页面已登录且网络可访问，再重试。`
+      );
     }
-
-    const reserved = await icloudRequest('POST', `${serviceUrl}/v1/hme/reserve`, {
-      data: {
-        hme: generated.result.hme,
-        label: getIcloudAliasLabel(),
-        note: 'Generated through Multi-Page Automation',
-      },
-    });
-
-    if (!reserved?.success || !reserved?.result?.hme?.hme) {
-      throw new Error(reserved?.error?.errorMessage || 'iCloud 隐私邮箱保留失败。');
-    }
-
-    const alias = String(reserved.result.hme.hme || '').trim().toLowerCase();
-    await setEmailState(alias);
-    await addLog(`iCloud：已创建并保留新别名 ${alias}`, 'ok');
-    broadcastIcloudAliasesChanged({ reason: 'created', email: alias });
-    return alias;
   });
 }
 
@@ -6014,6 +6464,42 @@ async function resumeAutoRunIfWaitingForEmail(options = {}) {
   return false;
 }
 
+function shouldStopIcloudAutoFetchRetries(error) {
+  if (!error) {
+    return false;
+  }
+
+  if (error.code === 'ICLOUD_TRANSIENT_CONTEXT') {
+    return true;
+  }
+
+  const message = getErrorMessage(error).toLowerCase();
+  if (message.includes('请先在新打开的 icloud 页面中完成登录')) {
+    return true;
+  }
+  return message.includes('网络/上下文波动')
+    || message.includes('could not validate icloud session')
+    || message.includes('status 421')
+    || message.includes('failed to fetch')
+    || message.includes('network request failed')
+    || message.includes('networkerror')
+    || message.includes('cors')
+    || message.includes('address space')
+    || message.includes('timed out')
+    || message.includes('timeout');
+}
+
+function shouldStopEmailAutoFetchRetries(generator, error) {
+  if (generator === 'icloud' && shouldStopIcloudAutoFetchRetries(error)) {
+    return true;
+  }
+  const message = String(error?.message || '');
+  if (generator === 'cloudflare' && /域名/.test(message)) {
+    return true;
+  }
+  return generator === CLOUDFLARE_TEMP_EMAIL_GENERATOR && /(服务地址|Admin Auth|域名)/.test(message);
+}
+
 async function ensureAutoEmailReady(targetRun, totalRuns, attemptRuns) {
   const currentState = await getState();
   if (isHotmailProvider(currentState)) {
@@ -6099,7 +6585,9 @@ async function ensureAutoEmailReady(targetRun, totalRuns, attemptRuns) {
   const generator = normalizeEmailGenerator(currentState.emailGenerator);
   const generatorLabel = getEmailGeneratorLabel(generator);
   let lastError = null;
+  let attemptedFetches = 0;
   for (let attempt = 1; attempt <= EMAIL_FETCH_MAX_ATTEMPTS; attempt++) {
+    attemptedFetches = attempt;
     try {
       if (attempt > 1) {
         await addLog(`${generatorLabel}：正在进行第 ${attempt}/${EMAIL_FETCH_MAX_ATTEMPTS} 次自动获取重试...`, 'warn');
@@ -6116,16 +6604,17 @@ async function ensureAutoEmailReady(targetRun, totalRuns, attemptRuns) {
     } catch (err) {
       lastError = err;
       await addLog(`${generatorLabel}自动获取失败（${attempt}/${EMAIL_FETCH_MAX_ATTEMPTS}）：${err.message}`, 'warn');
-      if (
-        (generator === 'cloudflare' && /域名/.test(String(err.message || '')))
-        || (generator === CLOUDFLARE_TEMP_EMAIL_GENERATOR && /(服务地址|Admin Auth|域名)/.test(String(err.message || '')))
-      ) {
+      if (generator === 'icloud' && shouldStopIcloudAutoFetchRetries(err)) {
+        await addLog('iCloud：检测到会话/网络异常，本轮将停止重复重试。请先确认 iCloud 页面已登录，再点击“我已登录”或手动粘贴邮箱继续。', 'warn');
+      }
+      if (shouldStopEmailAutoFetchRetries(generator, err)) {
         break;
       }
     }
   }
 
-  await addLog(`${generatorLabel}自动获取已连续失败 ${EMAIL_FETCH_MAX_ATTEMPTS} 次：${lastError?.message || '未知错误'}`, 'error');
+  const totalAttempts = Math.max(1, attemptedFetches);
+  await addLog(`${generatorLabel}自动获取已连续失败 ${totalAttempts} 次：${lastError?.message || '未知错误'}`, 'error');
   await addLog(`=== 目标 ${targetRun}/${totalRuns} 轮已暂停：请先自动获取邮箱或手动粘贴邮箱，然后继续 ===`, 'warn');
   await broadcastAutoRunStatus('waiting_email', {
     currentRun: targetRun,
@@ -6248,7 +6737,9 @@ async function ensureAutoEmailReady(targetRun, totalRuns, attemptRuns) {
   const generator = normalizeEmailGenerator(currentState.emailGenerator);
   const generatorLabel = getEmailGeneratorLabel(generator);
   let lastError = null;
+  let attemptedFetches = 0;
   for (let attempt = 1; attempt <= EMAIL_FETCH_MAX_ATTEMPTS; attempt++) {
+    attemptedFetches = attempt;
     try {
       if (attempt > 1) {
         await addLog(`${generatorLabel}：正在进行第 ${attempt}/${EMAIL_FETCH_MAX_ATTEMPTS} 次自动获取重试...`, 'warn');
@@ -6265,16 +6756,17 @@ async function ensureAutoEmailReady(targetRun, totalRuns, attemptRuns) {
     } catch (err) {
       lastError = err;
       await addLog(`${generatorLabel}自动获取失败（${attempt}/${EMAIL_FETCH_MAX_ATTEMPTS}）：${err.message}`, 'warn');
-      if (
-        (generator === 'cloudflare' && /域名/.test(String(err.message || '')))
-        || (generator === CLOUDFLARE_TEMP_EMAIL_GENERATOR && /(服务地址|Admin Auth|域名)/.test(String(err.message || '')))
-      ) {
+      if (generator === 'icloud' && shouldStopIcloudAutoFetchRetries(err)) {
+        await addLog('iCloud：检测到会话/网络异常，本轮将停止重复重试。请先确认 iCloud 页面已登录，再点击“我已登录”或手动粘贴邮箱继续。', 'warn');
+      }
+      if (shouldStopEmailAutoFetchRetries(generator, err)) {
         break;
       }
     }
   }
 
-  await addLog(`${generatorLabel}自动获取已连续失败 ${EMAIL_FETCH_MAX_ATTEMPTS} 次：${lastError?.message || '未知错误'}`, 'error');
+  const totalAttempts = Math.max(1, attemptedFetches);
+  await addLog(`${generatorLabel}自动获取已连续失败 ${totalAttempts} 次：${lastError?.message || '未知错误'}`, 'error');
   await addLog(`=== 目标 ${targetRun}/${totalRuns} 轮已暂停：请先自动获取邮箱或手动粘贴邮箱，然后继续 ===`, 'warn');
   await broadcastAutoRunStatus('waiting_email', {
     currentRun: targetRun,

--- a/background.js
+++ b/background.js
@@ -119,6 +119,7 @@ const {
   getIcloudSetupUrlForHost,
   normalizeBooleanMap,
   normalizeIcloudAliasList,
+  normalizeIcloudAliasRecord,
   normalizeIcloudHost,
   pickReusableIcloudAlias,
   toNormalizedEmailSet,
@@ -137,6 +138,9 @@ const ICLOUD_LOGIN_URLS = [
   'https://www.icloud.com.cn/',
   'https://www.icloud.com/',
 ];
+const ICLOUD_ALIAS_CACHE_MAX_AGE_MS = 6 * 60 * 60 * 1000;
+const ICLOUD_TRANSIENT_RETRY_MAX_ATTEMPTS = 2;
+const ICLOUD_TRANSIENT_RETRY_DELAY_MS = 1200;
 const ICLOUD_PROVIDER = 'icloud';
 const GMAIL_PROVIDER = 'gmail';
 const GMAIL_ALIAS_GENERATOR = 'gmail-alias';
@@ -329,6 +333,8 @@ const DEFAULT_STATE = {
   accountRunHistory: [], // 账号运行历史快照，实际持久化在 chrome.storage.local。
   manualAliasUsage: {},
   preservedAliases: {},
+  icloudAliasCache: [],
+  icloudAliasCacheAt: 0,
   lastEmailTimestamp: null, // 最近一次获取到邮箱数据的运行时时间戳。
   lastSignupCode: null, // 注册验证码，运行时由程序自动读取并写入。
   lastLoginCode: null, // 登录验证码，运行时由程序自动读取并写入。
@@ -1404,6 +1410,35 @@ function isAliasPreserved(state, email) {
 
 function getEffectiveUsedEmails(state) {
   return toNormalizedEmailSet(getManualAliasUsageMap(state));
+}
+
+function normalizeIcloudAliasCacheList(value = [], options = {}) {
+  const aliases = Array.isArray(value) ? value : [];
+  const usedEmails = toNormalizedEmailSet(options.usedEmails);
+  const preservedEmails = toNormalizedEmailSet(options.preservedEmails);
+  return aliases
+    .map((alias) => normalizeIcloudAliasRecord(alias, { usedEmails, preservedEmails }))
+    .filter(Boolean)
+    .sort((left, right) => {
+      if (left.active !== right.active) return left.active ? -1 : 1;
+      if (left.used !== right.used) return left.used ? 1 : -1;
+      return String(left.email).localeCompare(String(right.email));
+    });
+}
+
+function getIcloudAliasCacheFromState(state, options = {}) {
+  const maxAgeMs = Math.max(0, Number(options.maxAgeMs) || ICLOUD_ALIAS_CACHE_MAX_AGE_MS);
+  const cachedAt = Number(state?.icloudAliasCacheAt || 0);
+  if (!Array.isArray(state?.icloudAliasCache) || state.icloudAliasCache.length <= 0) {
+    return [];
+  }
+  if (maxAgeMs > 0 && cachedAt > 0 && Date.now() - cachedAt > maxAgeMs) {
+    return [];
+  }
+  return normalizeIcloudAliasCacheList(state.icloudAliasCache, {
+    usedEmails: getEffectiveUsedEmails(state),
+    preservedEmails: getPreservedAliasMap(state),
+  });
 }
 
 async function setIcloudAliasUsedState(payload = {}, options = {}) {
@@ -3452,19 +3487,32 @@ async function promptIcloudLogin(error, actionLabel = 'iCloud 操作') {
 }
 
 async function withIcloudLoginHelp(actionLabel, action) {
-  try {
-    return await action();
-  } catch (err) {
-    if (isIcloudLoginRequiredError(err)) {
-      await promptIcloudLogin(err, actionLabel);
-      throw new Error('请先在新打开的 iCloud 页面中完成登录，再回来点击“我已登录”。');
+  const maxTransientAttempts = Math.max(1, Number(ICLOUD_TRANSIENT_RETRY_MAX_ATTEMPTS) || 1);
+  const retryDelayMs = Math.max(300, Number(ICLOUD_TRANSIENT_RETRY_DELAY_MS) || 1200);
+  for (let attempt = 1; attempt <= maxTransientAttempts; attempt += 1) {
+    try {
+      return await action();
+    } catch (err) {
+      if (isIcloudLoginRequiredError(err)) {
+        await promptIcloudLogin(err, actionLabel);
+        throw new Error('请先在新打开的 iCloud 页面中完成登录，再回来点击“我已登录”。');
+      }
+      if (isIcloudTransientContextError(err)) {
+        if (attempt < maxTransientAttempts) {
+          await addLog(`iCloud：${actionLabel}受网络/上下文波动影响，正在重试（${attempt}/${maxTransientAttempts}）...`, 'warn');
+          await new Promise((resolve) => setTimeout(resolve, retryDelayMs * attempt));
+          continue;
+        }
+        await addLog(`iCloud：${actionLabel}受网络/上下文波动影响：${getErrorMessage(err)}`, 'warn');
+        const transientError = new Error('iCloud 别名加载受网络/上下文波动影响，请稍后重试。');
+        transientError.code = 'ICLOUD_TRANSIENT_CONTEXT';
+        transientError.cause = err;
+        throw transientError;
+      }
+      throw err;
     }
-    if (isIcloudTransientContextError(err)) {
-      await addLog(`iCloud：${actionLabel}受网络/上下文波动影响：${getErrorMessage(err)}`, 'warn');
-      throw new Error('iCloud 别名加载受网络/上下文波动影响，请稍后重试。');
-    }
-    throw err;
   }
+  throw new Error('iCloud 操作失败：未知错误。');
 }
 
 async function icloudRequest(method, url, options = {}) {
@@ -3549,15 +3597,36 @@ async function checkIcloudSession(options = {}) {
 }
 
 async function listIcloudAliases(options = {}) {
-  return withIcloudLoginHelp('加载 iCloud 隐私邮箱列表', async () => {
-    const { serviceUrl } = await resolveIcloudPremiumMailService(options);
-    const response = await icloudRequest('GET', `${serviceUrl}/v2/hme/list`);
-    const state = await getState();
-    return normalizeIcloudAliasList(response, {
-      usedEmails: getEffectiveUsedEmails(state),
-      preservedEmails: getPreservedAliasMap(state),
+  try {
+    return await withIcloudLoginHelp('加载 iCloud 隐私邮箱列表', async () => {
+      const { serviceUrl } = await resolveIcloudPremiumMailService(options);
+      const response = await icloudRequest('GET', `${serviceUrl}/v2/hme/list`);
+      const state = await getState();
+      const aliases = normalizeIcloudAliasList(response, {
+        usedEmails: getEffectiveUsedEmails(state),
+        preservedEmails: getPreservedAliasMap(state),
+      });
+      await setState({
+        icloudAliasCache: normalizeIcloudAliasCacheList(aliases),
+        icloudAliasCacheAt: Date.now(),
+      });
+      return aliases;
     });
-  });
+  } catch (err) {
+    const message = getErrorMessage(err);
+    const transientContextError = err?.code === 'ICLOUD_TRANSIENT_CONTEXT'
+      || message.includes('网络/上下文波动');
+    if (!transientContextError) {
+      throw err;
+    }
+    const state = await getState();
+    const cachedAliases = getIcloudAliasCacheFromState(state);
+    if (!cachedAliases.length) {
+      throw err;
+    }
+    await addLog(`iCloud：加载别名失败，已回退最近缓存（${cachedAliases.length} 条）。`, 'warn');
+    return cachedAliases;
+  }
 }
 
 async function deleteIcloudAlias(payload) {

--- a/icloud-utils.js
+++ b/icloud-utils.js
@@ -7,10 +7,17 @@
   root.IcloudUtils = factory();
 })(typeof self !== 'undefined' ? self : globalThis, function createIcloudUtils() {
   function normalizeIcloudHost(rawHost) {
-    const host = String(rawHost || '').trim().toLowerCase();
+    let host = String(rawHost || '').trim().toLowerCase();
     if (!host) return '';
-    if (host === 'icloud.com' || host === 'www.icloud.com' || host === 'setup.icloud.com') return 'icloud.com';
-    if (host === 'icloud.com.cn' || host === 'www.icloud.com.cn' || host === 'setup.icloud.com.cn') return 'icloud.com.cn';
+    try {
+      if (host.includes('://')) {
+        host = new URL(host).hostname.toLowerCase();
+      }
+    } catch {}
+    host = host.split('/')[0].split('?')[0].split('#')[0];
+    host = host.replace(/:\d+$/, '').replace(/\.$/, '');
+    if (host === 'icloud.com' || host.endsWith('.icloud.com')) return 'icloud.com';
+    if (host === 'icloud.com.cn' || host.endsWith('.icloud.com.cn')) return 'icloud.com.cn';
     return '';
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "codex-oauth-automation-extension",
-  "version": "7.6",
-  "version_name": "Pro7.6",
+  "version": "8.0",
+  "version_name": "Pro8.0",
   "description": "用于自动执行多步骤 OAuth 注册流程",
   "permissions": [
     "sidePanel",

--- a/sidepanel/icloud-manager.js
+++ b/sidepanel/icloud-manager.js
@@ -388,6 +388,19 @@
       }
     }
 
+    function isLikelyIcloudLoginRequiredMessage(message = '') {
+      const lower = String(message || '').toLowerCase();
+      return lower.includes('请先在新打开的 icloud 页面中完成登录')
+        || lower.includes('请先在当前浏览器登录')
+        || lower.includes('需要先登录')
+        || lower.includes('请先登录')
+        || lower.includes('please sign in')
+        || lower.includes('sign in required')
+        || lower.includes('not logged in')
+        || lower.includes('authentication required')
+        || lower.includes('unauthenticated');
+    }
+
     async function handleLoginDone() {
       if (dom.btnIcloudLoginDone) {
         dom.btnIcloudLoginDone.disabled = true;
@@ -405,7 +418,14 @@
         helpers.showToast('iCloud 会话已恢复，别名列表已刷新。', 'success', 2600);
         await refreshIcloudAliases({ silent: true });
       } catch (err) {
-        helpers.showToast(`看起来还没有登录完成：${err.message}`, 'warn', 4200);
+        const errorMessage = String(err?.message || '未知错误');
+        if (isLikelyIcloudLoginRequiredMessage(errorMessage)) {
+          helpers.showToast(`看起来还没有登录完成：${errorMessage}`, 'warn', 4200);
+          return;
+        }
+
+        await refreshIcloudAliases({ silent: true }).catch(() => { });
+        helpers.showToast(`iCloud 会话校验失败（非登录态）：${errorMessage}`, 'warn', 4200);
       } finally {
         if (dom.btnIcloudLoginDone) {
           dom.btnIcloudLoginDone.disabled = false;

--- a/tests/background-icloud-login-help.test.js
+++ b/tests/background-icloud-login-help.test.js
@@ -67,8 +67,38 @@ test('icloud login helper distinguishes auth-required errors from transient cont
 
   assert.match(
     source,
+    /function appendIcloudClientQueryParams\(rawUrl = ''\) \{[\s\S]*clientBuildNumber[\s\S]*clientMasteringNumber[\s\S]*clientId[\s\S]*dsid/m,
+    'icloud maildomainws requests should include compatible client query params before sending requests'
+  );
+
+  assert.match(
+    source,
+    /function isIcloudMailPageUrl\(rawUrl = ''\) \{[\s\S]*pathname === '\/mail'[\s\S]*pathname\.startsWith\('\/mail\/'\)/m,
+    'icloud page-context fallback should be able to identify mail pages as preferred execution context'
+  );
+
+  assert.match(
+    source,
+    /async function waitForIcloudMailTabReady\(tabId, timeoutMs = 8000\) \{[\s\S]*status === 'complete'/m,
+    'icloud page-context fallback should wait for a created mail tab to finish loading before using it'
+  );
+
+  assert.match(
+    source,
+    /async function icloudRequestViaPageContext\(method, url, options = \{\}\) \{[\s\S]*ensureIcloudMailContextTab\([\s\S]*isIcloudMailPageUrl\(tab\?\.url\) \? 8 : 0[\s\S]*const mailTabs = sortedTabs\.filter/m,
+    'icloud page-context requests should ensure a mail-context tab exists and prioritize it before other icloud pages'
+  );
+
+  assert.match(
+    source,
     /async function fetchIcloudHideMyEmail\(options = \{\}\) \{[\s\S]*const existingAliases = await listIcloudAliases\(\);/m,
     'icloud auto-fetch should load aliases through listIcloudAliases so transient cache/local fallback applies before creation'
+  );
+
+  assert.match(
+    source,
+    /保留别名返回鉴权\/网络异常，正在回查别名列表确认是否已创建[\s\S]*保留请求异常，但已在列表确认别名/m,
+    'icloud auto-fetch should attempt list-confirmation recovery when reserve returns auth/network errors'
   );
 
   assert.match(

--- a/tests/background-icloud-login-help.test.js
+++ b/tests/background-icloud-login-help.test.js
@@ -1,0 +1,25 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+test('icloud login helper distinguishes auth-required errors from transient context errors', () => {
+  const source = fs.readFileSync('background.js', 'utf8');
+
+  assert.match(
+    source,
+    /function isIcloudLoginRequiredError\(error\) \{[\s\S]*status \(401\|403\)[\s\S]*status \(409\|421\|429\|5\\d\\d\)[\s\S]*return false;/m,
+    'login-required detection should only force login for auth failures and ignore transient 421/429/5xx statuses'
+  );
+
+  assert.match(
+    source,
+    /function isIcloudTransientContextError\(error\) \{[\s\S]*status \(409\|421\|429\|5\\d\\d\)[\s\S]*timeout[\s\S]*timed out/m,
+    'transient context detection should treat 421/429/5xx and timeout-like network errors as retryable context failures'
+  );
+
+  assert.match(
+    source,
+    /if \(isIcloudTransientContextError\(err\)\) \{[\s\S]*iCloud 别名加载受网络\/上下文波动影响，请稍后重试。/m,
+    'withIcloudLoginHelp should surface transient-context copy instead of forcing login prompt'
+  );
+});

--- a/tests/background-icloud-login-help.test.js
+++ b/tests/background-icloud-login-help.test.js
@@ -7,13 +7,13 @@ test('icloud login helper distinguishes auth-required errors from transient cont
 
   assert.match(
     source,
-    /function isIcloudLoginRequiredError\(error\) \{[\s\S]*status \(401\|403\)[\s\S]*status \(409\|421\|429\|5\\d\\d\)[\s\S]*return false;/m,
+    /function isIcloudLoginRequiredError\(error\) \{[\s\S]*hasAuthStatus401[\s\S]*status \(409\|421\|429\|5\\d\\d\)[\s\S]*could not validate icloud session[\s\S]*return false;/m,
     'login-required detection should only force login for auth failures and ignore transient 421/429/5xx statuses'
   );
 
   assert.match(
     source,
-    /function isIcloudTransientContextError\(error\) \{[\s\S]*status \(409\|421\|429\|5\\d\\d\)[\s\S]*timeout[\s\S]*timed out/m,
+    /function isIcloudTransientContextError\(error\) \{[\s\S]*status \(401\|403\|409\|421\|429\|5\\d\\d\)[\s\S]*timeout[\s\S]*timed out/m,
     'transient context detection should treat 421/429/5xx and timeout-like network errors as retryable context failures'
   );
 
@@ -37,7 +37,43 @@ test('icloud login helper distinguishes auth-required errors from transient cont
 
   assert.match(
     source,
-    /已回退最近缓存（\$\{cachedAliases\.length\} 条）/,
+    /已回退最近缓存（\$\{[a-zA-Z0-9_]+\.length\} 条）/,
     'icloud alias listing should fallback to cached aliases when transient context errors occur'
+  );
+
+  assert.match(
+    source,
+    /PERSISTENT_ALIAS_STATE_KEYS = \[[\s\S]*'icloudAliasCache'[\s\S]*'icloudAliasCacheAt'[\s\S]*\]/m,
+    'icloud alias cache should be persisted so transient fallback can survive restarts'
+  );
+
+  assert.match(
+    source,
+    /function shouldStopIcloudAutoFetchRetries\(error\) \{[\s\S]*网络\/上下文波动[\s\S]*status 421/m,
+    'icloud auto-fetch retry guard should stop repeated retries for transient session/context failures'
+  );
+
+  assert.match(
+    source,
+    /async function validateIcloudSessionViaPageContext\(tabId, setupUrl\) \{[\s\S]*world:\s*'MAIN'[\s\S]*\/validate/m,
+    'icloud service resolution should support page-context validate fallback when background validate keeps failing'
+  );
+
+  assert.match(
+    source,
+    /function isIcloudApiUrl\(url = ''\) \{[\s\S]*new URL\(rawUrl\)[\s\S]*hostname\.endsWith\('\.icloud\.com'\)[\s\S]*hostname\.endsWith\('\.icloud\.com\.cn'\)/m,
+    'icloud api url detection should match icloud subdomains so maildomainws hosts can trigger page-context fallback'
+  );
+
+  assert.match(
+    source,
+    /async function fetchIcloudHideMyEmail\(options = \{\}\) \{[\s\S]*const existingAliases = await listIcloudAliases\(\);/m,
+    'icloud auto-fetch should load aliases through listIcloudAliases so transient cache/local fallback applies before creation'
+  );
+
+  assert.match(
+    source,
+    /当前网络\/上下文波动，暂无法创建新别名，已临时回退复用/,
+    'icloud auto-fetch should fallback to reusable aliases when create-new fails due transient session/context issues'
   );
 });

--- a/tests/background-icloud-login-help.test.js
+++ b/tests/background-icloud-login-help.test.js
@@ -22,4 +22,22 @@ test('icloud login helper distinguishes auth-required errors from transient cont
     /if \(isIcloudTransientContextError\(err\)\) \{[\s\S]*iCloud 别名加载受网络\/上下文波动影响，请稍后重试。/m,
     'withIcloudLoginHelp should surface transient-context copy instead of forcing login prompt'
   );
+
+  assert.match(
+    source,
+    /ICLOUD_TRANSIENT_RETRY_MAX_ATTEMPTS = 2/,
+    'icloud transient context handling should retry at least once before failing'
+  );
+
+  assert.match(
+    source,
+    /function getIcloudAliasCacheFromState\(state, options = \{\}\)/,
+    'icloud alias flow should expose cache lookup helper for transient fallback'
+  );
+
+  assert.match(
+    source,
+    /已回退最近缓存（\$\{cachedAliases\.length\} 条）/,
+    'icloud alias listing should fallback to cached aliases when transient context errors occur'
+  );
 });

--- a/tests/icloud-utils.test.js
+++ b/tests/icloud-utils.test.js
@@ -20,6 +20,8 @@ const {
 test('normalizeIcloudHost and host preference helpers resolve supported hosts', () => {
   assert.equal(normalizeIcloudHost('www.icloud.com'), 'icloud.com');
   assert.equal(normalizeIcloudHost('setup.icloud.com.cn'), 'icloud.com.cn');
+  assert.equal(normalizeIcloudHost('setup.icloud.com:443'), 'icloud.com');
+  assert.equal(normalizeIcloudHost('https://setup.icloud.com.cn/setup/ws/1'), 'icloud.com.cn');
   assert.equal(normalizeIcloudHost('example.com'), '');
 
   assert.equal(getConfiguredIcloudHostPreference({ icloudHostPreference: 'icloud.com' }), 'icloud.com');


### PR DESCRIPTION
## 背景（问题说明）
在 iCloud 已登录状态下，自动流程仍会间歇性失败，常见表现：

- `LIST_ICLOUD_ALIASES` 偶发 `status 401`
- `POST /v1/hme/generate` / `POST /v1/hme/reserve` 偶发 `status 401`
- sidepanel 误提示“未登录完成”
- 自动流程进入 `waiting_email` 暂停

现场日志中可见典型报错：
- `iCloud 请求失败：POST https://p172-maildomainws.icloud.com/v1/hme/reserve，status 401`
- `page_context:tab_xxx:Failed to fetch`

## 这次修复内容
### 1) Pro8.0 基线固化
- 升级版本到 `manifest.version=8.0` / `version_name=Pro8.0`

### 2) iCloud 会话与错误分流
- 收紧“未登录”判定：仅在明确鉴权失败场景触发登录引导
- 将 `421/429/5xx`、网络/CORS/address-space 等归类为上下文波动
- 避免把上下文问题误报为“请先登录”

### 3) iCloud API 回退能力增强
- iCloud API 域名识别覆盖所有 `*.icloud.com` / `*.icloud.com.cn`
- direct 请求失败后，支持 page-context 回退
- page-context 前强制确保并优先使用 `https://www.icloud.com/mail/` 上下文（避免 `icloudplus` 页面上下文不稳定）

### 4) maildomainws 兼容修复（关键）
针对 `maildomainws` 请求增加兼容参数与请求头：
- 自动附加 `clientBuildNumber/clientMasteringNumber/clientId/dsid`
- 带 body 请求使用 `Content-Type: text/plain;charset=UTF-8`

### 5) reserve 401 恢复链路
- `reserve` 发生 `401/403/409` 或 `failed to fetch` 时，不直接失败
- 自动回查 `/v2/hme/list` 确认是否已创建成功
- 若列表未确认但 `generate` 已返回 alias，则回退使用该 alias，避免整轮中断

### 6) 别名回退策略完善
- `list` 失败时依次回退：最近缓存 -> 历史缓存 -> 本地别名记录
- 自动流程检测到上下文波动后停止无效重复重试，减少误导性噪音

## 影响文件
- `background.js`
- `icloud-utils.js`
- `sidepanel/icloud-manager.js`
- `manifest.json`
- `tests/background-icloud-login-help.test.js`
- `tests/icloud-utils.test.js`

## 验证
已在本地通过：
- `node --test tests/icloud-utils.test.js`
- `node --test tests/background-icloud-login-help.test.js tests/background-icloud-mail-provider.test.js tests/background-icloud.test.js`
- `node --test tests/background-generated-email-module.test.js tests/background-auto-run-module.test.js`
- `node --check background.js && node --check icloud-utils.js && node --check sidepanel/icloud-manager.js`

## 目标
把当前 iCloud 问题在 Pro8.0 基线上稳定收敛，后续代理相关改动可在该基线上继续迭代。
