### PR TITLE
feat: Ultra1 新增 IP 模块（独立分支）

### DIFF
--- a/background.js
+++ b/background.js
@@ -7,6 +7,8 @@ importScripts(
   'background/account-run-history.js',
   'background/contribution-oauth.js',
   'background/mail-2925-session.js',
+  'background/ip-proxy-provider-lumiproxy.js',
+  'background/ip-proxy-core.js',
   'background/panel-bridge.js',
   'background/generated-email-helpers.js',
   'background/signup-flow-helpers.js',
@@ -142,6 +144,7 @@ const {
   getIcloudSetupUrlForHost,
   normalizeBooleanMap,
   normalizeIcloudAliasList,
+  normalizeIcloudAliasRecord,
   normalizeIcloudHost,
   pickReusableIcloudAlias,
   toNormalizedEmailSet,
@@ -169,6 +172,18 @@ const ICLOUD_REQUEST_TIMEOUT_MS = 15000;
 const ICLOUD_LIST_MAX_ATTEMPTS = 3;
 const ICLOUD_WRITE_MAX_ATTEMPTS = 2;
 const ICLOUD_RETRY_DELAYS_MS = [1000, 2500, 5000];
+const ICLOUD_TAB_URL_PATTERNS = [
+  'https://www.icloud.com/*',
+  'https://www.icloud.com.cn/*',
+  'https://setup.icloud.com/*',
+  'https://setup.icloud.com.cn/*',
+  'https://*.icloud.com/*',
+  'https://*.icloud.com.cn/*',
+];
+const ICLOUD_MAILDOMAINWS_CLIENT_BUILD_NUMBER = '2206Hotfix11';
+const ICLOUD_ALIAS_CACHE_MAX_AGE_MS = 6 * 60 * 60 * 1000;
+const ICLOUD_TRANSIENT_RETRY_MAX_ATTEMPTS = 2;
+const ICLOUD_TRANSIENT_RETRY_DELAY_MS = 1200;
 const ICLOUD_PROVIDER = 'icloud';
 const GMAIL_PROVIDER = 'gmail';
 const GMAIL_ALIAS_GENERATOR = 'gmail-alias';
@@ -198,6 +213,41 @@ const CONTRIBUTION_SOURCE_SUB2API = 'sub2api';
 const CONTRIBUTION_SUB2API_DEFAULT_GROUP_NAME = 'codex号池';
 const CONTRIBUTION_SUB2API_PLUS_GROUP_NAME = 'openai-plus';
 const DEFAULT_SUB2API_REDIRECT_URI = 'http://localhost:1455/auth/callback';
+const DEFAULT_IP_PROXY_SERVICE = 'lumiproxy';
+const IP_PROXY_SERVICE_VALUES = ['lumiproxy', 'iproyal', '711proxy', 'omegaproxy'];
+const DEFAULT_IP_PROXY_MODE = 'api';
+const IP_PROXY_MODE_VALUES = ['api', 'account'];
+const DEFAULT_IP_PROXY_PROTOCOL = 'http';
+const IP_PROXY_PROTOCOL_VALUES = ['http', 'https', 'socks4', 'socks5'];
+const IP_PROXY_FETCH_TIMEOUT_MS = 20000;
+const IP_PROXY_SETTINGS_SCOPE = 'regular';
+const IP_PROXY_BYPASS_LIST = ['<local>', 'localhost', '127.0.0.1'];
+const IP_PROXY_ROUTE_ALL_TRAFFIC = true;
+const IP_PROXY_ACCOUNT_LIST_ENABLED = false;
+const IP_PROXY_INIT_ENABLE_EXIT_PROBE = false;
+const IP_PROXY_INIT_SUPPRESS_AUTH_REBIND = true;
+const IP_PROXY_TARGET_HOST_PATTERNS = [
+  'openai.com',
+  '*.openai.com',
+  'chatgpt.com',
+  '*.chatgpt.com',
+  'ipwho.is',
+  '*.ipwho.is',
+  'ipapi.co',
+  '*.ipapi.co',
+  'ipinfo.io',
+  '*.ipinfo.io',
+  'api.ipify.org',
+  'api64.ipify.org',
+  'api.ip.cc',
+  'ifconfig.me',
+  'checkip.amazonaws.com',
+  'ipv4.icanhazip.com',
+  'ident.me',
+  'httpbin.org',
+  'ip-api.com',
+  'myip.ipip.net',
+];
 const AUTO_RUN_TIMER_ALARM_NAME = 'auto-run-timer';
 const AUTO_RUN_TIMER_KIND_SCHEDULED_START = 'scheduled_start';
 const AUTO_RUN_TIMER_KIND_BETWEEN_ROUNDS = 'between_rounds';
@@ -231,7 +281,12 @@ const HERO_SMS_COUNTRY_ID = 52;
 const HERO_SMS_COUNTRY_LABEL = 'Thailand';
 const DISPLAY_TIMEZONE = 'Asia/Shanghai';
 const MICROSOFT_TOKEN_DNR_RULE_ID = 1001;
-const PERSISTENT_ALIAS_STATE_KEYS = ['manualAliasUsage', 'preservedAliases'];
+const PERSISTENT_ALIAS_STATE_KEYS = [
+  'manualAliasUsage',
+  'preservedAliases',
+  'icloudAliasCache',
+  'icloudAliasCacheAt',
+];
 const ACCOUNT_RUN_HISTORY_STORAGE_KEY = 'accountRunHistory';
 const CONTRIBUTION_RUNTIME_DEFAULTS = self.MultiPageBackgroundContributionOAuth?.RUNTIME_DEFAULTS || {
   contributionMode: false,
@@ -358,6 +413,21 @@ const PERSISTED_SETTING_DEFAULTS = {
   sub2apiPassword: '',
   sub2apiGroupName: DEFAULT_SUB2API_GROUP_NAME,
   sub2apiDefaultProxyName: DEFAULT_SUB2API_PROXY_NAME,
+  ipProxyEnabled: false,
+  ipProxyService: DEFAULT_IP_PROXY_SERVICE,
+  ipProxyMode: DEFAULT_IP_PROXY_MODE,
+  ipProxyApiUrl: '',
+  ipProxyServiceProfiles: {},
+  ipProxyAccountList: '',
+  ipProxyAccountSessionPrefix: '',
+  ipProxyAccountLifeMinutes: '',
+  ipProxyPoolTargetCount: '20',
+  ipProxyHost: '',
+  ipProxyPort: '',
+  ipProxyProtocol: DEFAULT_IP_PROXY_PROTOCOL,
+  ipProxyUsername: '',
+  ipProxyPassword: '',
+  ipProxyRegion: '',
   codex2apiUrl: DEFAULT_CODEX2API_URL,
   codex2apiAdminKey: '',
   customPassword: '',
@@ -441,6 +511,8 @@ const DEFAULT_STATE = {
   accountRunHistory: [], // 账号运行历史快照，实际持久化在 chrome.storage.local。
   manualAliasUsage: {},
   preservedAliases: {},
+  icloudAliasCache: [],
+  icloudAliasCacheAt: 0,
   lastEmailTimestamp: null, // 最近一次获取到邮箱数据的运行时时间戳。
   lastSignupCode: null, // 注册验证码，运行时由程序自动读取并写入。
   lastLoginCode: null, // 登录验证码，运行时由程序自动读取并写入。
@@ -465,6 +537,15 @@ const DEFAULT_STATE = {
   sourceLastUrls: {}, // 各来源页面最近一次打开的地址记录。
   logs: [], // 侧边栏展示的运行日志。
   ...PERSISTED_SETTING_DEFAULTS, // 合并 chrome.storage.local 中持久化保存的用户配置。
+  ipProxyApiPool: [],
+  ipProxyApiCurrentIndex: 0,
+  ipProxyApiCurrent: null,
+  ipProxyAccountPool: [],
+  ipProxyAccountCurrentIndex: 0,
+  ipProxyAccountCurrent: null,
+  ipProxyPool: [],
+  ipProxyCurrentIndex: 0,
+  ipProxyCurrent: null,
   luckmailApiKey: '',
   luckmailBaseUrl: DEFAULT_LUCKMAIL_BASE_URL,
   luckmailEmailType: DEFAULT_LUCKMAIL_EMAIL_TYPE,
@@ -495,6 +576,21 @@ const DEFAULT_STATE = {
   currentHotmailAccountId: null,
   currentMail2925AccountId: null,
   preferredIcloudHost: '',
+  ipProxyApplied: false,
+  ipProxyAppliedReason: 'disabled',
+  ipProxyAppliedAt: 0,
+  ipProxyAppliedHost: '',
+  ipProxyAppliedPort: 0,
+  ipProxyAppliedRegion: '',
+  ipProxyAppliedHasAuth: false,
+  ipProxyAppliedProvider: DEFAULT_IP_PROXY_SERVICE,
+  ipProxyAppliedError: '',
+  ipProxyAppliedWarning: '',
+  ipProxyAppliedExitIp: '',
+  ipProxyAppliedExitRegion: '',
+  ipProxyAppliedExitDetecting: false,
+  ipProxyAppliedExitError: '',
+  ipProxyAppliedExitSource: '',
 };
 
 function normalizeAutoRunDelayMinutes(value) {
@@ -1077,6 +1173,63 @@ function normalizePersistentSettingValue(key, value) {
       return String(value || '').trim();
     case 'sub2apiDefaultProxyName':
       return String(value || '').trim();
+    case 'ipProxyEnabled':
+      return Boolean(value);
+    case 'ipProxyService':
+      return normalizeIpProxyProviderValue(value);
+    case 'ipProxyMode':
+      return normalizeIpProxyMode(value);
+    case 'ipProxyApiUrl':
+      return String(value || '').trim();
+    case 'ipProxyServiceProfiles':
+      return normalizeIpProxyServiceProfiles(value || {}, PERSISTED_SETTING_DEFAULTS);
+    case 'ipProxyAccountList':
+      return normalizeIpProxyAccountList(value || '');
+    case 'ipProxyAccountSessionPrefix':
+      return normalizeIpProxyAccountSessionPrefix(value || '');
+    case 'ipProxyAccountLifeMinutes':
+      return normalizeIpProxyAccountLifeMinutes(value || '');
+    case 'ipProxyPoolTargetCount':
+      return normalizeIpProxyPoolTargetCount(value || '', 20);
+    case 'ipProxyHost':
+      return String(value || '').trim();
+    case 'ipProxyPort':
+      return String(normalizeIpProxyPort(value || '') || '');
+    case 'ipProxyProtocol':
+      return normalizeIpProxyProtocol(value);
+    case 'ipProxyUsername':
+      return String(value || '').trim();
+    case 'ipProxyPassword':
+      return String(value || '');
+    case 'ipProxyRegion':
+      return String(value || '').trim();
+    case 'ipProxyApiPool':
+      return normalizeProxyPoolEntries(
+        value,
+        normalizeIpProxyProviderValue(value?.provider || DEFAULT_IP_PROXY_SERVICE)
+      );
+    case 'ipProxyApiCurrentIndex':
+      return normalizeIpProxyCurrentIndex(value, 0);
+    case 'ipProxyApiCurrent':
+      return normalizeProxyPoolEntries(value ? [value] : [], DEFAULT_IP_PROXY_SERVICE)[0] || null;
+    case 'ipProxyAccountPool':
+      return normalizeProxyPoolEntries(
+        value,
+        normalizeIpProxyProviderValue(value?.provider || DEFAULT_IP_PROXY_SERVICE)
+      );
+    case 'ipProxyAccountCurrentIndex':
+      return normalizeIpProxyCurrentIndex(value, 0);
+    case 'ipProxyAccountCurrent':
+      return normalizeProxyPoolEntries(value ? [value] : [], DEFAULT_IP_PROXY_SERVICE)[0] || null;
+    case 'ipProxyPool':
+      return normalizeProxyPoolEntries(
+        value,
+        normalizeIpProxyProviderValue(value?.provider || DEFAULT_IP_PROXY_SERVICE)
+      );
+    case 'ipProxyCurrentIndex':
+      return normalizeIpProxyCurrentIndex(value, 0);
+    case 'ipProxyCurrent':
+      return normalizeProxyPoolEntries(value ? [value] : [], DEFAULT_IP_PROXY_SERVICE)[0] || null;
     case 'codex2apiUrl':
       return normalizeCodex2ApiUrl(value);
     case 'codex2apiAdminKey':
@@ -1221,6 +1374,34 @@ function buildPersistentSettingsPayload(input = {}, options = {}) {
     }
     payload.cloudflareTempEmailDomains = domains;
   }
+  if (payload.ipProxyServiceProfiles) {
+    const selectedService = normalizeIpProxyProviderValue(
+      payload.ipProxyService || PERSISTED_SETTING_DEFAULTS.ipProxyService
+    );
+    const normalizedProfiles = normalizeIpProxyServiceProfiles(payload.ipProxyServiceProfiles, {
+      ...PERSISTED_SETTING_DEFAULTS,
+      ...payload,
+    });
+    payload.ipProxyServiceProfiles = normalizedProfiles;
+    const activeProfile = normalizedProfiles[selectedService]
+      || buildIpProxyServiceProfileFromState({
+        ...PERSISTED_SETTING_DEFAULTS,
+        ...payload,
+      });
+    payload.ipProxyService = selectedService;
+    payload.ipProxyMode = normalizeIpProxyMode(activeProfile?.mode || payload.ipProxyMode);
+    payload.ipProxyApiUrl = String(activeProfile?.apiUrl || payload.ipProxyApiUrl || '').trim();
+    payload.ipProxyAccountList = normalizeIpProxyAccountList(activeProfile?.accountList || payload.ipProxyAccountList || '');
+    payload.ipProxyAccountSessionPrefix = normalizeIpProxyAccountSessionPrefix(activeProfile?.accountSessionPrefix || payload.ipProxyAccountSessionPrefix || '');
+    payload.ipProxyAccountLifeMinutes = normalizeIpProxyAccountLifeMinutes(activeProfile?.accountLifeMinutes || payload.ipProxyAccountLifeMinutes || '');
+    payload.ipProxyPoolTargetCount = normalizeIpProxyPoolTargetCount(activeProfile?.poolTargetCount || payload.ipProxyPoolTargetCount || '', 20);
+    payload.ipProxyHost = String(activeProfile?.host || payload.ipProxyHost || '').trim();
+    payload.ipProxyPort = String(normalizeIpProxyPort(activeProfile?.port || payload.ipProxyPort || '') || '');
+    payload.ipProxyProtocol = normalizeIpProxyProtocol(activeProfile?.protocol || payload.ipProxyProtocol);
+    payload.ipProxyUsername = String(activeProfile?.username || payload.ipProxyUsername || '').trim();
+    payload.ipProxyPassword = String(activeProfile?.password || payload.ipProxyPassword || '');
+    payload.ipProxyRegion = String(activeProfile?.region || payload.ipProxyRegion || '').trim();
+  }
 
   return payload;
 }
@@ -1237,15 +1418,24 @@ async function getPersistedSettings() {
 async function getPersistedAliasState() {
   try {
     const stored = await chrome.storage.local.get(PERSISTENT_ALIAS_STATE_KEYS);
+    const manualAliasUsage = normalizeBooleanMap(stored.manualAliasUsage);
+    const preservedAliases = normalizeBooleanMap(stored.preservedAliases);
     return {
-      manualAliasUsage: normalizeBooleanMap(stored.manualAliasUsage),
-      preservedAliases: normalizeBooleanMap(stored.preservedAliases),
+      manualAliasUsage,
+      preservedAliases,
+      icloudAliasCache: normalizeIcloudAliasCacheList(stored.icloudAliasCache, {
+        usedEmails: toNormalizedEmailSet(manualAliasUsage),
+        preservedEmails: toNormalizedEmailSet(preservedAliases),
+      }),
+      icloudAliasCacheAt: Math.max(0, Number(stored.icloudAliasCacheAt) || 0),
     };
   } catch (err) {
     console.warn(LOG_PREFIX, 'Failed to read persisted iCloud alias state:', err?.message || err);
     return {
       manualAliasUsage: {},
       preservedAliases: {},
+      icloudAliasCache: [],
+      icloudAliasCacheAt: 0,
     };
   }
 }
@@ -1283,6 +1473,12 @@ async function setState(updates) {
     }
     if (Object.prototype.hasOwnProperty.call(updates, 'preservedAliases')) {
       persistentAliasUpdates.preservedAliases = normalizeBooleanMap(updates.preservedAliases);
+    }
+    if (Object.prototype.hasOwnProperty.call(updates, 'icloudAliasCache')) {
+      persistentAliasUpdates.icloudAliasCache = normalizeIcloudAliasCacheList(updates.icloudAliasCache);
+    }
+    if (Object.prototype.hasOwnProperty.call(updates, 'icloudAliasCacheAt')) {
+      persistentAliasUpdates.icloudAliasCacheAt = Math.max(0, Number(updates.icloudAliasCacheAt) || 0);
     }
     if (Object.keys(persistentAliasUpdates).length > 0) {
       await chrome.storage.local.set(persistentAliasUpdates);
@@ -1547,6 +1743,80 @@ function isAliasPreserved(state, email) {
 
 function getEffectiveUsedEmails(state) {
   return toNormalizedEmailSet(getManualAliasUsageMap(state));
+}
+
+function normalizeIcloudAliasCacheList(value = [], options = {}) {
+  const aliases = Array.isArray(value) ? value : [];
+  const usedEmails = toNormalizedEmailSet(options.usedEmails);
+  const preservedEmails = toNormalizedEmailSet(options.preservedEmails);
+  return aliases
+    .map((alias) => normalizeIcloudAliasRecord(alias, { usedEmails, preservedEmails }))
+    .filter(Boolean)
+    .sort((left, right) => {
+      if (left.active !== right.active) return left.active ? -1 : 1;
+      if (left.used !== right.used) return left.used ? 1 : -1;
+      return String(left.email).localeCompare(String(right.email));
+    });
+}
+
+function getIcloudAliasCacheFromState(state, options = {}) {
+  const maxAgeMs = Math.max(0, Number(options.maxAgeMs) || ICLOUD_ALIAS_CACHE_MAX_AGE_MS);
+  const cachedAt = Number(state?.icloudAliasCacheAt || 0);
+  if (!Array.isArray(state?.icloudAliasCache) || state.icloudAliasCache.length <= 0) {
+    return [];
+  }
+  if (maxAgeMs > 0 && cachedAt > 0 && Date.now() - cachedAt > maxAgeMs) {
+    return [];
+  }
+  return normalizeIcloudAliasCacheList(state.icloudAliasCache, {
+    usedEmails: getEffectiveUsedEmails(state),
+    preservedEmails: getPreservedAliasMap(state),
+  });
+}
+
+function isLikelyIcloudAliasEmail(value = '') {
+  const email = String(value || '').trim().toLowerCase();
+  if (!email || !email.includes('@')) {
+    return false;
+  }
+  return /@(icloud\.com|me\.com|mac\.com|privaterelay\.appleid\.com)$/.test(email);
+}
+
+function buildIcloudAliasFallbackFromLocalState(state = {}) {
+  const manualAliasUsage = getManualAliasUsageMap(state);
+  const preservedAliases = getPreservedAliasMap(state);
+  const candidates = new Set();
+
+  for (const email of Object.keys(manualAliasUsage)) {
+    if (isLikelyIcloudAliasEmail(email)) {
+      candidates.add(String(email).trim().toLowerCase());
+    }
+  }
+  for (const email of Object.keys(preservedAliases)) {
+    if (isLikelyIcloudAliasEmail(email)) {
+      candidates.add(String(email).trim().toLowerCase());
+    }
+  }
+
+  const currentEmail = String(state?.email || '').trim().toLowerCase();
+  if (isLikelyIcloudAliasEmail(currentEmail)) {
+    candidates.add(currentEmail);
+  }
+
+  if (!candidates.size) {
+    return [];
+  }
+
+  const aliases = Array.from(candidates, (email) => ({
+    hme: email,
+    email,
+    state: 'active',
+    active: true,
+  }));
+  return normalizeIcloudAliasCacheList(aliases, {
+    usedEmails: getEffectiveUsedEmails(state),
+    preservedEmails: preservedAliases,
+  });
 }
 
 async function setIcloudAliasUsedState(payload = {}, options = {}) {
@@ -3438,10 +3708,7 @@ async function pollCloudflareTempEmailVerificationCode(step, state, pollPayload 
 async function getOpenIcloudHostPreference() {
   try {
     const tabs = await chrome.tabs.query({
-      url: [
-        'https://www.icloud.com/*',
-        'https://www.icloud.com.cn/*',
-      ],
+      url: ICLOUD_TAB_URL_PATTERNS,
     });
 
     const activeTab = tabs.find((tab) => tab.active);
@@ -3464,9 +3731,9 @@ async function getPreferredIcloudLoginUrl(error = null, state = null) {
     return getIcloudLoginUrlForHost(configuredHost);
   }
 
-  const messageHint = getIcloudHostHintFromMessage(getErrorMessage(error));
-  if (messageHint) {
-    return getIcloudLoginUrlForHost(messageHint);
+  const openHost = await getOpenIcloudHostPreference();
+  if (openHost) {
+    return getIcloudLoginUrlForHost(openHost);
   }
 
   const savedHost = normalizeIcloudHost(currentState?.preferredIcloudHost);
@@ -3474,9 +3741,9 @@ async function getPreferredIcloudLoginUrl(error = null, state = null) {
     return getIcloudLoginUrlForHost(savedHost);
   }
 
-  const openHost = await getOpenIcloudHostPreference();
-  if (openHost) {
-    return getIcloudLoginUrlForHost(openHost);
+  const messageHint = getIcloudHostHintFromMessage(getErrorMessage(error));
+  if (messageHint) {
+    return getIcloudLoginUrlForHost(messageHint);
   }
 
   return ICLOUD_LOGIN_URLS[0];
@@ -3497,36 +3764,111 @@ async function getPreferredIcloudSetupUrls(state = null, error = null) {
 
 function isIcloudLoginRequiredError(error) {
   const message = getErrorMessage(error).toLowerCase();
-  return message.includes('could not validate icloud session')
-    || message.includes('hide my email service was unavailable')
-    || /\bstatus (401|403|409|421)\b/.test(message);
+  const hasAuthStatus401 = /\bstatus 401\b/.test(message);
+  const hasAuthStatus403 = /\bstatus 403\b/.test(message);
+  const hasTransientStatus = /\bstatus (409|421|429|5\d\d)\b/.test(message);
+  const hasTransientNetworkHint = message.includes('failed to fetch')
+    || message.includes('networkerror')
+    || message.includes('network request failed')
+    || message.includes('timeout')
+    || message.includes('timed out')
+    || message.includes('cors')
+    || message.includes('address space');
+  const hasExplicitLoginHint = message.includes('please sign in')
+    || message.includes('sign in required')
+    || message.includes('not logged in')
+    || message.includes('login required')
+    || message.includes('re-authentication required')
+    || message.includes('unauthenticated')
+    || message.includes('authentication required')
+    || message.includes('需要先登录')
+    || message.includes('请先登录');
+  const hasSelfPromptHint = message.includes('请先在新打开的 icloud 页面中完成登录')
+    || message.includes('请先在当前浏览器登录');
+  const hasAuthStatusWithExplicitLoginHint = (hasAuthStatus401 || hasAuthStatus403)
+    && hasExplicitLoginHint;
+
+  // Keep transient validate/network/cors errors out of login-required path.
+  if (message.includes('could not validate icloud session')) {
+    return false;
+  }
+  if (message.includes('page_context:')) {
+    return false;
+  }
+  if (hasSelfPromptHint) {
+    return false;
+  }
+  if (hasTransientStatus || hasTransientNetworkHint) {
+    return false;
+  }
+
+  if (hasAuthStatusWithExplicitLoginHint) {
+    return true;
+  }
+
+  if (hasExplicitLoginHint) {
+    return true;
+  }
+
+  return false;
+}
+
+function isIcloudTransientContextError(error) {
+  const message = getErrorMessage(error).toLowerCase();
+  return /\bstatus (401|403|409|421|429|5\d\d)\b/.test(message)
+    || message.includes('could not validate icloud session')
+    || message.includes('page_context:')
+    || message.includes('failed to fetch')
+    || message.includes('networkerror')
+    || message.includes('network request failed')
+    || message.includes('cors')
+    || message.includes('address space')
+    || message.includes('timeout')
+    || message.includes('timed out');
 }
 
 let lastIcloudLoginPromptAt = 0;
 const activeIcloudRequestControllers = new Set();
+let lastResolvedIcloudServiceUrl = '';
+const icloudTransientLogThrottle = new Map();
+
+function shouldEmitIcloudTransientLog(key, windowMs = 1500) {
+  const normalizedKey = String(key || '').trim();
+  if (!normalizedKey) {
+    return true;
+  }
+  const now = Date.now();
+  const lastAt = Number(icloudTransientLogThrottle.get(normalizedKey) || 0);
+  if (now - lastAt < Math.max(200, Number(windowMs) || 1500)) {
+    return false;
+  }
+  icloudTransientLogThrottle.set(normalizedKey, now);
+  return true;
+}
 
 async function openIcloudLoginPage(preferredUrl) {
   const tabs = await chrome.tabs.query({
-    url: [
-      'https://www.icloud.com/*',
-      'https://www.icloud.com.cn/*',
-    ],
+    url: ICLOUD_TAB_URL_PATTERNS,
   });
   const preferredHost = new URL(preferredUrl).host;
-  const existing = tabs.find((tab) => {
+  const preferredIcloudHost = normalizeIcloudHost(preferredHost);
+  const existingSameHost = tabs.find((tab) => {
     try {
-      return new URL(tab.url).host === preferredHost;
+      return normalizeIcloudHost(new URL(tab.url).host) === preferredIcloudHost;
     } catch {
       return false;
     }
   });
+  const existingAnyIcloudTab = tabs.find((tab) => Number.isInteger(tab?.id));
 
-  if (existing?.id) {
-    await chrome.tabs.update(existing.id, { active: true });
-    if (existing.url !== preferredUrl) {
-      await chrome.tabs.update(existing.id, { url: preferredUrl });
-    }
-    return existing.id;
+  if (existingSameHost?.id) {
+    await chrome.tabs.update(existingSameHost.id, { active: true });
+    return existingSameHost.id;
+  }
+
+  if (existingAnyIcloudTab?.id) {
+    await chrome.tabs.update(existingAnyIcloudTab.id, { active: true });
+    return existingAnyIcloudTab.id;
   }
 
   const created = await chrome.tabs.create({ url: preferredUrl, active: true });
@@ -3563,15 +3905,322 @@ async function promptIcloudLogin(error, actionLabel = 'iCloud 操作') {
 }
 
 async function withIcloudLoginHelp(actionLabel, action) {
-  try {
-    return await action();
-  } catch (err) {
-    if (isIcloudLoginRequiredError(err)) {
-      await promptIcloudLogin(err, actionLabel);
-      throw new Error('请先在新打开的 iCloud 页面中完成登录，再回来点击“我已登录”。');
+  const maxTransientAttempts = Math.max(1, Number(ICLOUD_TRANSIENT_RETRY_MAX_ATTEMPTS) || 1);
+  const retryDelayMs = Math.max(300, Number(ICLOUD_TRANSIENT_RETRY_DELAY_MS) || 1200);
+  for (let attempt = 1; attempt <= maxTransientAttempts; attempt += 1) {
+    try {
+      return await action();
+    } catch (err) {
+      if (isIcloudLoginRequiredError(err)) {
+        await promptIcloudLogin(err, actionLabel);
+        throw new Error('请先在新打开的 iCloud 页面中完成登录，再回来点击“我已登录”。');
+      }
+      if (isIcloudTransientContextError(err)) {
+        if (attempt < maxTransientAttempts) {
+          if (shouldEmitIcloudTransientLog(`${actionLabel}:retry:${attempt}/${maxTransientAttempts}`)) {
+            await addLog(`iCloud：${actionLabel}受网络/上下文波动影响，正在重试（${attempt}/${maxTransientAttempts}）...`, 'warn');
+          }
+          await new Promise((resolve) => setTimeout(resolve, retryDelayMs * attempt));
+          continue;
+        }
+        if (shouldEmitIcloudTransientLog(`${actionLabel}:final`)) {
+          await addLog(`iCloud：${actionLabel}受网络/上下文波动影响：${getErrorMessage(err)}`, 'warn');
+        }
+        const transientError = new Error('iCloud 别名加载受网络/上下文波动影响，请稍后重试。');
+        transientError.code = 'ICLOUD_TRANSIENT_CONTEXT';
+        transientError.cause = err;
+        throw transientError;
+      }
+      throw err;
     }
-    throw err;
   }
+  throw new Error('iCloud 操作失败：未知错误。');
+}
+
+function isIcloudApiUrl(url = '') {
+  const rawUrl = String(url || '').trim();
+  if (!rawUrl) {
+    return false;
+  }
+  try {
+    const parsedUrl = new URL(rawUrl);
+    if (parsedUrl.protocol !== 'https:') {
+      return false;
+    }
+    const hostname = String(parsedUrl.hostname || '').trim().toLowerCase().replace(/\.$/, '');
+    if (!hostname) {
+      return false;
+    }
+    return hostname === 'icloud.com'
+      || hostname.endsWith('.icloud.com')
+      || hostname === 'icloud.com.cn'
+      || hostname.endsWith('.icloud.com.cn');
+  } catch {
+    return false;
+  }
+}
+
+function normalizeIcloudServiceUrl(rawUrl = '') {
+  const value = String(rawUrl || '').trim();
+  if (!value) {
+    return '';
+  }
+  try {
+    const parsedUrl = new URL(value);
+    if ((parsedUrl.protocol === 'https:' && parsedUrl.port === '443')
+      || (parsedUrl.protocol === 'http:' && parsedUrl.port === '80')) {
+      parsedUrl.port = '';
+    }
+    return parsedUrl.toString().replace(/\/$/, '');
+  } catch {
+    return value.replace(/\/$/, '');
+  }
+}
+
+function rememberIcloudServiceUrl(rawUrl = '') {
+  const normalized = normalizeIcloudServiceUrl(rawUrl);
+  if (normalized) {
+    lastResolvedIcloudServiceUrl = normalized;
+  }
+  return normalized;
+}
+
+function isIcloudMaildomainwsHost(rawHost = '') {
+  const host = String(rawHost || '').trim().toLowerCase().replace(/\.$/, '');
+  if (!host) {
+    return false;
+  }
+  return host.endsWith('maildomainws.icloud.com') || host.endsWith('maildomainws.icloud.com.cn');
+}
+
+function appendIcloudClientQueryParams(rawUrl = '') {
+  const input = String(rawUrl || '').trim();
+  if (!input) {
+    return '';
+  }
+  try {
+    const parsed = new URL(input);
+    if (!isIcloudMaildomainwsHost(parsed.hostname)) {
+      return input;
+    }
+
+    if (!parsed.searchParams.has('clientBuildNumber')) {
+      parsed.searchParams.set('clientBuildNumber', ICLOUD_MAILDOMAINWS_CLIENT_BUILD_NUMBER);
+    }
+    if (!parsed.searchParams.has('clientMasteringNumber')) {
+      parsed.searchParams.set('clientMasteringNumber', ICLOUD_MAILDOMAINWS_CLIENT_BUILD_NUMBER);
+    }
+    if (!parsed.searchParams.has('clientId')) {
+      parsed.searchParams.set('clientId', '');
+    }
+    if (!parsed.searchParams.has('dsid')) {
+      parsed.searchParams.set('dsid', '');
+    }
+    return parsed.toString();
+  } catch {
+    return input;
+  }
+}
+
+function isIcloudMailPageUrl(rawUrl = '') {
+  try {
+    const parsedUrl = new URL(String(rawUrl || '').trim());
+    if (!normalizeIcloudHost(parsedUrl.hostname)) {
+      return false;
+    }
+    const pathname = String(parsedUrl.pathname || '').toLowerCase();
+    return pathname === '/mail' || pathname.startsWith('/mail/');
+  } catch {
+    return false;
+  }
+}
+
+async function waitForIcloudMailTabReady(tabId, timeoutMs = 8000) {
+  if (!Number.isInteger(tabId)) {
+    return false;
+  }
+  const deadline = Date.now() + Math.max(500, Number(timeoutMs) || 8000);
+  while (Date.now() < deadline) {
+    try {
+      const tab = await chrome.tabs.get(tabId);
+      const status = String(tab?.status || '');
+      if (isIcloudMailPageUrl(tab?.url) && status === 'complete') {
+        return true;
+      }
+    } catch {
+      return false;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  return false;
+}
+
+async function ensureIcloudMailContextTab(tabs = [], targetHost = '', preferredHost = '') {
+  const tabList = Array.isArray(tabs) ? tabs : [];
+  if (tabList.some((tab) => isIcloudMailPageUrl(tab?.url))) {
+    return tabList;
+  }
+
+  const fallbackHost = targetHost
+    || preferredHost
+    || await getOpenIcloudHostPreference()
+    || 'icloud.com';
+  const fallbackMailUrl = getIcloudMailUrlForHost(fallbackHost) || getIcloudMailUrlForHost('icloud.com');
+  if (!fallbackMailUrl) {
+    return tabList;
+  }
+
+  try {
+    const created = await chrome.tabs.create({ url: fallbackMailUrl, active: false });
+    await waitForIcloudMailTabReady(created?.id, 9000);
+  } catch {}
+
+  try {
+    return await chrome.tabs.query({
+      url: ICLOUD_TAB_URL_PATTERNS,
+    });
+  } catch {
+    return tabList;
+  }
+}
+
+function shouldTryIcloudRequestPageContextFallback(url, status, errorMessage = '') {
+  if (!isIcloudApiUrl(url)) {
+    return false;
+  }
+
+  const normalizedStatus = Number(status) || 0;
+  if (normalizedStatus === 401
+    || normalizedStatus === 403
+    || normalizedStatus === 409
+    || normalizedStatus === 421
+    || normalizedStatus === 429
+    || normalizedStatus >= 500) {
+    return true;
+  }
+
+  const message = String(errorMessage || '').toLowerCase();
+  return message.includes('failed to fetch')
+    || message.includes('network request failed')
+    || message.includes('networkerror')
+    || message.includes('timed out')
+    || message.includes('timeout')
+    || message.includes('cors')
+    || message.includes('address space');
+}
+
+async function icloudRequestViaPageContext(method, url, options = {}) {
+  const {
+    data,
+    contentType = '',
+  } = options;
+  const state = await getState();
+  const targetHost = normalizeIcloudHost(new URL(url).hostname);
+  const preferredHost = normalizeIcloudHost(state?.preferredIcloudHost);
+
+  let tabs = await chrome.tabs.query({
+    url: ICLOUD_TAB_URL_PATTERNS,
+  });
+  tabs = await ensureIcloudMailContextTab(tabs, targetHost, preferredHost);
+  if (!tabs.length) {
+    throw new Error('page_context:no_icloud_tab');
+  }
+
+  const sortedTabs = [...tabs].sort((left, right) => {
+    const score = (tab) => {
+      let tabHost = '';
+      try {
+        tabHost = normalizeIcloudHost(new URL(String(tab?.url || '')).hostname);
+      } catch {}
+      return (isIcloudMailPageUrl(tab?.url) ? 8 : 0)
+        + (tab?.active ? 4 : 0)
+        + (tabHost && tabHost === targetHost ? 2 : 0)
+        + (tabHost && tabHost === preferredHost ? 1 : 0);
+    };
+    return score(right) - score(left);
+  });
+  const mailTabs = sortedTabs.filter((tab) => isIcloudMailPageUrl(tab?.url));
+  const candidateTabs = mailTabs.length ? mailTabs : sortedTabs;
+
+  const errors = [];
+  for (const tab of candidateTabs) {
+    if (!Number.isInteger(tab?.id)) {
+      continue;
+    }
+    try {
+      const injections = await chrome.scripting.executeScript({
+        target: { tabId: tab.id, allFrames: false },
+        world: 'MAIN',
+        func: async (requestConfig) => {
+          const timeoutMs = 15000;
+          const controller = new AbortController();
+          const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+          try {
+            const headers = requestConfig.hasData
+              ? { 'Content-Type': requestConfig.contentType || 'application/json' }
+              : undefined;
+            const response = await fetch(requestConfig.url, {
+              method: requestConfig.method,
+              credentials: 'include',
+              cache: 'no-store',
+              mode: 'cors',
+              headers,
+              body: requestConfig.hasData ? JSON.stringify(requestConfig.data) : undefined,
+              signal: controller.signal,
+            });
+            const text = await response.text();
+            return {
+              ok: Boolean(response.ok),
+              status: Number(response.status) || 0,
+              text,
+              error: '',
+            };
+          } catch (err) {
+            return {
+              ok: false,
+              status: 0,
+              text: '',
+              error: String(err?.message || err || 'unknown error'),
+            };
+          } finally {
+            clearTimeout(timeoutId);
+          }
+        },
+        args: [{
+          method,
+          url,
+          hasData: data !== undefined,
+          data: data === undefined ? null : data,
+          contentType: contentType || '',
+        }],
+      });
+
+      const result = injections?.[0]?.result || null;
+      if (!result) {
+        throw new Error('empty result');
+      }
+      if (!result.ok) {
+        if (result.status) {
+          throw new Error(`status ${result.status}`);
+        }
+        throw new Error(result.error || 'page context request failed');
+      }
+
+      if (!String(result.text || '').trim()) {
+        return {};
+      }
+
+      try {
+        return JSON.parse(result.text);
+      } catch (parseErr) {
+        throw new Error(`invalid json: ${getErrorMessage(parseErr)}`);
+      }
+    } catch (err) {
+      errors.push(`tab_${tab.id}:${getErrorMessage(err)}`);
+    }
+  }
+
+  throw new Error(errors.length ? errors.join(' | ') : 'page_context:unknown');
 }
 
 function getIcloudRequestTargetLabel(rawUrl) {
@@ -3628,6 +4277,19 @@ async function icloudRequest(method, url, options = {}) {
     retryLabel = '',
     logRetries = false,
   } = options;
+  const requestUrl = appendIcloudClientQueryParams(url);
+  const requestContentType = (() => {
+    if (data === undefined) {
+      return '';
+    }
+    try {
+      return isIcloudMaildomainwsHost(new URL(requestUrl).hostname)
+        ? 'text/plain;charset=UTF-8'
+        : 'application/json';
+    } catch {
+      return 'application/json';
+    }
+  })();
 
   let lastError = null;
   const totalAttempts = Math.max(1, Number(maxAttempts) || 1);
@@ -3649,10 +4311,10 @@ async function icloudRequest(method, url, options = {}) {
         } catch {}
       }, Math.max(1000, Number(timeoutMs) || ICLOUD_REQUEST_TIMEOUT_MS));
 
-      response = await fetch(url, {
+      response = await fetch(requestUrl, {
         method,
         credentials: 'include',
-        headers: data !== undefined ? { 'Content-Type': 'application/json' } : undefined,
+        headers: requestContentType ? { 'Content-Type': requestContentType } : undefined,
         body: data !== undefined ? JSON.stringify(data) : undefined,
         signal: controller.signal,
       });
@@ -3665,8 +4327,8 @@ async function icloudRequest(method, url, options = {}) {
 
         const error = new Error(
           responseText
-            ? `iCloud 请求失败：${method} ${url}，status ${response.status}，body: ${responseText}`
-            : `iCloud 请求失败：${method} ${url}，status ${response.status}`
+            ? `iCloud 请求失败：${method} ${requestUrl}，status ${response.status}，body: ${responseText}`
+            : `iCloud 请求失败：${method} ${requestUrl}，status ${response.status}`
         );
         error.status = response.status;
         throw error;
@@ -3680,7 +4342,7 @@ async function icloudRequest(method, url, options = {}) {
       try {
         return JSON.parse(rawText);
       } catch (err) {
-        throw new Error(`iCloud 返回的 JSON 无法解析：${method} ${url}，${err.message}`);
+        throw new Error(`iCloud 返回的 JSON 无法解析：${method} ${requestUrl}，${err.message}`);
       }
     } catch (err) {
       if (stopRequested) {
@@ -3699,6 +4361,31 @@ async function icloudRequest(method, url, options = {}) {
         }
       }
 
+      const directErrorMessage = getErrorMessage(requestError)
+        || `iCloud 请求失败：${method} ${requestUrl}`;
+      const shouldTryPageContext = shouldTryIcloudRequestPageContextFallback(
+        requestUrl,
+        Number(requestError?.status) || 0,
+        directErrorMessage
+      );
+      if (shouldTryPageContext) {
+        try {
+          return await icloudRequestViaPageContext(method, requestUrl, {
+            data,
+            contentType: requestContentType || undefined,
+          });
+        } catch (pageContextError) {
+          const pageContextMessage = getErrorMessage(pageContextError);
+          if (!pageContextMessage.includes('page_context:no_icloud_tab')) {
+            const mergedError = new Error(`${directErrorMessage} | page_context:${pageContextMessage}`);
+            if (requestError?.status) {
+              mergedError.status = requestError.status;
+            }
+            requestError = mergedError;
+          }
+        }
+      }
+
       lastError = requestError;
       const shouldRetry = attempt < totalAttempts && isIcloudRetryableError(requestError);
       if (!shouldRetry) {
@@ -3708,7 +4395,7 @@ async function icloudRequest(method, url, options = {}) {
       if (logRetries) {
         const delayMs = getIcloudRetryDelay(attempt);
         await addLog(
-          `iCloud：${retryLabel || getIcloudRequestTargetLabel(url)} 第 ${attempt}/${totalAttempts} 次失败：${getErrorMessage(requestError)}，${Math.round(delayMs / 1000)} 秒后重试...`,
+          `iCloud：${retryLabel || getIcloudRequestTargetLabel(requestUrl)} 第 ${attempt}/${totalAttempts} 次失败：${getErrorMessage(requestError)}，${Math.round(delayMs / 1000)} 秒后重试...`,
           'warn'
         );
       }
@@ -3722,7 +4409,7 @@ async function icloudRequest(method, url, options = {}) {
     }
   }
 
-  throw lastError || new Error(`iCloud 请求失败：${method} ${url}`);
+  throw lastError || new Error(`iCloud 请求失败：${method} ${requestUrl}`);
 }
 
 async function validateIcloudSession(setupUrl) {
@@ -3731,6 +4418,133 @@ async function validateIcloudSession(setupUrl) {
     throw new Error('Could not validate iCloud session. Hide My Email service was unavailable.');
   }
   return data;
+}
+
+function shouldTryIcloudPageContextFallback(errors = []) {
+  const combinedMessage = String((errors || []).join(' | ')).toLowerCase();
+  if (!combinedMessage) {
+    return false;
+  }
+  return combinedMessage.includes('status 401')
+    || combinedMessage.includes('status 403')
+    || combinedMessage.includes('status 421')
+    || combinedMessage.includes('networkerror')
+    || combinedMessage.includes('network request failed')
+    || combinedMessage.includes('failed to fetch')
+    || combinedMessage.includes('timed out')
+    || combinedMessage.includes('timeout')
+    || combinedMessage.includes('cors');
+}
+
+async function validateIcloudSessionViaPageContext(tabId, setupUrl) {
+  const host = new URL(setupUrl).host;
+  try {
+    const injections = await chrome.scripting.executeScript({
+      target: { tabId, allFrames: false },
+      world: 'MAIN',
+      func: async (targetSetupUrl) => {
+        const timeoutMs = 12000;
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+        try {
+          const response = await fetch(`${targetSetupUrl}/validate`, {
+            method: 'POST',
+            credentials: 'include',
+            cache: 'no-store',
+            mode: 'cors',
+            signal: controller.signal,
+          });
+          const text = await response.text();
+          let data = null;
+          try {
+            data = text ? JSON.parse(text) : null;
+          } catch {}
+          return {
+            ok: Boolean(response.ok),
+            status: Number(response.status) || 0,
+            data,
+            error: '',
+          };
+        } catch (err) {
+          return {
+            ok: false,
+            status: 0,
+            data: null,
+            error: String(err?.message || err || 'unknown error'),
+          };
+        } finally {
+          clearTimeout(timeoutId);
+        }
+      },
+      args: [setupUrl],
+    });
+
+    const result = injections?.[0]?.result || null;
+    if (result?.ok && result?.data?.webservices?.premiummailsettings?.url) {
+      return {
+        setupUrl,
+        serviceUrl: normalizeIcloudServiceUrl(result.data.webservices.premiummailsettings.url),
+        resolvedBy: 'page_context',
+      };
+    }
+
+    if (result?.status) {
+      throw new Error(`status ${result.status}`);
+    }
+    throw new Error(result?.error || 'page context validate failed');
+  } catch (err) {
+    throw new Error(`${host}: ${getErrorMessage(err)}`);
+  }
+}
+
+async function resolveIcloudPremiumMailServiceViaPageContext(setupUrls, state) {
+  const errors = [];
+  let tabs = [];
+  try {
+    tabs = await chrome.tabs.query({
+      url: ICLOUD_TAB_URL_PATTERNS,
+    });
+  } catch (err) {
+    errors.push(`page_context:query_tabs:${getErrorMessage(err)}`);
+    return { service: null, errors, noTab: false };
+  }
+
+  const preferredHost = normalizeIcloudHost(state?.preferredIcloudHost);
+  tabs = await ensureIcloudMailContextTab(tabs, preferredHost, preferredHost);
+  if (!tabs.length) {
+    return { service: null, errors: [], noTab: true };
+  }
+  const sortedTabs = [...tabs].sort((left, right) => {
+    const leftActive = left?.active ? 1 : 0;
+    const rightActive = right?.active ? 1 : 0;
+    if (leftActive !== rightActive) return rightActive - leftActive;
+    const leftMail = isIcloudMailPageUrl(left?.url) ? 1 : 0;
+    const rightMail = isIcloudMailPageUrl(right?.url) ? 1 : 0;
+    if (leftMail !== rightMail) return rightMail - leftMail;
+    let leftHost = '';
+    let rightHost = '';
+    try { leftHost = normalizeIcloudHost(new URL(String(left?.url || '')).host); } catch {}
+    try { rightHost = normalizeIcloudHost(new URL(String(right?.url || '')).host); } catch {}
+    const leftPreferred = leftHost && leftHost === preferredHost ? 1 : 0;
+    const rightPreferred = rightHost && rightHost === preferredHost ? 1 : 0;
+    return rightPreferred - leftPreferred;
+  });
+
+  for (const tab of sortedTabs) {
+    if (!Number.isInteger(tab?.id)) {
+      continue;
+    }
+    for (const setupUrl of setupUrls) {
+      try {
+        const service = await validateIcloudSessionViaPageContext(tab.id, setupUrl);
+        return { service, errors };
+      } catch (err) {
+        errors.push(`page_context:tab_${tab.id}:${getErrorMessage(err)}`);
+      }
+    }
+  }
+
+  return { service: null, errors, noTab: false };
 }
 
 async function resolveIcloudPremiumMailService(options = {}) {
@@ -3753,10 +4567,32 @@ async function resolveIcloudPremiumMailService(options = {}) {
       }
       return {
         setupUrl,
-        serviceUrl: String(data.webservices.premiummailsettings.url || '').replace(/\/$/, ''),
+        serviceUrl: rememberIcloudServiceUrl(data.webservices.premiummailsettings.url),
       };
     } catch (err) {
       errors.push(`${new URL(setupUrl).host}: ${getErrorMessage(err)}`);
+    }
+  }
+
+  if (shouldTryIcloudPageContextFallback(errors)) {
+    const {
+      service,
+      errors: pageContextErrors,
+      noTab: pageContextNoTab = false,
+    } = await resolveIcloudPremiumMailServiceViaPageContext(setupUrls, state);
+    if (service) {
+      const preferredIcloudHost = normalizeIcloudHost(new URL(service.setupUrl).host);
+      if (preferredIcloudHost && preferredIcloudHost !== normalizeIcloudHost(state.preferredIcloudHost)) {
+        await setState({ preferredIcloudHost });
+      }
+      await addLog(`iCloud：后台会话校验失败，已切换页面上下文校验（${new URL(service.setupUrl).host}）。`, 'warn');
+      return {
+        ...service,
+        serviceUrl: rememberIcloudServiceUrl(service.serviceUrl),
+      };
+    }
+    if (!pageContextNoTab && Array.isArray(pageContextErrors) && pageContextErrors.length) {
+      errors.push(...pageContextErrors);
     }
   }
 
@@ -3831,10 +4667,49 @@ async function loadNormalizedIcloudAliases(options = {}) {
 }
 
 async function listIcloudAliases(options = {}) {
-  return withIcloudLoginHelp('加载 iCloud 隐私邮箱列表', async () => {
-    const { aliases } = await loadNormalizedIcloudAliases({ resolveOptions: options });
-    return aliases;
-  });
+  try {
+    return await withIcloudLoginHelp('加载 iCloud 隐私邮箱列表', async () => {
+      const { serviceUrl } = await resolveIcloudPremiumMailService(options);
+      const response = await icloudRequest('GET', `${serviceUrl}/v2/hme/list`);
+      const state = await getState();
+      const aliases = normalizeIcloudAliasList(response, {
+        usedEmails: getEffectiveUsedEmails(state),
+        preservedEmails: getPreservedAliasMap(state),
+      });
+      await setState({
+        icloudAliasCache: normalizeIcloudAliasCacheList(aliases),
+        icloudAliasCacheAt: Date.now(),
+      });
+      return aliases;
+    });
+  } catch (err) {
+    const message = getErrorMessage(err);
+    const transientContextError = err?.code === 'ICLOUD_TRANSIENT_CONTEXT'
+      || message.includes('网络/上下文波动');
+    if (!transientContextError) {
+      throw err;
+    }
+    const state = await getState();
+    const freshCachedAliases = getIcloudAliasCacheFromState(state);
+    if (freshCachedAliases.length) {
+      await addLog(`iCloud：加载别名失败，已回退最近缓存（${freshCachedAliases.length} 条）。`, 'warn');
+      return freshCachedAliases;
+    }
+
+    const staleCachedAliases = getIcloudAliasCacheFromState(state, { maxAgeMs: 0 });
+    if (staleCachedAliases.length) {
+      await addLog(`iCloud：加载别名失败，已回退历史缓存（${staleCachedAliases.length} 条）。`, 'warn');
+      return staleCachedAliases;
+    }
+
+    const localFallbackAliases = buildIcloudAliasFallbackFromLocalState(state);
+    if (localFallbackAliases.length) {
+      await addLog(`iCloud：加载别名失败，已回退本地别名记录（${localFallbackAliases.length} 条）。`, 'warn');
+      return localFallbackAliases;
+    }
+
+    throw err;
+  }
 }
 
 async function deleteIcloudAlias(payload) {
@@ -3853,7 +4728,18 @@ async function deleteIcloudAlias(payload) {
       throw new Error(`缺少 ${alias.email} 的 anonymousId，请先刷新 iCloud 别名列表。`);
     }
 
-    const { serviceUrl } = await resolveIcloudPremiumMailService();
+    let serviceUrl = '';
+    try {
+      ({ serviceUrl } = await resolveIcloudPremiumMailService());
+    } catch (resolveErr) {
+      const canFallbackToCachedService = isIcloudTransientContextError(resolveErr)
+        && Boolean(lastResolvedIcloudServiceUrl);
+      if (!canFallbackToCachedService) {
+        throw resolveErr;
+      }
+      serviceUrl = lastResolvedIcloudServiceUrl;
+      await addLog(`iCloud：会话校验暂时不可用，已回退最近可用服务节点 ${new URL(serviceUrl).host} 继续删除。`, 'warn');
+    }
 
     try {
       const directDelete = await icloudRequest('POST', `${serviceUrl}/v1/hme/delete`, {
@@ -3921,18 +4807,19 @@ async function fetchIcloudHideMyEmail(options = {}) {
   return withIcloudLoginHelp('获取 iCloud 隐私邮箱', async () => {
     throwIfStopped();
     const generateNew = Boolean(options?.generateNew);
-    await addLog('iCloud：正在校验当前浏览器登录状态...', 'info');
+    await addLog('iCloud：正在加载别名列表并校验当前浏览器登录状态...', 'info');
 
     const { serviceUrl, setupUrl } = await resolveIcloudPremiumMailService();
     await addLog(`iCloud：已通过 ${new URL(setupUrl).host} 验证会话`, 'ok');
     await addLog(`iCloud：当前 Hide My Email 服务节点 ${new URL(serviceUrl).host}`, 'info');
 
     let activeServiceUrl = serviceUrl;
-    const { aliases: existingAliases, serviceUrl: listServiceUrl } = await loadNormalizedIcloudAliases({
-      serviceUrl: activeServiceUrl,
-      silent: true,
-    });
-    activeServiceUrl = listServiceUrl || activeServiceUrl;
+    const existingAliases = await listIcloudAliases();
+    const existingAliasEmailSet = new Set(
+      existingAliases
+        .map((aliasItem) => String(aliasItem?.email || '').trim().toLowerCase())
+        .filter(Boolean)
+    );
 
     if (!generateNew) {
       const reusableAlias = pickReusableIcloudAlias(existingAliases);
@@ -3949,90 +4836,140 @@ async function fetchIcloudHideMyEmail(options = {}) {
     await addLog('iCloud：没有可复用别名，开始生成新的 Hide My Email 地址...', 'warn');
     await addLog(`iCloud：正在向 ${new URL(activeServiceUrl).host} 请求新的 Hide My Email 候选地址...`, 'info');
 
-    let generated = null;
     try {
-      generated = await icloudRequest('POST', `${activeServiceUrl}/v1/hme/generate`, {
-        timeoutMs: ICLOUD_REQUEST_TIMEOUT_MS,
-        maxAttempts: ICLOUD_WRITE_MAX_ATTEMPTS,
-        retryLabel: '生成 Hide My Email 地址',
-        logRetries: true,
-      });
+      let generated = null;
+      try {
+        generated = await icloudRequest('POST', `${activeServiceUrl}/v1/hme/generate`, {
+          timeoutMs: ICLOUD_REQUEST_TIMEOUT_MS,
+          maxAttempts: ICLOUD_WRITE_MAX_ATTEMPTS,
+          retryLabel: '生成 Hide My Email 地址',
+          logRetries: true,
+        });
+      } catch (err) {
+        if (!isIcloudRetryableError(err)) {
+          throw err;
+        }
+        await addLog('iCloud：生成候选别名失败，正在刷新服务节点后再试一次...', 'warn');
+        const refreshedService = await resolveIcloudPremiumMailService();
+        activeServiceUrl = refreshedService.serviceUrl;
+        generated = await icloudRequest('POST', `${activeServiceUrl}/v1/hme/generate`, {
+          timeoutMs: ICLOUD_REQUEST_TIMEOUT_MS,
+          maxAttempts: ICLOUD_WRITE_MAX_ATTEMPTS,
+          retryLabel: '生成 Hide My Email 地址',
+          logRetries: true,
+        });
+      }
+
+      if (!generated?.success || !generated?.result?.hme) {
+        throw new Error(generated?.error?.errorMessage || 'iCloud 隐私邮箱生成失败。');
+      }
+
+      const generatedHmeRaw = generated.result.hme;
+      const generatedAlias = String(
+        (typeof generatedHmeRaw === 'string'
+          ? generatedHmeRaw
+          : generatedHmeRaw?.hme
+            || generatedHmeRaw?.email
+            || generatedHmeRaw?.alias
+            || generatedHmeRaw?.address
+            || '')
+      ).trim().toLowerCase();
+      if (!generatedAlias) {
+        throw new Error('iCloud 隐私邮箱生成失败：未返回可用别名。');
+      }
+      await addLog(`iCloud：已生成候选别名 ${generatedAlias}，正在保留...`, 'info');
+
+      const reserveData = {
+        ...(generatedHmeRaw && typeof generatedHmeRaw === 'object' && !Array.isArray(generatedHmeRaw)
+          ? generatedHmeRaw
+          : {}),
+        hme: generatedAlias,
+        label: getIcloudAliasLabel(),
+        note: 'Generated through Multi-Page Automation',
+      };
+
+      let alias = '';
+      try {
+        const reserved = await icloudRequest('POST', `${activeServiceUrl}/v1/hme/reserve`, {
+          data: reserveData,
+          timeoutMs: ICLOUD_REQUEST_TIMEOUT_MS,
+          maxAttempts: 1,
+        });
+
+        if (!reserved?.success || !reserved?.result?.hme?.hme) {
+          throw new Error(reserved?.error?.errorMessage || 'iCloud 隐私邮箱保留失败。');
+        }
+
+        alias = String(reserved.result.hme.hme || '').trim().toLowerCase();
+      } catch (reserveErr) {
+        const reserveErrMessage = getErrorMessage(reserveErr);
+        const shouldTryListFallback = isIcloudRetryableError(reserveErr)
+          || /\bstatus (?:401|403|409)\b/i.test(reserveErrMessage)
+          || /failed to fetch/i.test(reserveErrMessage);
+        if (!shouldTryListFallback) {
+          throw reserveErr;
+        }
+
+        await addLog('iCloud：保留别名返回鉴权/网络异常，正在回查别名列表确认是否已创建...', 'warn');
+        const { aliases: aliasesAfterReserveFailure, serviceUrl: refreshedListServiceUrl } = await loadNormalizedIcloudAliases({
+          serviceUrl: activeServiceUrl,
+          silent: true,
+        });
+        activeServiceUrl = refreshedListServiceUrl || activeServiceUrl;
+
+        let recoveredAlias = findIcloudAliasByEmail(aliasesAfterReserveFailure, generatedAlias);
+        if (!recoveredAlias) {
+          recoveredAlias = aliasesAfterReserveFailure.find(
+            (aliasItem) => !existingAliasEmailSet.has(String(aliasItem?.email || '').trim().toLowerCase())
+          ) || null;
+        }
+
+        if (recoveredAlias?.email) {
+          alias = String(recoveredAlias.email || '').trim().toLowerCase();
+          await addLog(`iCloud：保留请求异常，但已在列表确认别名 ${alias}，继续使用。`, 'warn');
+        } else if (isIcloudRetryableError(reserveErr)) {
+          await addLog(`iCloud：列表中尚未出现 ${generatedAlias}，正在刷新服务节点后重试保留一次...`, 'warn');
+          const refreshedService = await resolveIcloudPremiumMailService();
+          activeServiceUrl = refreshedService.serviceUrl;
+          const reservedRetry = await icloudRequest('POST', `${activeServiceUrl}/v1/hme/reserve`, {
+            data: reserveData,
+            timeoutMs: ICLOUD_REQUEST_TIMEOUT_MS,
+            maxAttempts: 1,
+          });
+          if (!reservedRetry?.success || !reservedRetry?.result?.hme?.hme) {
+            throw new Error(reservedRetry?.error?.errorMessage || 'iCloud 隐私邮箱保留失败。');
+          }
+          alias = String(reservedRetry.result.hme.hme || '').trim().toLowerCase();
+        } else {
+          alias = generatedAlias;
+          await addLog(`iCloud：保留请求异常，已回退使用生成别名 ${alias}。`, 'warn');
+        }
+      }
+
+      await setEmailState(alias);
+      await addLog(`iCloud：已创建并保留新别名 ${alias}`, 'ok');
+      broadcastIcloudAliasesChanged({ reason: 'created', email: alias });
+      return alias;
     } catch (err) {
-      if (!isIcloudRetryableError(err)) {
+      if (!shouldStopIcloudAutoFetchRetries(err)) {
         throw err;
       }
-      await addLog('iCloud：生成候选别名失败，正在刷新服务节点后再试一次...', 'warn');
-      const refreshedService = await resolveIcloudPremiumMailService();
-      activeServiceUrl = refreshedService.serviceUrl;
-      generated = await icloudRequest('POST', `${activeServiceUrl}/v1/hme/generate`, {
-        timeoutMs: ICLOUD_REQUEST_TIMEOUT_MS,
-        maxAttempts: ICLOUD_WRITE_MAX_ATTEMPTS,
-        retryLabel: '生成 Hide My Email 地址',
-        logRetries: true,
-      });
-    }
 
-    if (!generated?.success || !generated?.result?.hme) {
-      throw new Error(generated?.error?.errorMessage || 'iCloud 隐私邮箱生成失败。');
-    }
-
-    const generatedAlias = String(generated.result.hme || '').trim().toLowerCase();
-    await addLog(`iCloud：已生成候选别名 ${generatedAlias}，正在保留...`, 'info');
-
-    let reserved = null;
-    try {
-      reserved = await icloudRequest('POST', `${activeServiceUrl}/v1/hme/reserve`, {
-        data: {
-          hme: generatedAlias,
-          label: getIcloudAliasLabel(),
-          note: 'Generated through Multi-Page Automation',
-        },
-        timeoutMs: ICLOUD_REQUEST_TIMEOUT_MS,
-        maxAttempts: 1,
-      });
-    } catch (err) {
-      if (!isIcloudRetryableError(err)) {
-        throw err;
+      const reusableAlias = pickReusableIcloudAlias(existingAliases);
+      if (reusableAlias) {
+        await setEmailState(reusableAlias.email);
+        await addLog(
+          `iCloud：当前网络/上下文波动，暂无法创建新别名，已临时回退复用 ${reusableAlias.email}。`,
+          'warn'
+        );
+        broadcastIcloudAliasesChanged({ reason: 'selected', email: reusableAlias.email });
+        return reusableAlias.email;
       }
 
-      await addLog(`iCloud：保留 ${generatedAlias} 失败，正在回查别名列表确认是否已成功保留...`, 'warn');
-      const { aliases: aliasesAfterReserveFailure, serviceUrl: refreshedListServiceUrl } = await loadNormalizedIcloudAliases({
-        serviceUrl: activeServiceUrl,
-        silent: true,
-      });
-      activeServiceUrl = refreshedListServiceUrl || activeServiceUrl;
-
-      const alreadyReservedAlias = findIcloudAliasByEmail(aliasesAfterReserveFailure, generatedAlias);
-      if (alreadyReservedAlias) {
-        await setEmailState(alreadyReservedAlias.email);
-        await addLog(`iCloud：已在列表中确认 ${alreadyReservedAlias.email}，按保留成功处理。`, 'ok');
-        broadcastIcloudAliasesChanged({ reason: 'created', email: alreadyReservedAlias.email });
-        return alreadyReservedAlias.email;
-      }
-
-      await addLog(`iCloud：列表中尚未出现 ${generatedAlias}，正在刷新服务节点后重试保留一次...`, 'warn');
-      const refreshedService = await resolveIcloudPremiumMailService();
-      activeServiceUrl = refreshedService.serviceUrl;
-      reserved = await icloudRequest('POST', `${activeServiceUrl}/v1/hme/reserve`, {
-        data: {
-          hme: generatedAlias,
-          label: getIcloudAliasLabel(),
-          note: 'Generated through Multi-Page Automation',
-        },
-        timeoutMs: ICLOUD_REQUEST_TIMEOUT_MS,
-        maxAttempts: 1,
-      });
+      throw new Error(
+        `iCloud 当前无法创建新别名：${getErrorMessage(err)}。请先确认 iCloud 页面已登录且网络可访问，再重试。`
+      );
     }
-
-    if (!reserved?.success || !reserved?.result?.hme?.hme) {
-      throw new Error(reserved?.error?.errorMessage || 'iCloud 隐私邮箱保留失败。');
-    }
-
-    const alias = String(reserved.result.hme.hme || '').trim().toLowerCase();
-    await setEmailState(alias);
-    await addLog(`iCloud：已创建并保留新别名 ${alias}`, 'ok');
-    broadcastIcloudAliasesChanged({ reason: 'created', email: alias });
-    return alias;
   });
 }
 
@@ -4080,7 +5017,11 @@ async function finalizeIcloudAliasAfterSuccessfulFlow(state) {
     await addLog(`iCloud：流程成功后已自动删除 ${email}。`, 'ok');
     return { handled: true, deleted: true };
   } catch (err) {
-    await addLog(`iCloud：自动删除 ${email} 失败：${getErrorMessage(err)}`, 'warn');
+    if (isIcloudTransientContextError(err)) {
+      await addLog(`iCloud：自动删除 ${email} 暂时跳过（网络/上下文波动），可稍后手动删除。`, 'info');
+    } else {
+      await addLog(`iCloud：自动删除 ${email} 失败：${getErrorMessage(err)}`, 'warn');
+    }
     return { handled: true, deleted: false };
   }
 }
@@ -6510,6 +7451,85 @@ async function deleteAndBroadcastAccountRunHistoryRecords(recordIds = [], stateO
   return result;
 }
 
+function resolveIpProxyCandidateCountForAutoSwitch(state = {}, mode = 'account', provider = DEFAULT_IP_PROXY_SERVICE) {
+  const normalizedMode = typeof normalizeIpProxyMode === 'function'
+    ? normalizeIpProxyMode(mode)
+    : String(mode || 'account').trim().toLowerCase();
+  const normalizedProvider = typeof normalizeIpProxyProviderValue === 'function'
+    ? normalizeIpProxyProviderValue(provider)
+    : String(provider || DEFAULT_IP_PROXY_SERVICE).trim().toLowerCase();
+  if (normalizedMode === 'account' && typeof getAccountModeProxyPoolFromState === 'function') {
+    const pool = getAccountModeProxyPoolFromState(state, normalizedProvider);
+    return Array.isArray(pool) ? pool.length : 0;
+  }
+  if (typeof getIpProxyRuntimeSnapshot === 'function') {
+    const runtime = getIpProxyRuntimeSnapshot(state, normalizedMode, normalizedProvider);
+    return Array.isArray(runtime?.pool) ? runtime.pool.length : 0;
+  }
+  return 0;
+}
+
+async function maybeSwitchIpProxyAfterAutoRunRoundSuccess(payload = {}) {
+  if (typeof switchIpProxy !== 'function') {
+    return null;
+  }
+  const successfulRuns = Number(payload?.successfulRuns) || 0;
+  if (successfulRuns <= 0) {
+    return null;
+  }
+
+  const state = await getState();
+  if (!state?.ipProxyEnabled) {
+    return null;
+  }
+
+  const mode = typeof normalizeIpProxyMode === 'function'
+    ? normalizeIpProxyMode(state?.ipProxyMode)
+    : String(state?.ipProxyMode || 'account').trim().toLowerCase();
+  const provider = typeof normalizeIpProxyProviderValue === 'function'
+    ? normalizeIpProxyProviderValue(state?.ipProxyService)
+    : String(state?.ipProxyService || DEFAULT_IP_PROXY_SERVICE).trim().toLowerCase();
+  const threshold = typeof resolveIpProxyAutoSwitchThreshold === 'function'
+    ? resolveIpProxyAutoSwitchThreshold(state)
+    : Math.max(1, Math.min(500, Number(state?.ipProxyPoolTargetCount) || 20));
+  if (successfulRuns % threshold !== 0) {
+    return null;
+  }
+
+  const candidateCount = resolveIpProxyCandidateCountForAutoSwitch(state, mode, provider);
+  if (candidateCount <= 1) {
+    await addLog(
+      `任务切换阈值命中（成功 ${successfulRuns} 轮 / 阈值 ${threshold}），但当前仅 ${candidateCount} 条可切换代理，已跳过自动切换。`,
+      'info'
+    );
+    return {
+      skipped: true,
+      reason: 'insufficient_candidates',
+      candidateCount,
+      threshold,
+      successfulRuns,
+    };
+  }
+
+  const switchResult = await switchIpProxy('next', {
+    mode,
+    state,
+    forceRefresh: mode === 'api',
+    maxItems: typeof resolveIpProxyPoolTargetCountForMode === 'function'
+      ? resolveIpProxyPoolTargetCountForMode(state, mode)
+      : undefined,
+  });
+  const display = String(switchResult?.display || '').trim();
+  const routingApplied = Boolean(switchResult?.proxyRouting?.applied);
+  await addLog(
+    routingApplied
+      ? `任务切换阈值命中（成功 ${successfulRuns} 轮 / 阈值 ${threshold}），已自动切换代理：${display || '已切换到下一条'}。`
+      : `任务切换阈值命中（成功 ${successfulRuns} 轮 / 阈值 ${threshold}），已尝试自动切换代理，但连通性仍异常。`,
+    routingApplied ? 'ok' : 'warn'
+  );
+  return switchResult;
+}
+
 const autoRunController = self.MultiPageBackgroundAutoRunController?.createAutoRunController({
   addLog,
   appendAccountRunRecord: (...args) => appendAndBroadcastAccountRunRecord(...args),
@@ -6536,6 +7556,7 @@ const autoRunController = self.MultiPageBackgroundAutoRunController?.createAutoR
   isStopError,
   launchAutoRunTimerPlan,
   normalizeAutoRunFallbackThreadIntervalMinutes,
+  onAutoRunRoundSuccess: (payload = {}) => maybeSwitchIpProxyAfterAutoRunRoundSuccess(payload),
   persistAutoRunTimerPlan,
   resetState,
   runAutoSequenceFromStep: (...args) => runAutoSequenceFromStep(...args),
@@ -6580,6 +7601,42 @@ async function resumeAutoRunIfWaitingForEmail(options = {}) {
   }
 
   return false;
+}
+
+function shouldStopIcloudAutoFetchRetries(error) {
+  if (!error) {
+    return false;
+  }
+
+  if (error.code === 'ICLOUD_TRANSIENT_CONTEXT') {
+    return true;
+  }
+
+  const message = getErrorMessage(error).toLowerCase();
+  if (message.includes('请先在新打开的 icloud 页面中完成登录')) {
+    return true;
+  }
+  return message.includes('网络/上下文波动')
+    || message.includes('could not validate icloud session')
+    || message.includes('status 421')
+    || message.includes('failed to fetch')
+    || message.includes('network request failed')
+    || message.includes('networkerror')
+    || message.includes('cors')
+    || message.includes('address space')
+    || message.includes('timed out')
+    || message.includes('timeout');
+}
+
+function shouldStopEmailAutoFetchRetries(generator, error) {
+  if (generator === 'icloud' && shouldStopIcloudAutoFetchRetries(error)) {
+    return true;
+  }
+  const message = String(error?.message || '');
+  if (generator === 'cloudflare' && /域名/.test(message)) {
+    return true;
+  }
+  return generator === CLOUDFLARE_TEMP_EMAIL_GENERATOR && /(服务地址|Admin Auth|域名)/.test(message);
 }
 
 async function ensureAutoEmailReady(targetRun, totalRuns, attemptRuns) {
@@ -6667,7 +7724,9 @@ async function ensureAutoEmailReady(targetRun, totalRuns, attemptRuns) {
   const generator = normalizeEmailGenerator(currentState.emailGenerator);
   const generatorLabel = getEmailGeneratorLabel(generator);
   let lastError = null;
+  let attemptedFetches = 0;
   for (let attempt = 1; attempt <= EMAIL_FETCH_MAX_ATTEMPTS; attempt++) {
+    attemptedFetches = attempt;
     try {
       if (attempt > 1) {
         await addLog(`${generatorLabel}：正在进行第 ${attempt}/${EMAIL_FETCH_MAX_ATTEMPTS} 次自动获取重试...`, 'warn');
@@ -6684,16 +7743,17 @@ async function ensureAutoEmailReady(targetRun, totalRuns, attemptRuns) {
     } catch (err) {
       lastError = err;
       await addLog(`${generatorLabel}自动获取失败（${attempt}/${EMAIL_FETCH_MAX_ATTEMPTS}）：${err.message}`, 'warn');
-      if (
-        (generator === 'cloudflare' && /域名/.test(String(err.message || '')))
-        || (generator === CLOUDFLARE_TEMP_EMAIL_GENERATOR && /(服务地址|Admin Auth|域名)/.test(String(err.message || '')))
-      ) {
+      if (generator === 'icloud' && shouldStopIcloudAutoFetchRetries(err)) {
+        await addLog('iCloud：检测到会话/网络异常，本轮将停止重复重试。请先确认 iCloud 页面已登录，再点击“我已登录”或手动粘贴邮箱继续。', 'warn');
+      }
+      if (shouldStopEmailAutoFetchRetries(generator, err)) {
         break;
       }
     }
   }
 
-  await addLog(`${generatorLabel}自动获取已连续失败 ${EMAIL_FETCH_MAX_ATTEMPTS} 次：${lastError?.message || '未知错误'}`, 'error');
+  const totalAttempts = Math.max(1, attemptedFetches);
+  await addLog(`${generatorLabel}自动获取已连续失败 ${totalAttempts} 次：${lastError?.message || '未知错误'}`, 'error');
   await addLog(`=== 目标 ${targetRun}/${totalRuns} 轮已暂停：请先自动获取邮箱或手动粘贴邮箱，然后继续 ===`, 'warn');
   await broadcastAutoRunStatus('waiting_email', {
     currentRun: targetRun,
@@ -6816,7 +7876,9 @@ async function ensureAutoEmailReady(targetRun, totalRuns, attemptRuns) {
   const generator = normalizeEmailGenerator(currentState.emailGenerator);
   const generatorLabel = getEmailGeneratorLabel(generator);
   let lastError = null;
+  let attemptedFetches = 0;
   for (let attempt = 1; attempt <= EMAIL_FETCH_MAX_ATTEMPTS; attempt++) {
+    attemptedFetches = attempt;
     try {
       if (attempt > 1) {
         await addLog(`${generatorLabel}：正在进行第 ${attempt}/${EMAIL_FETCH_MAX_ATTEMPTS} 次自动获取重试...`, 'warn');
@@ -6833,16 +7895,17 @@ async function ensureAutoEmailReady(targetRun, totalRuns, attemptRuns) {
     } catch (err) {
       lastError = err;
       await addLog(`${generatorLabel}自动获取失败（${attempt}/${EMAIL_FETCH_MAX_ATTEMPTS}）：${err.message}`, 'warn');
-      if (
-        (generator === 'cloudflare' && /域名/.test(String(err.message || '')))
-        || (generator === CLOUDFLARE_TEMP_EMAIL_GENERATOR && /(服务地址|Admin Auth|域名)/.test(String(err.message || '')))
-      ) {
+      if (generator === 'icloud' && shouldStopIcloudAutoFetchRetries(err)) {
+        await addLog('iCloud：检测到会话/网络异常，本轮将停止重复重试。请先确认 iCloud 页面已登录，再点击“我已登录”或手动粘贴邮箱继续。', 'warn');
+      }
+      if (shouldStopEmailAutoFetchRetries(generator, err)) {
         break;
       }
     }
   }
 
-  await addLog(`${generatorLabel}自动获取已连续失败 ${EMAIL_FETCH_MAX_ATTEMPTS} 次：${lastError?.message || '未知错误'}`, 'error');
+  const totalAttempts = Math.max(1, attemptedFetches);
+  await addLog(`${generatorLabel}自动获取已连续失败 ${totalAttempts} 次：${lastError?.message || '未知错误'}`, 'error');
   await addLog(`=== 目标 ${targetRun}/${totalRuns} 轮已暂停：请先自动获取邮箱或手动粘贴邮箱，然后继续 ===`, 'warn');
   await broadcastAutoRunStatus('waiting_email', {
     currentRun: targetRun,
@@ -7412,6 +8475,7 @@ const messageRouter = self.MultiPageBackgroundMessageRouter?.createMessageRouter
   buildLuckmailSessionSettingsPayload,
   buildPersistentSettingsPayload,
   broadcastDataUpdate,
+  applyIpProxySettingsFromState,
   cancelScheduledAutoRun,
   checkIcloudSession,
   clearAccountRunHistory: (...args) => clearAndBroadcastAccountRunHistory(...args),
@@ -7468,6 +8532,7 @@ const messageRouter = self.MultiPageBackgroundMessageRouter?.createMessageRouter
   launchAutoRunTimerPlan,
   listIcloudAliases,
   listLuckmailPurchasesForManagement,
+  refreshIpProxyPool,
   getCurrentMail2925Account,
   normalizeHotmailAccounts,
   normalizeMail2925Accounts,
@@ -7479,10 +8544,13 @@ const messageRouter = self.MultiPageBackgroundMessageRouter?.createMessageRouter
   patchMail2925Account,
   registerTab,
   requestStop,
+  probeIpProxyExit,
   resetState,
   resumeAutoRun,
   scheduleAutoRun,
   selectLuckmailPurchase,
+  switchIpProxy,
+  changeIpProxyExit,
   setCurrentHotmailAccount,
   setCurrentMail2925Account,
   setContributionMode,
@@ -8666,14 +9734,32 @@ chrome.runtime.onStartup.addListener(() => {
   restoreAutoRunTimerIfNeeded().catch((err) => {
     console.error(LOG_PREFIX, 'Failed to restore auto run timer on startup:', err);
   });
+  ensureIpProxySettingsAppliedFromCurrentState({
+    skipExitProbe: !IP_PROXY_INIT_ENABLE_EXIT_PROBE,
+    suppressAuthRebind: IP_PROXY_INIT_SUPPRESS_AUTH_REBIND,
+  }).catch((err) => {
+    console.error(LOG_PREFIX, 'Failed to restore IP proxy settings on startup:', err);
+  });
 });
 
 chrome.runtime.onInstalled.addListener(() => {
   restoreAutoRunTimerIfNeeded().catch((err) => {
     console.error(LOG_PREFIX, 'Failed to restore auto run timer on install/update:', err);
   });
+  ensureIpProxySettingsAppliedFromCurrentState({
+    skipExitProbe: !IP_PROXY_INIT_ENABLE_EXIT_PROBE,
+    suppressAuthRebind: IP_PROXY_INIT_SUPPRESS_AUTH_REBIND,
+  }).catch((err) => {
+    console.error(LOG_PREFIX, 'Failed to restore IP proxy settings on install/update:', err);
+  });
 });
 
 restoreAutoRunTimerIfNeeded().catch((err) => {
   console.error(LOG_PREFIX, 'Failed to restore auto run timer:', err);
+});
+ensureIpProxySettingsAppliedFromCurrentState({
+  skipExitProbe: !IP_PROXY_INIT_ENABLE_EXIT_PROBE,
+  suppressAuthRebind: IP_PROXY_INIT_SUPPRESS_AUTH_REBIND,
+}).catch((err) => {
+  console.error(LOG_PREFIX, 'Failed to restore IP proxy settings:', err);
 });

--- a/background/ip-proxy-core.js
+++ b/background/ip-proxy-core.js
@@ -1,0 +1,3589 @@
+// background/ip-proxy-core.js — IP代理核心（解析/应用/切换/探测）
+let ipProxyAuthListenerInstalled = false;
+let ipProxyErrorListenerInstalled = false;
+let currentIpProxyAuthEntry = null;
+let ipProxyExitDetectionToken = 0;
+let lastAppliedIpProxyEntrySignature = '';
+let ipProxyAuthHostVariantToggle = false;
+const ipProxyHostResolveCache = new Map();
+const IP_PROXY_HOST_RESOLVE_CACHE_TTL_MS = 60 * 1000;
+const ipProxyHostResolveCursor = new Map();
+let lastAppliedIpProxyAuthSnapshot = {
+  host: '',
+  port: 0,
+  username: '',
+  password: '',
+};
+let ipProxyAuthDiagnostics = {
+  challengeCount: 0,
+  providedCount: 0,
+  lastIsProxy: null,
+  lastStatusCode: 0,
+  lastHost: '',
+  lastPort: 0,
+  lastAt: 0,
+};
+let ipProxyLastRuntimeError = {
+  error: '',
+  details: '',
+  fatal: false,
+  at: 0,
+};
+const IP_PROXY_EXIT_PROBE_ENDPOINTS = [
+  'http://ip-api.com/json?lang=en',
+  'http://ipinfo.io/json',
+  'https://ipinfo.io/json',
+  'http://myip.ipip.net',
+  'https://chatgpt.com/cdn-cgi/trace',
+  'https://ipwho.is/',
+  'https://ipapi.co/json/',
+  'https://api.ipify.org?format=json',
+  'https://api64.ipify.org?format=json',
+  'https://httpbin.org/ip',
+  'https://checkip.amazonaws.com',
+  'https://ident.me',
+];
+const IP_PROXY_EXIT_PROBE_ENDPOINTS_711_STICKY = [
+  'https://ipinfo.io/json',
+];
+const IP_PROXY_BACKGROUND_PROBE_MAX_ENDPOINTS = 4;
+const IP_PROXY_BACKGROUND_PROBE_PER_ENDPOINT_TIMEOUT_MS = 3500;
+const IP_PROXY_PAGE_CONTEXT_PROBE_URL = 'https://example.com/';
+const IP_PROXY_PAGE_CONTEXT_BASELINE_URL = 'https://ifconfig.co/json';
+const IP_PROXY_PAGE_CONTEXT_READY_TIMEOUT_MS = 8000;
+const IP_PROXY_PAGE_CONTEXT_BASELINE_TIMEOUT_MS = 6000;
+const IP_PROXY_DIAGNOSTICS_SUMMARY_MAX_ITEMS = 8;
+const IP_PROXY_GUARD_BLOCK_RULE_ID = 10991;
+const IP_PROXY_GUARD_REGEX = '^https?:\\/\\/([^\\/]+\\.)?(chatgpt\\.com|openai\\.com)(\\/|$)';
+
+function normalizeIpProxyProviderValue(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (IP_PROXY_SERVICE_VALUES.includes(normalized)) {
+    return normalized;
+  }
+  return DEFAULT_IP_PROXY_SERVICE;
+}
+
+function normalizeProxyHostForCompare(value = '') {
+  return String(value || '').trim().toLowerCase().replace(/\.$/, '');
+}
+
+function stripProxyHostTrailingDot(value = '') {
+  return String(value || '').trim().replace(/\.$/, '');
+}
+
+function isIpv4LikeHost(value = '') {
+  const text = String(value || '').trim();
+  if (!text) {
+    return false;
+  }
+  return /^\d{1,3}(?:\.\d{1,3}){3}$/.test(text);
+}
+
+function isIpv6LikeHost(value = '') {
+  const text = String(value || '').trim();
+  if (!text) {
+    return false;
+  }
+  const compact = text.replace(/^\[/, '').replace(/\]$/, '');
+  return compact.includes(':');
+}
+
+function canUseProxyHostVariant(value = '') {
+  const host = stripProxyHostTrailingDot(value);
+  if (!host) {
+    return false;
+  }
+  if (isIpv4LikeHost(host) || isIpv6LikeHost(host)) {
+    return false;
+  }
+  return /[A-Za-z]/.test(host) && host.includes('.');
+}
+
+function isValidIpv4Address(value = '') {
+  const text = String(value || '').trim();
+  if (!/^\d{1,3}(?:\.\d{1,3}){3}$/.test(text)) {
+    return false;
+  }
+  const parts = text.split('.');
+  return parts.length === 4 && parts.every((part) => {
+    const numeric = Number.parseInt(part, 10);
+    return Number.isInteger(numeric) && numeric >= 0 && numeric <= 255;
+  });
+}
+
+function readCachedResolvedProxyHosts(host = '') {
+  const key = stripProxyHostTrailingDot(host).toLowerCase();
+  if (!key) {
+    return [];
+  }
+  const cached = ipProxyHostResolveCache.get(key);
+  if (!cached || !Array.isArray(cached?.ips) || !cached?.expiresAt) {
+    return [];
+  }
+  if (cached.expiresAt <= Date.now()) {
+    ipProxyHostResolveCache.delete(key);
+    return [];
+  }
+  return cached.ips;
+}
+
+function writeCachedResolvedProxyHosts(host = '', ips = []) {
+  const key = stripProxyHostTrailingDot(host).toLowerCase();
+  if (!key) {
+    return;
+  }
+  const normalized = Array.from(new Set((Array.isArray(ips) ? ips : [])
+    .map((item) => String(item || '').trim())
+    .filter((item) => isValidIpv4Address(item))));
+  if (!normalized.length) {
+    return;
+  }
+  ipProxyHostResolveCache.set(key, {
+    ips: normalized,
+    expiresAt: Date.now() + IP_PROXY_HOST_RESOLVE_CACHE_TTL_MS,
+  });
+  if (!ipProxyHostResolveCursor.has(key)) {
+    ipProxyHostResolveCursor.set(key, 0);
+  }
+}
+
+function pickNextResolvedProxyHost(host = '', candidates = []) {
+  const key = stripProxyHostTrailingDot(host).toLowerCase();
+  const list = Array.isArray(candidates)
+    ? candidates.map((item) => String(item || '').trim()).filter((item) => isValidIpv4Address(item))
+    : [];
+  if (!key || !list.length) {
+    return '';
+  }
+  const cursor = Number(ipProxyHostResolveCursor.get(key) || 0);
+  const index = Math.abs(cursor) % list.length;
+  ipProxyHostResolveCursor.set(key, cursor + 1);
+  return String(list[index] || '').trim();
+}
+
+async function resolveProxyHostIpv4Candidates(host = '', timeoutMs = 3500) {
+  const normalizedHost = stripProxyHostTrailingDot(host);
+  if (!canUseProxyHostVariant(normalizedHost)) {
+    return [];
+  }
+  const cached = readCachedResolvedProxyHosts(normalizedHost);
+  if (cached.length) {
+    return cached;
+  }
+  const endpoint = `https://dns.google/resolve?name=${encodeURIComponent(normalizedHost)}&type=A`;
+  const response = await fetchWithTimeout(endpoint, {
+    method: 'GET',
+    cache: 'no-store',
+    headers: {
+      Accept: 'application/dns-json, application/json, text/plain, */*',
+    },
+  }, timeoutMs);
+  if (!response.ok) {
+    return [];
+  }
+  const payload = await response.json().catch(() => null);
+  if (!payload || typeof payload !== 'object') {
+    return [];
+  }
+  const answers = Array.isArray(payload?.Answer) ? payload.Answer : [];
+  const ips = answers
+    .filter((item) => Number(item?.type) === 1)
+    .map((item) => String(item?.data || '').trim())
+    .filter((ip) => isValidIpv4Address(ip));
+  const uniqueIps = Array.from(new Set(ips));
+  if (!uniqueIps.length) {
+    return [];
+  }
+  writeCachedResolvedProxyHosts(normalizedHost, uniqueIps);
+  return uniqueIps;
+}
+
+async function maybeResolveProxyHostVariantForAuthSwitch(entry = {}, options = {}) {
+  const force = Boolean(options?.force);
+  if (!force) {
+    return entry;
+  }
+  const provider = normalizeIpProxyProviderValue(entry?.provider || DEFAULT_IP_PROXY_SERVICE);
+  const allow711ResolvedIp = Boolean(options?.allow711ResolvedIp);
+  // 711 默认仍保持域名路由；仅在“多账号列表切换”场景下允许解析 IP 变体，
+  // 用于强制打断同 host:port 连接复用，提升触发 407 挑战的概率。
+  if (provider === '711proxy' && !allow711ResolvedIp) {
+    return entry;
+  }
+  const protocol = normalizeIpProxyProtocol(entry?.protocol || DEFAULT_IP_PROXY_PROTOCOL);
+  if (protocol !== 'http') {
+    return entry;
+  }
+  if (!String(entry?.username || '').trim()) {
+    return entry;
+  }
+  const host = stripProxyHostTrailingDot(entry?.host || '');
+  if (!canUseProxyHostVariant(host)) {
+    return entry;
+  }
+  const candidates = await resolveProxyHostIpv4Candidates(host, Number(options?.timeoutMs) || 3500).catch(() => []);
+  if (!candidates.length) {
+    return entry;
+  }
+  const selectedHost = pickNextResolvedProxyHost(host, candidates);
+  if (!selectedHost || !isValidIpv4Address(selectedHost)) {
+    return entry;
+  }
+  return {
+    ...entry,
+    host: selectedHost,
+  };
+}
+
+function buildHostVariantForProxy(value = '', useTrailingDot = false) {
+  const host = stripProxyHostTrailingDot(value);
+  if (!canUseProxyHostVariant(host)) {
+    return host;
+  }
+  return useTrailingDot ? `${host}.` : host;
+}
+
+function shouldForceProxyConnectionDrainForEntry(entry = {}) {
+  const nextHost = normalizeProxyHostForCompare(entry?.host || '');
+  const nextPort = normalizeIpProxyPort(entry?.port);
+  const nextUser = String(entry?.username || '').trim();
+  const nextPass = String(entry?.password || '');
+  if (!nextHost || !nextPort || !nextUser) {
+    return false;
+  }
+  const previousHost = normalizeProxyHostForCompare(lastAppliedIpProxyAuthSnapshot?.host || '');
+  const previousPort = normalizeIpProxyPort(lastAppliedIpProxyAuthSnapshot?.port);
+  if (!previousHost || !previousPort) {
+    return false;
+  }
+  const sameEndpoint = nextHost === previousHost && nextPort === previousPort;
+  if (!sameEndpoint) {
+    return false;
+  }
+  const previousUser = String(lastAppliedIpProxyAuthSnapshot?.username || '').trim();
+  const previousPass = String(lastAppliedIpProxyAuthSnapshot?.password || '');
+  return nextUser !== previousUser || nextPass !== previousPass;
+}
+
+function buildEffectiveProxyEntryForApply(entry = {}, options = {}) {
+  const forceRotateVariant = Boolean(options?.forceRotateVariant);
+  const next = { ...(entry || {}) };
+  const provider = normalizeIpProxyProviderValue(next?.provider || DEFAULT_IP_PROXY_SERVICE);
+  const originalHost = String(next?.host || '').trim();
+  if (provider === '711proxy') {
+    const allow711HostVariant = Boolean(options?.allow711HostVariant) && forceRotateVariant;
+    if (allow711HostVariant && canUseProxyHostVariant(originalHost)) {
+      ipProxyAuthHostVariantToggle = !ipProxyAuthHostVariantToggle;
+      next.host = buildHostVariantForProxy(originalHost, ipProxyAuthHostVariantToggle);
+      return next;
+    }
+    // 单账号场景下保持 host 稳定，避免不必要的链路扰动。
+    next.host = stripProxyHostTrailingDot(originalHost);
+    return next;
+  }
+  const canVariant = canUseProxyHostVariant(originalHost);
+  if (!canVariant) {
+    next.host = stripProxyHostTrailingDot(originalHost);
+    return next;
+  }
+  if (forceRotateVariant) {
+    ipProxyAuthHostVariantToggle = !ipProxyAuthHostVariantToggle;
+  }
+  next.host = buildHostVariantForProxy(originalHost, ipProxyAuthHostVariantToggle);
+  return next;
+}
+
+function resetIpProxyAuthDiagnostics() {
+  ipProxyAuthDiagnostics = {
+    challengeCount: 0,
+    providedCount: 0,
+    lastIsProxy: null,
+    lastStatusCode: 0,
+    lastHost: '',
+    lastPort: 0,
+    lastAt: 0,
+  };
+}
+
+function recordIpProxyAuthChallenge(details = {}, provided = false) {
+  const host = String(details?.challenger?.host || '').trim();
+  const port = Number.parseInt(String(details?.challenger?.port || ''), 10) || 0;
+  const statusCode = Number.parseInt(String(details?.statusCode || ''), 10) || 0;
+  const isProxy = details?.isProxy === true;
+  ipProxyAuthDiagnostics.challengeCount += 1;
+  if (provided) {
+    ipProxyAuthDiagnostics.providedCount += 1;
+  }
+  ipProxyAuthDiagnostics.lastIsProxy = isProxy;
+  ipProxyAuthDiagnostics.lastStatusCode = statusCode;
+  ipProxyAuthDiagnostics.lastHost = host;
+  ipProxyAuthDiagnostics.lastPort = port;
+  ipProxyAuthDiagnostics.lastAt = Date.now();
+}
+
+function getIpProxyAuthDiagnosticsSummary() {
+  const lastHost = String(ipProxyAuthDiagnostics?.lastHost || '').trim();
+  const lastPort = Number(ipProxyAuthDiagnostics?.lastPort || 0);
+  const hostPort = lastHost
+    ? `${lastHost}${lastPort > 0 ? `:${lastPort}` : ''}`
+    : 'unknown';
+  const isProxyText = ipProxyAuthDiagnostics?.lastIsProxy === null
+    ? 'n/a'
+    : (ipProxyAuthDiagnostics.lastIsProxy ? 'true' : 'false');
+  return `auth(challenge=${Number(ipProxyAuthDiagnostics?.challengeCount || 0)},provided=${Number(ipProxyAuthDiagnostics?.providedCount || 0)},isProxy=${isProxyText},status=${Number(ipProxyAuthDiagnostics?.lastStatusCode || 0)},host=${hostPort})`;
+}
+
+function appendIpProxyAuthDiagnosticsToErrors(errors = []) {
+  if (!Array.isArray(errors)) {
+    return;
+  }
+  errors.push(`probe:${getIpProxyAuthDiagnosticsSummary()}`);
+}
+
+function parseIpProxyAuthDiagnosticsSummary(summary = '') {
+  const text = String(summary || '').trim();
+  if (!text) {
+    return null;
+  }
+  const challenge = Number.parseInt(String(text.match(/challenge=(\d+)/i)?.[1] || ''), 10) || 0;
+  const provided = Number.parseInt(String(text.match(/provided=(\d+)/i)?.[1] || ''), 10) || 0;
+  return { challenge, provided };
+}
+
+function resetIpProxyRuntimeErrorDiagnostics() {
+  ipProxyLastRuntimeError = {
+    error: '',
+    details: '',
+    fatal: false,
+    at: 0,
+  };
+}
+
+function getIpProxyRuntimeErrorSummary() {
+  const error = String(ipProxyLastRuntimeError?.error || '').trim();
+  const details = String(ipProxyLastRuntimeError?.details || '').trim();
+  const fatal = Boolean(ipProxyLastRuntimeError?.fatal);
+  if (!error && !details) {
+    return '';
+  }
+  return `proxy_error(error=${error || 'unknown'},fatal=${fatal ? 1 : 0},details=${details || 'n/a'})`;
+}
+
+function appendIpProxyRuntimeErrorDiagnosticsToErrors(errors = [], maxAgeMs = 30000) {
+  if (!Array.isArray(errors)) {
+    return;
+  }
+  const summary = getIpProxyRuntimeErrorSummary();
+  if (!summary) {
+    return;
+  }
+  const ageMs = Date.now() - Number(ipProxyLastRuntimeError?.at || 0);
+  if (!Number.isFinite(ageMs) || ageMs < 0 || ageMs > Math.max(1000, Number(maxAgeMs) || 30000)) {
+    return;
+  }
+  errors.push(`probe:${summary}`);
+}
+
+function buildProbeDiagnosticsSummary(errors = [], maxItems = 4) {
+  if (!Array.isArray(errors) || !errors.length) {
+    return '';
+  }
+  const normalized = errors
+    .map((item) => String(item || '').trim())
+    .filter(Boolean);
+  if (!normalized.length) {
+    return '';
+  }
+  const authItem = normalized.find((item) => /probe:auth\(/i.test(item)) || '';
+  const proxyErrorItem = normalized.find((item) => /probe:proxy_error\(/i.test(item)) || '';
+  const navigationItem = normalized.find((item) => /probe:page_context:navigation_error:/i.test(item)) || '';
+  const pageContextItem = normalized.find((item) => /probe:page_context:/i.test(item)) || '';
+  const slowRetryItem = normalized.find((item) => /probe:bg:slow_retry:/i.test(item)) || '';
+  const retryItem = normalized.find((item) => /probe:bg:retry:/i.test(item)) || '';
+  const abortFallbackItem = normalized.find((item) => /probe:bg:abort_storm_page_fallback/i.test(item)) || '';
+  const headLimit = Math.max(1, Number(maxItems) || 4);
+  const headItems = normalized.slice(0, headLimit);
+  const mustKeepItems = [
+    authItem,
+    proxyErrorItem,
+    navigationItem,
+    pageContextItem,
+    slowRetryItem,
+    retryItem,
+    abortFallbackItem,
+  ].filter(Boolean);
+  for (const mustKeepItem of mustKeepItems) {
+    if (headItems.includes(mustKeepItem)) {
+      continue;
+    }
+    if (headItems.length >= headLimit) {
+      headItems[headItems.length - 1] = mustKeepItem;
+    } else {
+      headItems.push(mustKeepItem);
+    }
+  }
+  return headItems.join(' | ');
+}
+
+function normalizeIpProxyMode(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  return IP_PROXY_MODE_VALUES.includes(normalized) ? normalized : DEFAULT_IP_PROXY_MODE;
+}
+
+function normalizeIpProxyProtocol(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  return IP_PROXY_PROTOCOL_VALUES.includes(normalized) ? normalized : DEFAULT_IP_PROXY_PROTOCOL;
+}
+
+function normalizeIpProxyPort(value = '') {
+  const numeric = Number.parseInt(String(value || '').trim(), 10);
+  if (!Number.isInteger(numeric) || numeric <= 0 || numeric > 65535) {
+    return 0;
+  }
+  return numeric;
+}
+
+function normalizeIpProxyCurrentIndex(value, fallback = 0) {
+  const numeric = Number.parseInt(String(value ?? ''), 10);
+  if (!Number.isInteger(numeric) || numeric < 0) {
+    return Math.max(0, Number(fallback) || 0);
+  }
+  return numeric;
+}
+
+function normalizeIpProxyPoolTargetCount(value = '', fallback = 20) {
+  const rawValue = String(value ?? '').trim();
+  if (!rawValue) {
+    return String(Math.max(1, Math.min(500, Number(fallback) || 20)));
+  }
+  const numeric = Number.parseInt(rawValue, 10);
+  if (!Number.isInteger(numeric)) {
+    return String(Math.max(1, Math.min(500, Number(fallback) || 20)));
+  }
+  return String(Math.max(1, Math.min(500, numeric)));
+}
+
+function normalizeIpProxyAccountLifeMinutes(value = '') {
+  const raw = String(value ?? '').trim();
+  if (!raw) return '';
+  const numeric = Number.parseInt(raw, 10);
+  if (!Number.isInteger(numeric)) return '';
+  return String(Math.max(1, Math.min(1440, numeric)));
+}
+
+function normalizeIpProxyAccountSessionPrefix(value = '') {
+  return String(value || '').trim().replace(/[^A-Za-z0-9_-]/g, '').slice(0, 32);
+}
+
+function normalizeIpProxyAccountList(value = '') {
+  return String(value || '')
+    .replace(/\r/g, '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join('\n');
+}
+
+function inferRegionFromProxyUsername(username = '') {
+  const text = String(username || '').trim();
+  if (!text) {
+    return '';
+  }
+  const match = text.match(/(?:^|[-_])(?:region|area|country)[-_:]?([A-Za-z]{2})\b/i);
+  if (!match) {
+    return '';
+  }
+  return String(match[1] || '').trim().toUpperCase();
+}
+
+function inferRegionFromProxyHost(host = '') {
+  const text = String(host || '').trim().toLowerCase().replace(/\.$/, '');
+  if (!text || !text.includes('.')) {
+    return '';
+  }
+  const firstLabel = String(text.split('.')[0] || '').trim();
+  if (!/^[a-z]{2}$/.test(firstLabel)) {
+    return '';
+  }
+  return firstLabel.toUpperCase();
+}
+
+function shouldApplyConfiguredRegionFallbackToEntry(entry = {}, context = {}) {
+  const provider = normalizeIpProxyProviderValue(
+    context?.provider || entry?.provider || DEFAULT_IP_PROXY_SERVICE
+  );
+  const configuredRegion = String(context?.configuredRegion || '').trim();
+  if (!configuredRegion) {
+    return false;
+  }
+  if (Boolean(context?.hasAccountList)) {
+    return false;
+  }
+  const entryRegion = String(entry?.region || '').trim();
+  if (entryRegion) {
+    return false;
+  }
+  if (provider !== '711proxy') {
+    return true;
+  }
+  const usernameRegion = inferRegionFromProxyUsername(entry?.username || '');
+  if (usernameRegion) {
+    return true;
+  }
+  const hostRegion = inferRegionFromProxyHost(entry?.host || '');
+  if (hostRegion) {
+    return true;
+  }
+  // 711 固定账号在 zone-custom 混播场景下，不使用旧的配置地区兜底，避免误报“卡在 AF”。
+  return false;
+}
+
+function resolveIpProxyAccountEntrySource(state = {}, mode = normalizeIpProxyMode(state?.ipProxyMode)) {
+  const normalizedMode = normalizeIpProxyMode(mode);
+  if (normalizedMode !== 'account') {
+    return 'non_account';
+  }
+  return hasConfiguredAccountListEntries(state) ? 'account_list' : 'fixed_account';
+}
+
+function isIpProxyAccountListEnabled() {
+  return Boolean(typeof IP_PROXY_ACCOUNT_LIST_ENABLED === 'undefined'
+    ? true
+    : IP_PROXY_ACCOUNT_LIST_ENABLED);
+}
+
+function normalizeIpProxyServiceProfile(rawValue = {}) {
+  const raw = (rawValue && typeof rawValue === 'object' && !Array.isArray(rawValue))
+    ? rawValue
+    : {};
+  return {
+    mode: normalizeIpProxyMode(raw.mode),
+    apiUrl: String(raw.apiUrl || '').trim(),
+    accountList: normalizeIpProxyAccountList(raw.accountList || ''),
+    accountSessionPrefix: normalizeIpProxyAccountSessionPrefix(raw.accountSessionPrefix || ''),
+    accountLifeMinutes: normalizeIpProxyAccountLifeMinutes(raw.accountLifeMinutes || ''),
+    poolTargetCount: normalizeIpProxyPoolTargetCount(raw.poolTargetCount || '', 20),
+    host: String(raw.host || '').trim(),
+    port: String(normalizeIpProxyPort(raw.port || '') || ''),
+    protocol: normalizeIpProxyProtocol(raw.protocol),
+    username: String(raw.username || '').trim(),
+    password: String(raw.password || ''),
+    region: String(raw.region || '').trim(),
+  };
+}
+
+function buildIpProxyServiceProfileFromState(state = {}) {
+  return normalizeIpProxyServiceProfile({
+    mode: state?.ipProxyMode,
+    apiUrl: state?.ipProxyApiUrl,
+    accountList: state?.ipProxyAccountList,
+    accountSessionPrefix: state?.ipProxyAccountSessionPrefix,
+    accountLifeMinutes: state?.ipProxyAccountLifeMinutes,
+    poolTargetCount: state?.ipProxyPoolTargetCount,
+    host: state?.ipProxyHost,
+    port: state?.ipProxyPort,
+    protocol: state?.ipProxyProtocol,
+    username: state?.ipProxyUsername,
+    password: state?.ipProxyPassword,
+    region: state?.ipProxyRegion,
+  });
+}
+
+function normalizeIpProxyServiceProfiles(rawValue = {}, fallbackState = {}) {
+  const raw = (rawValue && typeof rawValue === 'object' && !Array.isArray(rawValue))
+    ? rawValue
+    : {};
+  const fallbackProfile = buildIpProxyServiceProfileFromState(fallbackState);
+  const result = {};
+  IP_PROXY_SERVICE_VALUES.forEach((service) => {
+    const serviceRaw = raw[service];
+    if (serviceRaw && typeof serviceRaw === 'object' && !Array.isArray(serviceRaw)) {
+      result[service] = normalizeIpProxyServiceProfile(serviceRaw);
+      return;
+    }
+    result[service] = normalizeIpProxyServiceProfile(fallbackProfile);
+  });
+  return result;
+}
+
+function normalizeIpProxyEntriesFromObjectCandidate(candidate, provider = DEFAULT_IP_PROXY_SERVICE) {
+  if (!candidate || typeof candidate !== 'object') {
+    return null;
+  }
+
+  const directProxyText = String(
+    candidate.proxy
+    || candidate.proxy_url
+    || candidate.proxyUrl
+    || candidate.proxyAddress
+    || ''
+  ).trim();
+  if (directProxyText) {
+    const parsed = parseIpProxyLine(directProxyText, provider);
+    if (parsed) {
+      return {
+        ...parsed,
+        region: String(candidate.region || candidate.country || candidate.city || parsed.region || '').trim(),
+      };
+    }
+  }
+
+  const host = String(
+    candidate.host
+    || candidate.ip
+    || candidate.server
+    || candidate.address
+    || candidate.proxy_host
+    || candidate.proxyHost
+    || ''
+  ).trim();
+  const port = normalizeIpProxyPort(
+    candidate.port
+    || candidate.proxy_port
+    || candidate.proxyPort
+    || ''
+  );
+  if (!host || !port) {
+    return null;
+  }
+
+  const username = String(
+    candidate.username
+    || candidate.user
+    || candidate.account
+    || candidate.proxy_user
+    || candidate.proxyUser
+    || ''
+  ).trim();
+  const password = String(
+    candidate.password
+    || candidate.pass
+    || candidate.pwd
+    || candidate.proxy_pass
+    || candidate.proxyPass
+    || ''
+  );
+  const protocol = normalizeIpProxyProtocol(
+    candidate.protocol
+    || candidate.schema
+    || candidate.scheme
+    || candidate.type
+    || ''
+  );
+  const region = String(candidate.region || candidate.country || candidate.city || '').trim();
+  return {
+    host,
+    port,
+    username,
+    password,
+    protocol,
+    region,
+    provider: normalizeIpProxyProviderValue(candidate.provider || provider),
+  };
+}
+
+function parseIpProxyLine(line, provider = DEFAULT_IP_PROXY_SERVICE) {
+  const text = String(line || '').trim();
+  if (!text) {
+    return null;
+  }
+
+  const schemaMatch = text.match(/^(https?|socks4|socks5):\/\/(.+)$/i);
+  const protocol = normalizeIpProxyProtocol(schemaMatch ? schemaMatch[1] : '');
+  const rawBody = schemaMatch ? schemaMatch[2] : text;
+  const firstSegment = rawBody.split(/[/?#]/)[0];
+  const parts = firstSegment.split(':');
+  if (parts.length < 2) {
+    return null;
+  }
+  const host = String(parts[0] || '').trim();
+  const port = normalizeIpProxyPort(parts[1]);
+  if (!host || !port) {
+    return null;
+  }
+
+  const username = String(parts[2] || '').trim();
+  const password = parts.length >= 4 ? String(parts.slice(3).join(':') || '') : '';
+  return {
+    host,
+    port,
+    username,
+    password,
+    protocol,
+    region: '',
+    provider: normalizeIpProxyProviderValue(provider),
+  };
+}
+
+function enumerateContiguousIpv4WithColonCandidates(text = '', startIndex = 0) {
+  const source = String(text || '');
+  const candidates = [];
+  const sourceLength = source.length;
+  const isDigitCode = (code) => code >= 48 && code <= 57;
+
+  const readOctet = (offset, maxLen = 3) => {
+    let end = offset;
+    while (end < sourceLength && end < offset + maxLen) {
+      const code = source.charCodeAt(end);
+      if (!isDigitCode(code)) {
+        break;
+      }
+      end += 1;
+    }
+    if (end <= offset) {
+      return null;
+    }
+    const value = Number.parseInt(source.slice(offset, end), 10);
+    if (!Number.isInteger(value) || value < 0 || value > 255) {
+      return null;
+    }
+    return { value, end };
+  };
+
+  for (let l1 = 1; l1 <= 3; l1 += 1) {
+    const o1 = readOctet(startIndex, l1);
+    if (!o1 || source[o1.end] !== '.') continue;
+    for (let l2 = 1; l2 <= 3; l2 += 1) {
+      const o2 = readOctet(o1.end + 1, l2);
+      if (!o2 || source[o2.end] !== '.') continue;
+      for (let l3 = 1; l3 <= 3; l3 += 1) {
+        const o3 = readOctet(o2.end + 1, l3);
+        if (!o3 || source[o3.end] !== '.') continue;
+        for (let l4 = 1; l4 <= 3; l4 += 1) {
+          const o4 = readOctet(o3.end + 1, l4);
+          if (!o4 || source[o4.end] !== ':') continue;
+          const host = `${o1.value}.${o2.value}.${o3.value}.${o4.value}`;
+          candidates.push({
+            host,
+            hostEnd: o4.end,
+            portStart: o4.end + 1,
+          });
+        }
+      }
+    }
+  }
+
+  return candidates;
+}
+
+function parseContiguousProxyStream(rawText = '', provider = DEFAULT_IP_PROXY_SERVICE) {
+  const source = String(rawText || '').trim();
+  if (!source) {
+    return [];
+  }
+  if (!/^\d/.test(source) || !source.includes(':')) {
+    return [];
+  }
+
+  const memo = new Map();
+
+  const solve = (offset = 0, previousHost = '') => {
+    const key = `${offset}|${previousHost}`;
+    if (memo.has(key)) {
+      return memo.get(key);
+    }
+    if (offset >= source.length) {
+      const terminal = { score: 0, tokens: [] };
+      memo.set(key, terminal);
+      return terminal;
+    }
+
+    let best = null;
+    const hostCandidates = enumerateContiguousIpv4WithColonCandidates(source, offset);
+    for (const candidate of hostCandidates) {
+      const { host, portStart } = candidate;
+      for (let portLen = 2; portLen <= 5; portLen += 1) {
+        const portEnd = portStart + portLen;
+        if (portEnd > source.length) {
+          break;
+        }
+        const portText = source.slice(portStart, portEnd);
+        if (!/^\d+$/.test(portText)) {
+          break;
+        }
+        const port = Number.parseInt(portText, 10);
+        if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+          continue;
+        }
+        const next = solve(portEnd, host);
+        if (!next) {
+          continue;
+        }
+        const hostContinuityBonus = previousHost
+          ? (previousHost === host ? 8 : -4)
+          : 0;
+        const portLengthBonus = portLen * 2;
+        const tinyPortPenalty = port < 1000 ? -40 : 0;
+        const score = next.score + 100 + hostContinuityBonus + portLengthBonus + tinyPortPenalty;
+        if (!best || score > best.score) {
+          best = {
+            score,
+            tokens: [{
+              host,
+              port,
+              provider: normalizeIpProxyProviderValue(provider),
+            }, ...next.tokens],
+          };
+        }
+      }
+    }
+
+    memo.set(key, best);
+    return best;
+  };
+
+  const solved = solve(0, '');
+  if (!solved || !Array.isArray(solved.tokens) || solved.tokens.length <= 0) {
+    return [];
+  }
+  return solved.tokens.map((item) => ({
+    host: String(item.host || '').trim(),
+    port: normalizeIpProxyPort(item.port),
+    username: '',
+    password: '',
+    protocol: DEFAULT_IP_PROXY_PROTOCOL,
+    region: '',
+    provider: normalizeIpProxyProviderValue(item.provider || provider),
+  })).filter((item) => item.host && item.port);
+}
+
+function normalizeProxyPoolEntries(value = [], provider = DEFAULT_IP_PROXY_SERVICE) {
+  const result = [];
+  const seen = new Set();
+  const append = (entry) => {
+    if (!entry || !entry.host || !entry.port) {
+      return;
+    }
+    const normalizedEntry = {
+      host: String(entry.host || '').trim(),
+      port: normalizeIpProxyPort(entry.port),
+      username: String(entry.username || '').trim(),
+      password: String(entry.password || ''),
+      protocol: normalizeIpProxyProtocol(entry.protocol || ''),
+      region: String(entry.region || '').trim(),
+      provider: normalizeIpProxyProviderValue(entry.provider || provider),
+    };
+    if (!normalizedEntry.host || !normalizedEntry.port) {
+      return;
+    }
+    const dedupKey = `${normalizedEntry.host}:${normalizedEntry.port}:${normalizedEntry.username}:${normalizedEntry.password}:${normalizedEntry.protocol}`;
+    if (seen.has(dedupKey)) {
+      return;
+    }
+    seen.add(dedupKey);
+    result.push(normalizedEntry);
+  };
+
+  if (typeof value === 'string') {
+    const rawText = String(value || '');
+    normalizeIpProxyAccountList(rawText).split('\n').forEach((line) => {
+      append(parseIpProxyLine(line, provider));
+    });
+    if (!result.length) {
+      const contiguousEntries = parseContiguousProxyStream(rawText, provider);
+      contiguousEntries.forEach((entry) => append(entry));
+    }
+    if (!result.length) {
+      // Lumi API 在 lb 参数异常时，可能返回无分隔的 host:port 串，这里做兜底拆分。
+      const contiguousMatches = rawText.match(/\d{1,3}(?:\.\d{1,3}){3}:\d{2,5}/g) || [];
+      contiguousMatches.forEach((token) => {
+        append(parseIpProxyLine(token, provider));
+      });
+    }
+    return result;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => {
+      if (typeof item === 'string') {
+        append(parseIpProxyLine(item, provider));
+        return;
+      }
+      append(normalizeIpProxyEntriesFromObjectCandidate(item, provider));
+    });
+    return result;
+  }
+
+  if (value && typeof value === 'object') {
+    append(normalizeIpProxyEntriesFromObjectCandidate(value, provider));
+  }
+  return result;
+}
+
+function normalizeIpProxyListFromPayload(payload, provider = DEFAULT_IP_PROXY_SERVICE) {
+  if (Array.isArray(payload)) {
+    return normalizeProxyPoolEntries(payload, provider);
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    if (typeof payload === 'string') {
+      return normalizeProxyPoolEntries(payload, provider);
+    }
+    return [];
+  }
+
+  const candidateArrays = [
+    payload.data,
+    payload.list,
+    payload.items,
+    payload.proxies,
+    payload.result,
+    payload.rows,
+  ];
+  for (const candidate of candidateArrays) {
+    if (Array.isArray(candidate) && candidate.length > 0) {
+      return normalizeProxyPoolEntries(candidate, provider);
+    }
+  }
+
+  const singleCandidate = normalizeIpProxyEntriesFromObjectCandidate(payload, provider);
+  return singleCandidate ? [singleCandidate] : [];
+}
+
+function getAccountModeProxyPoolFromState(state = {}, provider = DEFAULT_IP_PROXY_SERVICE) {
+  const normalizedProvider = normalizeIpProxyProviderValue(provider || state?.ipProxyService || DEFAULT_IP_PROXY_SERVICE);
+  const accountListEnabled = isIpProxyAccountListEnabled();
+  const rawLines = normalizeIpProxyAccountList(state?.ipProxyAccountList || '').split('\n').filter(Boolean);
+  const lines = accountListEnabled ? rawLines : [];
+  const hasAccountList = lines.length > 0;
+  const transformState = hasAccountList
+    ? {
+      ...state,
+      ipProxyHost: '',
+      ipProxyPort: '',
+      ipProxyUsername: '',
+      ipProxyPassword: '',
+      ipProxyRegion: '',
+      ipProxyAccountSessionPrefix: '',
+      ipProxyAccountLifeMinutes: '',
+    }
+    : state;
+  let pool = lines.map((line) => parseIpProxyLine(line, normalizedProvider)).filter(Boolean);
+
+  if (!pool.length && !hasAccountList) {
+    const host = String(state?.ipProxyHost || '').trim();
+    const port = normalizeIpProxyPort(state?.ipProxyPort);
+    if (host && port) {
+      pool = [{
+        host,
+        port,
+        username: String(state?.ipProxyUsername || '').trim(),
+        password: String(state?.ipProxyPassword || ''),
+        protocol: normalizeIpProxyProtocol(state?.ipProxyProtocol),
+        region: '',
+        provider: normalizedProvider,
+      }];
+    } else if (!accountListEnabled && rawLines.length) {
+      const legacyEntry = parseIpProxyLine(rawLines[0], normalizedProvider);
+      if (legacyEntry) {
+        pool = [legacyEntry];
+      }
+    }
+  }
+
+  const configuredRegion = String(state?.ipProxyRegion || '').trim();
+  if (!pool.length) {
+    return [];
+  }
+
+  return pool.map((entry, index) => {
+    let nextEntry = { ...entry };
+    if (typeof transformIpProxyAccountEntryByProvider === 'function') {
+      const transformed = transformIpProxyAccountEntryByProvider(normalizedProvider, nextEntry, {
+        state: transformState,
+        index,
+        hasAccountList,
+      });
+      if (transformed && typeof transformed === 'object') {
+        nextEntry = transformed;
+      }
+    }
+    const inferredRegion = inferRegionFromProxyUsername(nextEntry.username);
+    if (inferredRegion) {
+      nextEntry.region = inferredRegion;
+    } else if (!String(nextEntry.region || '').trim()) {
+      const inferredHostRegion = inferRegionFromProxyHost(nextEntry.host);
+      if (inferredHostRegion) {
+        nextEntry.region = inferredHostRegion;
+      }
+    }
+    if (shouldApplyConfiguredRegionFallbackToEntry(nextEntry, {
+      provider: normalizedProvider,
+      configuredRegion,
+      hasAccountList,
+    })) {
+      nextEntry.region = configuredRegion;
+    }
+    return nextEntry;
+  });
+}
+
+function hasConfiguredAccountListEntries(state = {}) {
+  if (!isIpProxyAccountListEnabled()) {
+    return false;
+  }
+  const lines = normalizeIpProxyAccountList(state?.ipProxyAccountList || '').split('\n').filter(Boolean);
+  return lines.length > 0;
+}
+
+function getAccountListParseFailureHint(state = {}, provider = DEFAULT_IP_PROXY_SERVICE) {
+  if (!isIpProxyAccountListEnabled()) {
+    return '';
+  }
+  const normalizedProvider = normalizeIpProxyProviderValue(provider || state?.ipProxyService || DEFAULT_IP_PROXY_SERVICE);
+  const lines = normalizeIpProxyAccountList(state?.ipProxyAccountList || '').split('\n').filter(Boolean);
+  if (!lines.length) {
+    return '';
+  }
+  const parsedCount = lines
+    .map((line) => parseIpProxyLine(line, normalizedProvider))
+    .filter(Boolean)
+    .length;
+  if (parsedCount > 0) {
+    return '';
+  }
+  if (normalizedProvider === '711proxy') {
+    return '账号列表已填写，但未解析出有效条目。请按每行 host:port:username:password 填写。';
+  }
+  return '账号列表已填写，但未解析出有效条目。请检查列表格式。';
+}
+
+function resolveIpProxyPoolTargetCountForMode(state = {}, mode = normalizeIpProxyMode(state?.ipProxyMode)) {
+  const normalizedMode = normalizeIpProxyMode(mode);
+  // `ipProxyPoolTargetCount` 语义是“任务成功轮次阈值”，
+  // 拉取/切换代理池条数不再复用该字段，避免语义混淆。
+  if (normalizedMode === 'account') {
+    return 500;
+  }
+  return 100;
+}
+
+function resolveIpProxyAutoSwitchThreshold(state = {}) {
+  return Math.max(
+    1,
+    Math.min(500, Number(normalizeIpProxyPoolTargetCount(state?.ipProxyPoolTargetCount, 20)) || 20)
+  );
+}
+
+function buildProxyPoolSummary(pool = [], preferredIndex = 0) {
+  const normalizedPool = Array.isArray(pool) ? pool : [];
+  if (!normalizedPool.length) {
+    return {
+      count: 0,
+      index: 0,
+      current: null,
+      display: '暂无可用代理',
+    };
+  }
+  const index = normalizeIpProxyCurrentIndex(preferredIndex, 0) % normalizedPool.length;
+  const current = normalizedPool[index];
+  const region = String(current?.region || '').trim();
+  return {
+    count: normalizedPool.length,
+    index,
+    current,
+    display: `${current.host}:${current.port}${region ? ` [${region}]` : ''} (${index + 1}/${normalizedPool.length})`,
+  };
+}
+
+function getIpProxyRuntimeFieldNames(mode = DEFAULT_IP_PROXY_MODE) {
+  const normalizedMode = normalizeIpProxyMode(mode);
+  if (normalizedMode === 'account') {
+    return {
+      poolKey: 'ipProxyAccountPool',
+      indexKey: 'ipProxyAccountCurrentIndex',
+      currentKey: 'ipProxyAccountCurrent',
+    };
+  }
+  return {
+    poolKey: 'ipProxyApiPool',
+    indexKey: 'ipProxyApiCurrentIndex',
+    currentKey: 'ipProxyApiCurrent',
+  };
+}
+
+function getIpProxyRuntimeSnapshot(
+  state = {},
+  mode = normalizeIpProxyMode(state?.ipProxyMode),
+  provider = normalizeIpProxyProviderValue(state?.ipProxyService)
+) {
+  const normalizedMode = normalizeIpProxyMode(mode);
+  const normalizedProvider = normalizeIpProxyProviderValue(provider);
+  const fields = getIpProxyRuntimeFieldNames(normalizedMode);
+  const hasModePool = Array.isArray(state?.[fields.poolKey]);
+  const hasModeCurrent = state?.[fields.currentKey] !== undefined && state?.[fields.currentKey] !== null;
+  const hasModeIndex = state?.[fields.indexKey] !== undefined && state?.[fields.indexKey] !== null;
+  const modePool = normalizeProxyPoolEntries(state?.[fields.poolKey], normalizedProvider);
+  const modeCurrent = normalizeProxyPoolEntries(
+    state?.[fields.currentKey] ? [state[fields.currentKey]] : [],
+    normalizedProvider
+  )[0] || null;
+  const pool = hasModePool ? modePool : [];
+  const current = hasModeCurrent ? modeCurrent : null;
+  const indexSource = hasModeIndex ? state?.[fields.indexKey] : 0;
+  return {
+    mode: normalizedMode,
+    provider: normalizedProvider,
+    ...fields,
+    hasModePool,
+    hasModeCurrent,
+    hasModeIndex,
+    pool,
+    current,
+    index: normalizeIpProxyCurrentIndex(indexSource, 0),
+  };
+}
+
+function isApiModeProxyConfigAvailable(state = {}) {
+  return Boolean(String(state?.ipProxyApiUrl || '').trim());
+}
+
+function buildIpProxyRuntimeStatePatch(mode = DEFAULT_IP_PROXY_MODE, runtime = {}, provider = DEFAULT_IP_PROXY_SERVICE) {
+  const normalizedMode = normalizeIpProxyMode(mode);
+  const normalizedProvider = normalizeIpProxyProviderValue(provider);
+  const fields = getIpProxyRuntimeFieldNames(normalizedMode);
+  const pool = normalizeProxyPoolEntries(runtime?.pool, normalizedProvider);
+  const summary = buildProxyPoolSummary(pool, runtime?.index);
+  const explicitCurrent = normalizeProxyPoolEntries(
+    runtime?.current ? [runtime.current] : [],
+    normalizedProvider
+  )[0] || null;
+  const current = explicitCurrent || summary.current || null;
+  return {
+    [fields.poolKey]: pool,
+    [fields.indexKey]: summary.index,
+    [fields.currentKey]: current,
+    // 兼容旧状态字段，保持当前激活模式的摘要可见。
+    ipProxyPool: pool,
+    ipProxyCurrentIndex: summary.index,
+    ipProxyCurrent: current,
+  };
+}
+
+function getIpProxyCurrentEntryFromState(state = {}) {
+  const mode = normalizeIpProxyMode(state?.ipProxyMode);
+  const provider = normalizeIpProxyProviderValue(state?.ipProxyService);
+  if (mode === 'api' && !isApiModeProxyConfigAvailable(state)) {
+    return null;
+  }
+  const runtime = getIpProxyRuntimeSnapshot(state, mode, provider);
+  if (mode === 'account') {
+    const hasAccountList = hasConfiguredAccountListEntries(state);
+    const accountPool = getAccountModeProxyPoolFromState(state, provider);
+    if (hasAccountList) {
+      if (!accountPool.length) {
+        return null;
+      }
+      const index = normalizeIpProxyCurrentIndex(runtime.index, 0) % accountPool.length;
+      return accountPool[index];
+    }
+    if (accountPool.length) {
+      const index = normalizeIpProxyCurrentIndex(runtime.index, 0) % accountPool.length;
+      return accountPool[index];
+    }
+    const host = String(state?.ipProxyHost || '').trim();
+    const port = normalizeIpProxyPort(state?.ipProxyPort);
+    if (!host || !port) return null;
+    const entry = {
+      host,
+      port,
+      username: String(state?.ipProxyUsername || '').trim(),
+      password: String(state?.ipProxyPassword || ''),
+      protocol: normalizeIpProxyProtocol(state?.ipProxyProtocol),
+      region: '',
+      provider,
+    };
+    const inferredRegionFromUsername = inferRegionFromProxyUsername(entry.username);
+    if (inferredRegionFromUsername) {
+      entry.region = inferredRegionFromUsername;
+    } else {
+      const inferredRegionFromHost = inferRegionFromProxyHost(entry.host);
+      if (inferredRegionFromHost) {
+        entry.region = inferredRegionFromHost;
+      }
+    }
+    const configuredRegion = String(state?.ipProxyRegion || '').trim();
+    if (shouldApplyConfiguredRegionFallbackToEntry(entry, {
+      provider,
+      configuredRegion,
+      hasAccountList: false,
+    })) {
+      entry.region = configuredRegion;
+    }
+    return entry;
+  }
+
+  const pool = runtime.pool;
+  if (pool.length) {
+    const index = normalizeIpProxyCurrentIndex(runtime.index, 0) % pool.length;
+    return pool[index];
+  }
+  const fallback = normalizeProxyPoolEntries(runtime.current ? [runtime.current] : [], provider)[0];
+  return fallback || null;
+}
+
+function buildIpProxyRoutingStatePatch(status = {}) {
+  const provider = normalizeIpProxyProviderValue(status?.provider || DEFAULT_IP_PROXY_SERVICE);
+  const host = String(status?.host || '').trim();
+  const port = normalizeIpProxyPort(status?.port);
+  const region = String(status?.region || '').trim();
+  const hasAuth = Boolean(status?.hasAuth);
+  const applied = Boolean(status?.applied);
+  const reason = String(status?.reason || (applied ? 'applied' : 'disabled')).trim().toLowerCase();
+  const error = String(status?.error || '').trim();
+  const warning = String(status?.warning || '').trim();
+  const exitIp = String(status?.exitIp || '').trim();
+  const exitRegion = String(status?.exitRegion || '').trim();
+  const exitDetecting = Boolean(status?.exitDetecting);
+  const exitError = String(status?.exitError || '').trim();
+  const exitSource = String(status?.exitSource || '').trim().toLowerCase();
+  return {
+    ipProxyApplied: applied,
+    ipProxyAppliedReason: reason,
+    ipProxyAppliedAt: Date.now(),
+    ipProxyAppliedHost: host,
+    ipProxyAppliedPort: port,
+    ipProxyAppliedRegion: region,
+    ipProxyAppliedHasAuth: hasAuth,
+    ipProxyAppliedProvider: provider,
+    ipProxyAppliedError: error,
+    ipProxyAppliedWarning: warning,
+    ipProxyAppliedExitIp: exitIp,
+    ipProxyAppliedExitRegion: exitRegion,
+    ipProxyAppliedExitDetecting: exitDetecting,
+    ipProxyAppliedExitError: exitError,
+    ipProxyAppliedExitSource: exitSource,
+  };
+}
+
+async function setIpProxyLeakGuardEnabled(enabled) {
+  if (!chrome.declarativeNetRequest?.updateDynamicRules) {
+    return;
+  }
+  const removeRuleIds = [IP_PROXY_GUARD_BLOCK_RULE_ID];
+  const addRules = enabled ? [{
+    id: IP_PROXY_GUARD_BLOCK_RULE_ID,
+    priority: 100,
+    action: {
+      type: 'block',
+    },
+    condition: {
+      regexFilter: IP_PROXY_GUARD_REGEX,
+      resourceTypes: [
+        'main_frame',
+        'sub_frame',
+        'xmlhttprequest',
+        'websocket',
+        'other',
+      ],
+    },
+  }] : [];
+  await chrome.declarativeNetRequest.updateDynamicRules({
+    removeRuleIds,
+    addRules,
+  }).catch(() => { });
+}
+
+async function fetchWithTimeout(url, options = {}, timeoutMs = IP_PROXY_FETCH_TIMEOUT_MS) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), Math.max(1000, Number(timeoutMs) || IP_PROXY_FETCH_TIMEOUT_MS));
+  try {
+    return await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function extractIpv4FromText(value = '') {
+  const text = String(value || '').trim();
+  if (!text) {
+    return '';
+  }
+  const ipv4Match = text.match(/\b(\d{1,3}(?:\.\d{1,3}){3})\b/);
+  if (ipv4Match) {
+    return ipv4Match[1];
+  }
+  const ipv6Match = text.match(/\b([0-9a-f]{0,4}(?::[0-9a-f]{0,4}){2,7})\b/i);
+  return ipv6Match ? String(ipv6Match[1] || '').trim() : '';
+}
+
+function normalizeProbeRegionCode(value = '') {
+  const code = String(value || '')
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z]/g, '');
+  return /^[A-Z]{2}$/.test(code) ? code : '';
+}
+
+function pickProbeRegion(parsed = {}) {
+  const countryCodeCandidates = [
+    parsed?.countryCode,
+    parsed?.country_code,
+    parsed?.countrycode,
+    parsed?.countryAlpha2,
+    parsed?.country_alpha2,
+    parsed?.countryISO,
+    parsed?.countryIso,
+    parsed?.iso_country,
+    parsed?.geo?.countryCode,
+    parsed?.geo?.country_code,
+    parsed?.location?.countryCode,
+    parsed?.location?.country_code,
+  ];
+  for (const candidate of countryCodeCandidates) {
+    const code = normalizeProbeRegionCode(candidate);
+    if (code) {
+      return code;
+    }
+  }
+
+  const fallbackCandidates = [
+    parsed?.regionCode,
+    parsed?.region_code,
+    parsed?.country,
+    parsed?.country_name,
+    parsed?.countryName,
+    parsed?.regionName,
+    parsed?.region,
+    parsed?.city,
+  ];
+  for (const candidate of fallbackCandidates) {
+    const text = String(candidate || '').trim();
+    if (text) {
+      return text;
+    }
+  }
+  return '';
+}
+
+function parseProxyExitProbePayload(rawText = '', contentType = '') {
+  const text = String(rawText || '').trim();
+  if (!text) {
+    return { ip: '', region: '' };
+  }
+  if (/^[-_a-zA-Z0-9]+=/m.test(text)) {
+    const kv = {};
+    text.split(/\r?\n+/).forEach((line) => {
+      const index = line.indexOf('=');
+      if (index <= 0) return;
+      const key = String(line.slice(0, index) || '').trim().toLowerCase();
+      if (!key) return;
+      kv[key] = String(line.slice(index + 1) || '').trim();
+    });
+    const kvIp = extractIpv4FromText(
+      kv.ip
+      || kv.query
+      || kv.clientip
+      || kv.client_ip
+      || ''
+    );
+    const kvRegion = normalizeProbeRegionCode(kv.loc || kv.country_code || kv.countrycode || '');
+    if (kvIp) {
+      return {
+        ip: kvIp,
+        region: kvRegion,
+      };
+    }
+  }
+  const normalizedContentType = String(contentType || '').toLowerCase();
+  if (normalizedContentType.includes('application/json') || text.startsWith('{') || text.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(text);
+      const ip = extractIpv4FromText(
+        parsed?.ip
+        || parsed?.query
+        || parsed?.origin
+        || parsed?.address
+        || parsed?.ipAddress
+        || parsed?.ip_address
+        || ''
+      );
+      const region = pickProbeRegion(parsed);
+      if (ip) {
+        return { ip, region };
+      }
+    } catch {
+      // fall through to regex parse
+    }
+  }
+
+  const ip = extractIpv4FromText(text);
+  if (!ip) {
+    return { ip: '', region: '' };
+  }
+  return {
+    ip,
+    region: '',
+  };
+}
+
+function normalizeRegionToken(value = '') {
+  return String(value || '')
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, '');
+}
+
+function hasProxyExitRegionMismatch(expectedRegion = '', detectedRegion = '') {
+  const expected = normalizeRegionToken(expectedRegion);
+  const detected = normalizeRegionToken(detectedRegion);
+  if (!expected || !detected) {
+    return false;
+  }
+  if (expected === detected) {
+    return false;
+  }
+  if (expected.length >= 2 && detected.includes(expected)) {
+    return false;
+  }
+  if (detected.length >= 2 && expected.includes(detected)) {
+    return false;
+  }
+  return true;
+}
+
+function has711SessionToken(username = '') {
+  const text = String(username || '').trim();
+  if (!text) {
+    return false;
+  }
+  return /(?:^|[-_])session[-_:][A-Za-z0-9_-]+\b/i.test(text);
+}
+
+function resolveExitProbeEndpoints(options = {}) {
+  const provider = normalizeIpProxyProviderValue(options?.provider || '');
+  const username = String(options?.username || '').trim();
+  if (provider === '711proxy' && has711SessionToken(username)) {
+    return IP_PROXY_EXIT_PROBE_ENDPOINTS_711_STICKY.slice();
+  }
+  return IP_PROXY_EXIT_PROBE_ENDPOINTS.slice();
+}
+
+function applyExitRegionExpectation(status = {}, expectedRegion = '') {
+  const exitIp = String(status?.exitIp || '').trim();
+  const exitError = String(status?.exitError || '').trim();
+  if (!exitIp) {
+    const hasBackgroundAbortStorm = /probe:bg:/.test(exitError)
+      && /signal is aborted without reason/i.test(exitError);
+    const hasBackgroundAbortFallback = /probe:bg:abort_storm_page_fallback/i.test(exitError);
+    const hasProxyRuntimeError = /probe:proxy_error\(/i.test(exitError);
+    const hasAuth = Boolean(status?.hasAuth);
+    const challengeMatch = exitError.match(/challenge=(\d+)/i);
+    const providedMatch = exitError.match(/provided=(\d+)/i);
+    const challengeCount = Number.parseInt(String(challengeMatch?.[1] || ''), 10) || 0;
+    const providedCount = Number.parseInt(String(providedMatch?.[1] || ''), 10) || 0;
+    const missingProxyChallenge = hasAuth && challengeCount <= 0 && providedCount <= 0;
+    const hasErrorPageFailure = /Frame with ID 0 is showing error page|Cannot access contents of the page/i.test(exitError);
+    const netErrorCode = exitError.match(/net::ERR_[A-Z_]+/i)?.[0] || '';
+    const navigationHint = netErrorCode
+      ? `导航错误：${netErrorCode}。`
+      : '';
+    const tunnelFailedWithoutChallenge = missingProxyChallenge
+      && /ERR_TUNNEL_CONNECTION_FAILED/i.test(netErrorCode || exitError);
+    const humanizedError = hasErrorPageFailure
+      ? (
+          hasAuth
+            ? '探测页已进入浏览器错误页（常见于代理鉴权失败、代理节点不可用或网络被拦截）。请先检查代理账号/密码与节点可用性，再重试检测。'
+            : '探测页已进入浏览器错误页（常见于代理节点不可用、代理协议不匹配或网络被拦截）。请先检查代理节点、端口与协议配置，再重试检测。'
+        )
+      : '';
+    const authDiagnostics = exitError.match(/probe:auth\([^)]+\)/i)?.[0] || '';
+    const challengeHint = missingProxyChallenge
+      ? '当前链路未收到 407 代理鉴权挑战（可能是代理端返回非标准拒绝，例如 630 no Proxy-Authorization），浏览器无法触发扩展鉴权回填。建议切换 API 模式，或更换会返回标准 407 的账号节点。'
+      : '';
+    const compatibilityHint = tunnelFailedWithoutChallenge
+      ? '当前账号模式节点可能采用非标准代理鉴权链路（未发起 407 挑战），该链路在 Chrome 扩展代理 API 下无法自动回填凭据。'
+      : '';
+    const mergedErrorParts = [
+      hasBackgroundAbortStorm
+        ? (
+            hasBackgroundAbortFallback
+              ? '后台探测请求连续超时中断（代理隧道未在时限内建立），且已自动回退页面探测但仍未拿到可用出口。'
+              : '后台探测请求连续超时中断（代理隧道未在时限内建立）。这通常是代理节点链路不可用或被上游丢弃，并非探测页面本身异常。'
+          )
+        : '',
+      hasProxyRuntimeError
+        ? '已捕获浏览器代理栈错误事件（chrome.proxy.onProxyError），请优先依据诊断中的 proxy_error 字段排查节点/协议兼容性。'
+        : '',
+      humanizedError,
+      navigationHint,
+      compatibilityHint,
+      challengeHint,
+    ].filter(Boolean);
+    const mergedError = mergedErrorParts.length
+      ? `${mergedErrorParts.join(' ')}${authDiagnostics ? ` 诊断：${authDiagnostics}` : ''}`
+      : '';
+    const mergedWithDiagnostics = mergedError
+      ? (
+          exitError
+          && !mergedError.includes(exitError)
+            ? `${mergedError} 诊断：${exitError}`
+            : mergedError
+        )
+      : '';
+    return {
+      ...status,
+      applied: false,
+      reason: 'connectivity_failed',
+      error: mergedWithDiagnostics || exitError || '未检测到代理出口 IP，无法确认代理已生效。',
+    };
+  }
+
+  const expected = String(expectedRegion || '').trim();
+  const entrySource = String(status?.entrySource || '').trim();
+  const normalizedProvider = normalizeIpProxyProviderValue(status?.provider || DEFAULT_IP_PROXY_SERVICE);
+  const authSummary = String(status?.authDiagnostics || '').trim();
+  const parsedAuthSummary = parseIpProxyAuthDiagnosticsSummary(authSummary);
+  const missingAuthChallenge = Boolean(status?.hasAuth)
+    && parsedAuthSummary
+    && parsedAuthSummary.challenge <= 0
+    && parsedAuthSummary.provided <= 0;
+  if (!expected) {
+    return status;
+  }
+
+  const detected = String(status?.exitRegion || '').trim();
+  if (!detected) {
+    return {
+      ...status,
+      applied: false,
+      reason: 'connectivity_failed',
+      error: `已检测到出口 IP ${exitIp}，但地区探测未返回国家/地区代码，暂无法校验期望地区 ${expected}。`,
+    };
+  }
+
+  if (!hasProxyExitRegionMismatch(expected, detected)) {
+    return status;
+  }
+  const sourceHint = entrySource === 'account_list'
+    ? '（来源：账号列表）'
+    : (entrySource === 'fixed_account' ? '（来源：固定账号）' : '');
+  const usernameRegion = inferRegionFromProxyUsername(status?.username || '');
+  const usernameHint = usernameRegion
+    ? (
+      hasProxyExitRegionMismatch(expected, usernameRegion)
+        ? ` 当前账号用户名地区标记为 ${usernameRegion}，与期望不一致。`
+        : ` 当前账号用户名地区标记为 ${usernameRegion}。`
+    )
+    : '';
+  const missingAuthChallengeHint = Boolean(status?.hasAuth)
+    && parsedAuthSummary
+    && parsedAuthSummary.challenge <= 0
+    && parsedAuthSummary.provided <= 0
+    ? ' 当前链路未触发代理鉴权挑战（407），可能复用了历史代理连接/鉴权缓存，或代理端未返回标准 407 导致账号参数未被浏览器回填（可能走匿名链路）。可先关闭再开启代理，或切换到下一条节点后重试。'
+    : '';
+  const authHint = authSummary ? ` 诊断：probe:${authSummary}` : '';
+  const mismatchMessage = `代理出口地区与预期不一致：期望 ${expected}，实际 ${detected || 'unknown'}${sourceHint}。${usernameHint}${missingAuthChallengeHint}${authHint}`.trim();
+  if (normalizedProvider === '711proxy') {
+    if (missingAuthChallenge) {
+      return {
+        ...status,
+        applied: false,
+        reason: 'connectivity_failed',
+        error: mismatchMessage,
+        warning: '',
+      };
+    }
+    return {
+      ...status,
+      applied: true,
+      reason: 'applied_with_warning',
+      warning: `地区校验未通过，但已保留代理接管：${mismatchMessage}`,
+      error: '',
+    };
+  }
+  return {
+    ...status,
+    applied: false,
+    reason: 'connectivity_failed',
+    error: mismatchMessage,
+  };
+}
+
+function applyExitBaselineExpectation(status = {}) {
+  const exitIp = String(status?.exitIp || '').trim();
+  const baselineIp = String(status?.exitBaselineIp || '').trim();
+  const exitSource = String(status?.exitSource || '').trim().toLowerCase();
+  if (exitIp && exitSource.includes('background') && !baselineIp) {
+    return {
+      ...status,
+      applied: false,
+      reason: 'connectivity_failed',
+      error: `已检测到出口 IP ${exitIp}，但系统基线网络探测失败，无法确认是否经过插件代理链路。`,
+    };
+  }
+  if (!exitIp || !baselineIp) {
+    return status;
+  }
+  if (exitIp !== baselineIp) {
+    return status;
+  }
+  return {
+    ...status,
+    applied: false,
+    reason: 'connectivity_failed',
+    error: `检测到出口 IP ${exitIp} 与系统基线网络一致，疑似未经过插件代理链路。`,
+  };
+}
+
+async function detectProxyExitInfoByBackgroundFetch(options = {}) {
+  const timeoutMs = Number(options?.timeoutMs) > 0 ? Number(options.timeoutMs) : 10000;
+  const errors = Array.isArray(options?.errors) ? options.errors : [];
+  const configuredEndpoints = Array.isArray(options?.probeEndpoints)
+    ? options.probeEndpoints.map((item) => String(item || '').trim()).filter(Boolean)
+    : [];
+  const availableEndpoints = configuredEndpoints.length
+    ? configuredEndpoints
+    : IP_PROXY_EXIT_PROBE_ENDPOINTS;
+  const requestedPerEndpointTimeoutMs = Number(options?.backgroundPerEndpointTimeoutMs);
+  const perRequestTimeoutMs = Math.max(
+    1200,
+    Math.min(
+      Number.isFinite(requestedPerEndpointTimeoutMs) && requestedPerEndpointTimeoutMs > 0
+        ? requestedPerEndpointTimeoutMs
+        : IP_PROXY_BACKGROUND_PROBE_PER_ENDPOINT_TIMEOUT_MS,
+      timeoutMs
+    )
+  );
+  const maxEndpoints = Math.max(
+    1,
+    Math.min(
+      availableEndpoints.length,
+      Number.isFinite(Number(options?.backgroundMaxEndpoints))
+        ? Number(options.backgroundMaxEndpoints)
+        : IP_PROXY_BACKGROUND_PROBE_MAX_ENDPOINTS
+    )
+  );
+  const probeEndpoints = availableEndpoints.slice(0, maxEndpoints);
+  let baselineIp = '';
+  try {
+    const baselineUrl = `${IP_PROXY_PAGE_CONTEXT_BASELINE_URL}?_multipage_proxy_baseline=${Date.now()}`;
+    const baselineResponse = await fetchWithTimeout(baselineUrl, {
+      method: 'GET',
+      cache: 'no-store',
+      headers: { Accept: 'application/json, text/plain, */*' },
+    }, perRequestTimeoutMs);
+    if (!baselineResponse.ok) {
+      errors.push(`probe:bg:baseline:status:${baselineResponse.status}`);
+    } else {
+      const baselineText = await baselineResponse.text();
+      const parsedBaseline = parseProxyExitProbePayload(
+        baselineText,
+        baselineResponse.headers.get('content-type')
+      );
+      baselineIp = String(parsedBaseline?.ip || '').trim();
+      if (!baselineIp) {
+        errors.push('probe:bg:baseline:empty_parse');
+      }
+    }
+  } catch (baselineError) {
+    errors.push(`probe:bg:baseline:${baselineError?.message || baselineError}`);
+  }
+  const runProbePass = async (endpoints, requestTimeoutMs, diagnosticPrefix = 'probe:bg') => {
+    let bestEffortResult = null;
+    let abortLikeCount = 0;
+    for (const endpoint of endpoints) {
+      try {
+        const url = endpoint.includes('?') ? `${endpoint}&_t=${Date.now()}` : `${endpoint}?_t=${Date.now()}`;
+        const response = await fetchWithTimeout(url, {
+          method: 'GET',
+          cache: 'no-store',
+          headers: { Accept: 'application/json, text/plain, */*' },
+        }, requestTimeoutMs);
+        if (!response.ok) {
+          errors.push(`${diagnosticPrefix}:${endpoint}:status:${response.status}`);
+          continue;
+        }
+        const text = await response.text();
+        const parsed = parseProxyExitProbePayload(text, response.headers.get('content-type'));
+        if (parsed.ip) {
+          const result = {
+            ip: parsed.ip,
+            region: parsed.region,
+            source: 'background_fallback',
+            endpoint,
+            baselineIp,
+          };
+          if (parsed.region) {
+            return {
+              result,
+              bestEffortResult: result,
+              abortLikeCount,
+            };
+          }
+          if (!bestEffortResult) {
+            bestEffortResult = result;
+          }
+          errors.push(`${diagnosticPrefix}:${endpoint}:missing_region`);
+          continue;
+        }
+        errors.push(`${diagnosticPrefix}:${endpoint}:empty_parse`);
+      } catch (error) {
+        const message = String(error?.message || error || '').trim();
+        if (/signal is aborted without reason|abort/i.test(message)) {
+          abortLikeCount += 1;
+        }
+        errors.push(`${diagnosticPrefix}:${endpoint}:${message}`);
+      }
+    }
+    return {
+      result: bestEffortResult,
+      bestEffortResult,
+      abortLikeCount,
+    };
+  };
+
+  const firstPass = await runProbePass(probeEndpoints, perRequestTimeoutMs, 'probe:bg');
+  if (firstPass?.result?.ip && firstPass?.result?.region) {
+    return firstPass.result;
+  }
+
+  if (!firstPass?.result?.ip
+    && firstPass?.abortLikeCount >= Math.min(2, probeEndpoints.length)
+    && options?.backgroundSlowRetry !== false) {
+    const retryTimeoutMs = Math.max(perRequestTimeoutMs + 2500, 7000);
+    const retryEndpoints = probeEndpoints.slice(0, Math.min(2, probeEndpoints.length));
+    errors.push(`probe:bg:slow_retry:${retryTimeoutMs}ms`);
+    const retryPass = await runProbePass(retryEndpoints, retryTimeoutMs, 'probe:bg:retry');
+    if (retryPass?.result?.ip) {
+      return retryPass.result;
+    }
+  }
+
+  if (!firstPass?.bestEffortResult?.ip) {
+    appendIpProxyRuntimeErrorDiagnosticsToErrors(errors, 45000);
+  }
+
+  return firstPass?.bestEffortResult || { ip: '', region: '', source: 'background_fallback', baselineIp };
+}
+
+function isPageContextProbeHost(hostname = '') {
+  const normalized = String(hostname || '').trim().toLowerCase();
+  return normalized === 'chatgpt.com'
+    || normalized.endsWith('.chatgpt.com')
+    || normalized === 'openai.com'
+    || normalized.endsWith('.openai.com')
+    || normalized === 'example.com'
+    || normalized.endsWith('.example.com')
+    || normalized === 'ip-api.com'
+    || normalized.endsWith('.ip-api.com')
+    || normalized === 'httpbin.org'
+    || normalized === 'ipwho.is'
+    || normalized.endsWith('.ipwho.is')
+    || normalized === 'ipinfo.io'
+    || normalized.endsWith('.ipinfo.io')
+    || normalized === 'ipapi.co'
+    || normalized.endsWith('.ipapi.co');
+}
+
+function isProbeErrorPageExecutionError(error) {
+  const message = String(error?.message || error || '');
+  return /Frame with ID 0 is showing error page|Cannot access contents of the page/i.test(message);
+}
+
+function hasProbeErrorPageDiagnostics(errors = []) {
+  if (!Array.isArray(errors) || !errors.length) {
+    return false;
+  }
+  return errors.some((item) => isProbeErrorPageExecutionError(String(item || '')));
+}
+
+function createProbeNavigationErrorTracker(initialTabId = null) {
+  if (!chrome.webNavigation?.onErrorOccurred?.addListener) {
+    return {
+      setTabId: () => {},
+      appendDiagnostics: () => {},
+      dispose: () => {},
+    };
+  }
+
+  let activeTabId = Number.isInteger(initialTabId) ? Number(initialTabId) : null;
+  const entries = [];
+  const listener = (details = {}) => {
+    if (!Number.isInteger(activeTabId) || Number(details?.tabId) !== activeTabId) {
+      return;
+    }
+    if (Number(details?.frameId) !== 0) {
+      return;
+    }
+    const errorCode = String(details?.error || '').trim();
+    if (!errorCode) {
+      return;
+    }
+    const url = String(details?.url || '').trim();
+    entries.push({
+      error: errorCode,
+      host: extractProbeHostFromTabUrl(url),
+      url,
+    });
+  };
+
+  try {
+    chrome.webNavigation.onErrorOccurred.addListener(listener);
+  } catch {
+    return {
+      setTabId: () => {},
+      appendDiagnostics: () => {},
+      dispose: () => {},
+    };
+  }
+
+  return {
+    setTabId(nextTabId) {
+      activeTabId = Number.isInteger(nextTabId) ? Number(nextTabId) : null;
+    },
+    appendDiagnostics(errors, maxItems = 2) {
+      if (!Array.isArray(errors) || !entries.length) {
+        return;
+      }
+      const limit = Math.max(1, Number(maxItems) || 2);
+      const recent = entries.slice(-limit);
+      for (const item of recent) {
+        const errorCode = String(item?.error || '').trim();
+        if (!errorCode) {
+          continue;
+        }
+        const host = String(item?.host || '').trim() || 'unknown';
+        errors.push(`probe:page_context:navigation_error:${errorCode}@${host}`);
+      }
+    },
+    dispose() {
+      try {
+        chrome.webNavigation.onErrorOccurred.removeListener(listener);
+      } catch {
+        // ignore remove listener failures
+      }
+    },
+  };
+}
+
+function extractProbeHostFromTabUrl(rawUrl = '') {
+  try {
+    const parsed = new URL(rawUrl);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      return '';
+    }
+    return parsed.hostname || '';
+  } catch {
+    return '';
+  }
+}
+
+async function pickExistingPageContextProbeTabId() {
+  const tabs = await chrome.tabs.query({});
+  const candidates = tabs
+    .filter((tab) => Number.isInteger(tab?.id))
+    .filter((tab) => isPageContextProbeHost(extractProbeHostFromTabUrl(tab?.url || '')));
+  if (!candidates.length) {
+    return null;
+  }
+  const preferred = candidates.find((tab) => String(tab?.status || '').toLowerCase() === 'complete');
+  return Number((preferred || candidates[0]).id) || null;
+}
+
+async function waitForPageContextProbeTabReady(tabId, timeoutMs = 15000) {
+  const timeout = Math.max(1500, Number(timeoutMs) || 15000);
+
+  if (typeof waitForTabComplete === 'function') {
+    const result = await waitForTabComplete(tabId, {
+      timeoutMs: timeout,
+      retryDelayMs: 300,
+    });
+    return Boolean(result?.id);
+  }
+
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    try {
+      const tab = await chrome.tabs.get(tabId);
+      if (String(tab?.status || '').toLowerCase() === 'complete') {
+        return true;
+      }
+    } catch {
+      return false;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  return false;
+}
+
+async function readExitProbeFromTabDocument(tabId) {
+  const executionResults = await chrome.scripting.executeScript({
+    target: { tabId },
+    world: 'ISOLATED',
+    func: () => {
+      const preText = String(document.querySelector('pre')?.textContent || '').trim();
+      const bodyText = String(document.body?.innerText || document.documentElement?.innerText || '').trim();
+      return {
+        url: String(location.href || ''),
+        text: preText || bodyText,
+      };
+    },
+  });
+  return executionResults?.[0]?.result || null;
+}
+
+async function probeExitInfoByTabNavigation(tabId, timeoutMs = 10000, errors = []) {
+  return probeExitInfoByTabNavigationWithEndpoints(tabId, timeoutMs, errors, []);
+}
+
+async function probeExitInfoByTabNavigationWithEndpoints(tabId, timeoutMs = 10000, errors = [], endpointsOverride = []) {
+  if (!Number.isInteger(tabId)) {
+    return null;
+  }
+  const configuredEndpoints = Array.isArray(endpointsOverride)
+    ? endpointsOverride.map((item) => String(item || '').trim()).filter(Boolean)
+    : [];
+  const availableEndpoints = configuredEndpoints.length
+    ? configuredEndpoints
+    : IP_PROXY_EXIT_PROBE_ENDPOINTS;
+  const endpoints = availableEndpoints.slice(0, 6);
+  const perEndpointTimeoutMs = Math.max(
+    2000,
+    Math.min(IP_PROXY_PAGE_CONTEXT_READY_TIMEOUT_MS, Number(timeoutMs) || 10000)
+  );
+  let bestEffortResult = null;
+
+  for (const endpoint of endpoints) {
+    const endpointText = String(endpoint || '').trim();
+    if (!endpointText) {
+      continue;
+    }
+    const probeTargetUrl = endpointText.includes('?')
+      ? `${endpointText}&_multipage_proxy_probe=${Date.now()}`
+      : `${endpointText}?_multipage_proxy_probe=${Date.now()}`;
+    try {
+      await chrome.tabs.update(tabId, {
+        url: probeTargetUrl,
+        active: false,
+      });
+      const ready = await waitForPageContextProbeTabReady(tabId, perEndpointTimeoutMs);
+      if (!ready) {
+        if (Array.isArray(errors)) {
+          errors.push(`probe:page_context:navigation:${endpointText}:not_ready`);
+        }
+        continue;
+      }
+      const documentResult = await readExitProbeFromTabDocument(tabId);
+      const parsed = parseProxyExitProbePayload(String(documentResult?.text || ''), 'application/json');
+      if (parsed?.ip) {
+        const result = {
+          ip: String(parsed.ip || '').trim(),
+          region: String(parsed.region || '').trim(),
+          endpoint: String(documentResult?.url || probeTargetUrl || endpointText).trim(),
+          source: 'page_context_navigation',
+        };
+        if (result.region) {
+          return result;
+        }
+        if (!bestEffortResult) {
+          bestEffortResult = result;
+        }
+        if (Array.isArray(errors)) {
+          errors.push(`probe:page_context:navigation:${endpointText}:missing_region`);
+        }
+        continue;
+      }
+      if (Array.isArray(errors)) {
+        errors.push(`probe:page_context:navigation:${endpointText}:empty_parse`);
+      }
+    } catch (error) {
+      if (Array.isArray(errors)) {
+        errors.push(`probe:page_context:navigation:${endpointText}:${error?.message || error}`);
+      }
+    }
+  }
+
+  return bestEffortResult;
+}
+
+async function probeExitInfoViaExecuteScript(tabId, timeoutMs = 10000, endpointsOverride = []) {
+  const perRequestTimeoutMs = Math.max(
+    1200,
+    Math.min(IP_PROXY_BACKGROUND_PROBE_PER_ENDPOINT_TIMEOUT_MS, Number(timeoutMs) || 10000)
+  );
+  const configuredEndpoints = Array.isArray(endpointsOverride)
+    ? endpointsOverride.map((item) => String(item || '').trim()).filter(Boolean)
+    : [];
+  const availableEndpoints = configuredEndpoints.length
+    ? configuredEndpoints
+    : IP_PROXY_EXIT_PROBE_ENDPOINTS;
+  const endpoints = availableEndpoints.slice(0, IP_PROXY_BACKGROUND_PROBE_MAX_ENDPOINTS);
+  const executionResults = await chrome.scripting.executeScript({
+    target: { tabId },
+    world: 'ISOLATED',
+    func: async (payload) => {
+      const extractIpv4 = (value) => {
+        const text = String(value || '').trim();
+        if (!text) return '';
+        const match = text.match(/\b(\d{1,3}(?:\.\d{1,3}){3})\b/);
+        return match ? match[1] : '';
+      };
+      const normalizeRegionCode = (value) => {
+        const code = String(value || '')
+          .trim()
+          .toUpperCase()
+          .replace(/[^A-Z]/g, '');
+        return /^[A-Z]{2}$/.test(code) ? code : '';
+      };
+      const pickRegion = (parsed) => {
+        const codeCandidates = [
+          parsed?.countryCode,
+          parsed?.country_code,
+          parsed?.countrycode,
+          parsed?.countryAlpha2,
+          parsed?.country_alpha2,
+          parsed?.countryISO,
+          parsed?.countryIso,
+          parsed?.iso_country,
+          parsed?.geo?.countryCode,
+          parsed?.geo?.country_code,
+          parsed?.location?.countryCode,
+          parsed?.location?.country_code,
+        ];
+        for (const candidate of codeCandidates) {
+          const code = normalizeRegionCode(candidate);
+          if (code) return code;
+        }
+        const fallbackCandidates = [
+          parsed?.regionCode,
+          parsed?.region_code,
+          parsed?.country,
+          parsed?.country_name,
+          parsed?.countryName,
+          parsed?.regionName,
+          parsed?.region,
+          parsed?.city,
+        ];
+        for (const candidate of fallbackCandidates) {
+          const text = String(candidate || '').trim();
+          if (text) return text;
+        }
+        return '';
+      };
+      const parsePayload = (rawText, contentType) => {
+        const text = String(rawText || '').trim();
+        if (!text) {
+          return { ip: '', region: '' };
+        }
+
+        const normalizedContentType = String(contentType || '').toLowerCase();
+        if (normalizedContentType.includes('application/json') || text.startsWith('{') || text.startsWith('[')) {
+          try {
+            const parsed = JSON.parse(text);
+            const ip = extractIpv4(
+              parsed?.ip
+              || parsed?.query
+              || parsed?.origin
+              || parsed?.address
+              || parsed?.ipAddress
+              || parsed?.ip_address
+              || ''
+            );
+            const region = pickRegion(parsed);
+            if (ip) {
+              return { ip, region };
+            }
+          } catch {
+            // fall through to regex parse
+          }
+        }
+
+        const ipMatch = extractIpv4(text);
+        return {
+          ip: ipMatch || '',
+          region: '',
+        };
+      };
+
+      const fetchWithTimeout = async (url, timeoutValue) => {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), Math.max(1000, Number(timeoutValue) || 10000));
+        try {
+          return await fetch(url, {
+            method: 'GET',
+            cache: 'no-store',
+            credentials: 'omit',
+            headers: {
+              Accept: 'application/json, text/plain, */*',
+            },
+            signal: controller.signal,
+          });
+        } finally {
+          clearTimeout(timer);
+        }
+      };
+
+      const endpoints = Array.isArray(payload?.endpoints) ? payload.endpoints : [];
+      const normalizedEndpoints = [];
+      const endpointSet = new Set();
+      for (const endpoint of endpoints) {
+        const text = String(endpoint || '').trim();
+        if (!text || !/^https?:\/\//i.test(text) || endpointSet.has(text)) {
+          continue;
+        }
+        endpointSet.add(text);
+        normalizedEndpoints.push(text);
+      }
+      const timeoutValue = Math.max(1000, Number(payload?.timeoutMs) || 10000);
+      const diagnostics = [];
+      let bestEffortResult = null;
+
+      for (const endpoint of normalizedEndpoints.slice(0, 8)) {
+        try {
+          const url = endpoint.includes('?') ? `${endpoint}&_t=${Date.now()}` : `${endpoint}?_t=${Date.now()}`;
+          const response = await fetchWithTimeout(url, timeoutValue);
+          if (!response.ok) {
+            diagnostics.push(`${endpoint}:status:${response.status}`);
+            continue;
+          }
+          const text = await response.text();
+          const parsed = parsePayload(text, response.headers.get('content-type'));
+          if (parsed.ip) {
+            const result = {
+              ip: parsed.ip,
+              region: parsed.region,
+              endpoint,
+              diagnostics,
+            };
+            if (parsed.region) {
+              return result;
+            }
+            if (!bestEffortResult) {
+              bestEffortResult = result;
+            }
+            diagnostics.push(`${endpoint}:missing_region`);
+            continue;
+          }
+          diagnostics.push(`${endpoint}:empty_parse`);
+        } catch (error) {
+          diagnostics.push(`${endpoint}:${error?.message || error}`);
+        }
+      }
+
+      return bestEffortResult || {
+        ip: '',
+        region: '',
+        endpoint: '',
+        diagnostics,
+      };
+    },
+    args: [{
+      endpoints,
+      timeoutMs: perRequestTimeoutMs,
+    }],
+  });
+
+  return executionResults?.[0]?.result || null;
+}
+
+async function detectProxyExitInfoByPageContext(options = {}) {
+  const timeoutMs = Number(options?.timeoutMs) > 0 ? Number(options.timeoutMs) : 10000;
+  const errors = Array.isArray(options?.errors) ? options.errors : [];
+  const probeEndpoints = Array.isArray(options?.probeEndpoints)
+    ? options.probeEndpoints.map((item) => String(item || '').trim()).filter(Boolean)
+    : [];
+  let sawProbeErrorPage = false;
+
+  if (!chrome.scripting?.executeScript) {
+    errors.push('probe:page_context:scripting_unavailable');
+    return { ip: '', region: '', source: 'page_context_unavailable' };
+  }
+
+  let probeTabId = null;
+  let createdProbeTabId = null;
+  const probeUrl = `${IP_PROXY_PAGE_CONTEXT_PROBE_URL}?_multipage_proxy_probe=${Date.now()}`;
+  try {
+    const tab = await chrome.tabs.create({
+      url: probeUrl,
+      active: false,
+    });
+    probeTabId = Number(tab?.id) || null;
+    createdProbeTabId = probeTabId;
+  } catch (error) {
+    errors.push(`probe:page_context:create_probe_tab_failed:${error?.message || error}`);
+    probeTabId = await pickExistingPageContextProbeTabId();
+  }
+
+  if (!Number.isInteger(probeTabId)) {
+    errors.push('probe:page_context:no_probe_tab');
+    return { ip: '', region: '', source: 'page_context_unavailable' };
+  }
+
+  const navigationErrorTracker = createProbeNavigationErrorTracker(probeTabId);
+  let hasSuccessfulIp = false;
+
+  try {
+    const ready = await waitForPageContextProbeTabReady(
+      probeTabId,
+      Math.max(2500, Math.min(IP_PROXY_PAGE_CONTEXT_READY_TIMEOUT_MS, timeoutMs + 2500))
+    );
+    if (!ready) {
+      errors.push('probe:page_context:probe_tab_not_ready');
+      return { ip: '', region: '', source: 'page_context_unavailable' };
+    }
+
+    let ip = '';
+    let region = '';
+    let endpoint = '';
+    let canUseDocumentProbe = false;
+    try {
+      const probeTab = await chrome.tabs.get(probeTabId);
+      const probeHost = extractProbeHostFromTabUrl(probeTab?.url || '');
+      const expectedHost = extractProbeHostFromTabUrl(probeUrl);
+      canUseDocumentProbe = Boolean(probeHost && expectedHost && probeHost === expectedHost);
+    } catch {
+      canUseDocumentProbe = false;
+    }
+
+    if (canUseDocumentProbe) {
+      try {
+        const documentResult = await readExitProbeFromTabDocument(probeTabId);
+        const parsedDocument = parseProxyExitProbePayload(String(documentResult?.text || ''), 'application/json');
+        ip = String(parsedDocument?.ip || '').trim();
+        region = String(parsedDocument?.region || '').trim();
+        endpoint = String(documentResult?.url || '').trim();
+        if (ip) {
+          let baselineIp = '';
+          try {
+            const baselineUrl = `${IP_PROXY_PAGE_CONTEXT_BASELINE_URL}?_multipage_proxy_baseline=${Date.now()}`;
+            await chrome.tabs.update(probeTabId, {
+              url: baselineUrl,
+              active: false,
+            });
+            const baselineReady = await waitForPageContextProbeTabReady(
+              probeTabId,
+              Math.max(2000, Math.min(IP_PROXY_PAGE_CONTEXT_BASELINE_TIMEOUT_MS, timeoutMs + 1500))
+            );
+            if (baselineReady) {
+              const baselineResult = await readExitProbeFromTabDocument(probeTabId);
+              const parsedBaseline = parseProxyExitProbePayload(String(baselineResult?.text || ''), 'application/json');
+              baselineIp = String(parsedBaseline?.ip || '').trim();
+              if (!baselineIp) {
+                errors.push('probe:page_context:baseline_empty_parse');
+              }
+            } else {
+              errors.push('probe:page_context:baseline_not_ready');
+            }
+          } catch (baselineError) {
+            errors.push(`probe:page_context:baseline_failed:${baselineError?.message || baselineError}`);
+          }
+          hasSuccessfulIp = true;
+          return {
+            ip,
+            region,
+            source: 'page_context',
+            endpoint: endpoint || probeUrl,
+            baselineIp,
+          };
+        }
+        errors.push('probe:page_context:document_empty_parse');
+      } catch (documentError) {
+        if (isProbeErrorPageExecutionError(documentError)) {
+          sawProbeErrorPage = true;
+        }
+        errors.push(`probe:page_context:document_failed:${documentError?.message || documentError}`);
+      }
+    } else {
+      errors.push('probe:page_context:document_probe_skipped');
+    }
+
+    const navigationProbeResult = await probeExitInfoByTabNavigationWithEndpoints(
+      probeTabId,
+      timeoutMs,
+      errors,
+      probeEndpoints
+    );
+    if (navigationProbeResult?.ip) {
+      hasSuccessfulIp = true;
+      return {
+        ip: String(navigationProbeResult.ip || '').trim(),
+        region: String(navigationProbeResult.region || '').trim(),
+        source: 'page_context',
+        endpoint: String(navigationProbeResult.endpoint || '').trim(),
+      };
+    }
+
+    let scriptResult = null;
+    try {
+      scriptResult = await probeExitInfoViaExecuteScript(probeTabId, timeoutMs, probeEndpoints);
+    } catch (scriptError) {
+      if (isProbeErrorPageExecutionError(scriptError)) {
+        sawProbeErrorPage = true;
+      }
+      errors.push(`probe:page_context:script_failed:${scriptError?.message || scriptError}`);
+      if (!createdProbeTabId && isProbeErrorPageExecutionError(scriptError)) {
+        const retryUrl = `${IP_PROXY_PAGE_CONTEXT_PROBE_URL}?_multipage_proxy_probe=${Date.now()}&retry=1`;
+        const retryTab = await chrome.tabs.create({
+          url: retryUrl,
+          active: false,
+        });
+        const retryTabId = Number(retryTab?.id) || 0;
+        if (retryTabId > 0) {
+          createdProbeTabId = retryTabId;
+          navigationErrorTracker.setTabId(retryTabId);
+          const retryReady = await waitForPageContextProbeTabReady(
+            retryTabId,
+            Math.max(2500, Math.min(IP_PROXY_PAGE_CONTEXT_READY_TIMEOUT_MS, timeoutMs + 2500))
+          );
+          if (retryReady) {
+            scriptResult = await probeExitInfoViaExecuteScript(retryTabId, timeoutMs, probeEndpoints);
+          }
+        }
+      } else {
+        throw scriptError;
+      }
+    }
+
+    if (!scriptResult) {
+      return {
+        ip: '',
+        region: '',
+        source: sawProbeErrorPage ? 'page_context_error_page' : 'page_context_unavailable',
+      };
+    }
+    ip = String(scriptResult?.ip || '').trim();
+    region = String(scriptResult?.region || '').trim();
+    if (ip) {
+      hasSuccessfulIp = true;
+      return {
+        ip,
+        region,
+        source: 'page_context',
+        endpoint: String(scriptResult?.endpoint || '').trim(),
+      };
+    }
+    if (Array.isArray(scriptResult?.diagnostics) && scriptResult.diagnostics.length) {
+      for (const item of scriptResult.diagnostics.slice(0, 4)) {
+        errors.push(`probe:page_context:script:${String(item)}`);
+      }
+    } else {
+      errors.push('probe:page_context:script_empty');
+    }
+  } catch (error) {
+    const message = String(error?.message || error || '');
+    if (isProbeErrorPageExecutionError(error)) {
+      sawProbeErrorPage = true;
+    }
+    if (!/probe:page_context:script_failed/i.test(message)) {
+      errors.push(`probe:page_context:script_failed:${message}`);
+    }
+  } finally {
+    if (!hasSuccessfulIp) {
+      navigationErrorTracker.appendDiagnostics(errors, 2);
+    }
+    navigationErrorTracker.dispose();
+    if (Number.isInteger(createdProbeTabId)) {
+      try {
+        await chrome.tabs.remove(createdProbeTabId);
+      } catch {
+        // ignore tab close failures
+      }
+    }
+  }
+
+  return {
+    ip: '',
+    region: '',
+    source: sawProbeErrorPage ? 'page_context_error_page' : 'page_context_unavailable',
+  };
+}
+
+async function detectProxyExitInfo(options = {}) {
+  const timeoutMs = Number(options?.timeoutMs) > 0 ? Number(options.timeoutMs) : 10000;
+  const errors = Array.isArray(options?.errors) ? options.errors : [];
+  const preferPageContext = options?.preferPageContext !== false;
+  const allowBackgroundFallback = options?.allowBackgroundFallback === true;
+  const allowPageContextFallbackOnBackgroundAbort = options?.allowPageContextFallbackOnBackgroundAbort !== false;
+  const probeEndpoints = resolveExitProbeEndpoints({
+    provider: options?.provider || '',
+    username: options?.username || '',
+  });
+
+  if (preferPageContext) {
+    const pageResult = await detectProxyExitInfoByPageContext({
+      timeoutMs,
+      errors,
+      probeEndpoints,
+    });
+    if (pageResult?.ip) {
+      return pageResult;
+    }
+    const shouldFallbackToBackground = allowBackgroundFallback
+      || String(pageResult?.source || '').trim().toLowerCase() === 'page_context_error_page'
+      || hasProbeErrorPageDiagnostics(errors);
+    if (!shouldFallbackToBackground) {
+      return {
+        ip: '',
+        region: '',
+        source: String(pageResult?.source || 'page_context_unavailable'),
+      };
+    }
+    if (!allowBackgroundFallback) {
+      errors.push('probe:page_context:error_page_auto_fallback');
+    }
+  }
+
+  const backgroundResult = await detectProxyExitInfoByBackgroundFetch({
+    timeoutMs,
+    errors,
+    probeEndpoints,
+  });
+  if (!preferPageContext
+    && allowPageContextFallbackOnBackgroundAbort
+    && !backgroundResult?.ip
+    && Array.isArray(errors)
+    && errors.some((item) => /probe:bg:.*signal is aborted without reason/i.test(String(item || '')))) {
+    errors.push('probe:bg:abort_storm_page_fallback');
+    const pageResult = await detectProxyExitInfoByPageContext({
+      timeoutMs: Math.max(5000, Math.min(9000, timeoutMs)),
+      errors,
+      probeEndpoints,
+    });
+    errors.push(`probe:bg:abort_storm_page_fallback_result:${String(pageResult?.source || 'unknown')}`);
+    if (pageResult?.ip) {
+      return pageResult;
+    }
+  }
+  return backgroundResult;
+}
+
+async function pullIpProxyPoolFromApi(state = {}, options = {}) {
+  const apiUrl = String(state?.ipProxyApiUrl || '').trim();
+  if (!apiUrl) {
+    throw new Error('代理 API 不能为空。');
+  }
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(apiUrl);
+  } catch {
+    throw new Error('代理 API 不是有效 URL。');
+  }
+  if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+    throw new Error('代理 API 仅支持 http/https。');
+  }
+
+  const provider = normalizeIpProxyProviderValue(state?.ipProxyService);
+  const timeoutMs = Number(options?.timeoutMs) > 0 ? Number(options.timeoutMs) : IP_PROXY_FETCH_TIMEOUT_MS;
+  const response = await fetchWithTimeout(apiUrl, {
+    method: 'GET',
+    cache: 'no-store',
+    headers: { Accept: 'application/json, text/plain, */*' },
+  }, timeoutMs);
+  if (!response.ok) {
+    throw new Error(`代理 API 请求失败（HTTP ${response.status}）。`);
+  }
+
+  const rawText = await response.text();
+  let payload = rawText;
+  try {
+    payload = JSON.parse(rawText);
+  } catch {
+    payload = rawText;
+  }
+  const pool = normalizeIpProxyListFromPayload(payload, provider);
+  if (!pool.length && typeof payload === 'string') {
+    return normalizeProxyPoolEntries(payload, provider).slice(0, Number(options.maxItems) || 100);
+  }
+  const maxItems = Math.max(1, Math.min(500, Number(options.maxItems) || 100));
+  return pool.slice(0, maxItems);
+}
+
+function installIpProxyAuthListener() {
+  if (ipProxyAuthListenerInstalled) {
+    return;
+  }
+  if (!chrome.webRequest?.onAuthRequired?.addListener) {
+    return;
+  }
+
+  chrome.webRequest.onAuthRequired.addListener(
+    (details, callback) => {
+      try {
+        const auth = currentIpProxyAuthEntry;
+        if (!auth?.username) {
+          recordIpProxyAuthChallenge(details, false);
+          callback();
+          return;
+        }
+        const isProxyChallenge = details?.isProxy === true;
+        const challengerHost = String(details?.challenger?.host || '').trim().toLowerCase();
+        const challengerPort = Number.parseInt(String(details?.challenger?.port || ''), 10) || 0;
+        const authHost = String(auth?.host || '').trim().toLowerCase();
+        const authPort = Number.parseInt(String(auth?.port || ''), 10) || 0;
+        const challengerMatched = Boolean(
+          challengerHost
+          && authHost
+          && challengerHost === authHost
+          && (!authPort || !challengerPort || authPort === challengerPort)
+        );
+        const proxyAuthStatus = Number.parseInt(String(details?.statusCode || ''), 10) === 407;
+        const shouldProvide = isProxyChallenge || challengerMatched || proxyAuthStatus;
+        recordIpProxyAuthChallenge(details, shouldProvide);
+        if (!shouldProvide) {
+          callback();
+          return;
+        }
+        callback({
+          authCredentials: {
+            username: auth.username,
+            password: String(auth.password || ''),
+          },
+        });
+      } catch {
+        recordIpProxyAuthChallenge(details, false);
+        callback();
+      }
+    },
+    { urls: ['<all_urls>'] },
+    ['asyncBlocking']
+  );
+  ipProxyAuthListenerInstalled = true;
+}
+
+function installIpProxyErrorListener() {
+  if (ipProxyErrorListenerInstalled) {
+    return;
+  }
+  if (!chrome.proxy?.onProxyError?.addListener) {
+    return;
+  }
+
+  chrome.proxy.onProxyError.addListener((details = {}) => {
+    ipProxyLastRuntimeError = {
+      error: String(details?.error || '').trim(),
+      details: String(details?.details || '').trim(),
+      fatal: Boolean(details?.fatal),
+      at: Date.now(),
+    };
+  });
+
+  ipProxyErrorListenerInstalled = true;
+}
+
+function callChromeProxySettings(method, details) {
+  const proxySettings = chrome.proxy?.settings;
+  if (!proxySettings || typeof proxySettings[method] !== 'function') {
+    return Promise.reject(new Error('当前浏览器不支持扩展代理 API'));
+  }
+  return new Promise((resolve, reject) => {
+    proxySettings[method](details, () => {
+      const lastError = chrome.runtime?.lastError;
+      if (lastError) {
+        reject(new Error(lastError.message || String(lastError)));
+        return;
+      }
+      resolve(true);
+    });
+  });
+}
+
+function getChromeProxySettings(details = { incognito: false }) {
+  const proxySettings = chrome.proxy?.settings;
+  if (!proxySettings || typeof proxySettings.get !== 'function') {
+    return Promise.reject(new Error('当前浏览器不支持扩展代理 API'));
+  }
+  return new Promise((resolve, reject) => {
+    proxySettings.get(details, (value) => {
+      const lastError = chrome.runtime?.lastError;
+      if (lastError) {
+        reject(new Error(lastError.message || String(lastError)));
+        return;
+      }
+      resolve(value || {});
+    });
+  });
+}
+
+function validateProxyControlAfterApply(details, entry) {
+  const level = String(details?.levelOfControl || '').trim();
+  if (level && level !== 'controlled_by_this_extension') {
+    return {
+      ok: false,
+      message: `代理控制权不在当前扩展（levelOfControl=${level || 'unknown'}）`,
+    };
+  }
+
+  const mode = String(details?.value?.mode || '').trim().toLowerCase();
+  if (mode !== 'pac_script') {
+    return {
+      ok: false,
+      message: `代理模式不是 pac_script（当前为 ${mode || 'unknown'}）`,
+    };
+  }
+
+  const pacData = String(details?.value?.pacScript?.data || '');
+  const endpoint = `${entry.host}:${entry.port}`;
+  if (pacData && !pacData.includes(endpoint)) {
+    return {
+      ok: false,
+      message: `PAC 未包含当前代理节点 ${endpoint}，疑似被其他代理配置覆盖`,
+    };
+  }
+
+  return {
+    ok: true,
+    message: '',
+  };
+}
+
+function buildIpProxyPacScript(entry) {
+  const normalizedProtocol = normalizeIpProxyProtocol(entry?.protocol || DEFAULT_IP_PROXY_PROTOCOL);
+  const host = String(entry?.host || '').trim();
+  const port = normalizeIpProxyPort(entry?.port);
+  if (!host || !port) {
+    return '';
+  }
+  let pacScheme = 'PROXY';
+  if (normalizedProtocol === 'https') {
+    pacScheme = 'HTTPS';
+  } else if (normalizedProtocol === 'socks4') {
+    pacScheme = 'SOCKS4';
+  } else if (normalizedProtocol === 'socks5') {
+    pacScheme = 'SOCKS5';
+  }
+  const targetPatterns = IP_PROXY_TARGET_HOST_PATTERNS.map((pattern) => `'${String(pattern).replace(/'/g, "\\'")}'`).join(', ');
+  const bypassList = IP_PROXY_BYPASS_LIST.map((pattern) => `'${String(pattern).replace(/'/g, "\\'")}'`).join(', ');
+  const proxyEndpoint = `${pacScheme} ${host}:${port}`;
+  const routeAllLiteral = (typeof IP_PROXY_ROUTE_ALL_TRAFFIC !== 'undefined' && Boolean(IP_PROXY_ROUTE_ALL_TRAFFIC))
+    ? 'true'
+    : 'false';
+  return `
+function FindProxyForURL(url, host) {
+  if (!host) return "DIRECT";
+  var bypassList = [${bypassList}];
+  for (var i = 0; i < bypassList.length; i++) {
+    var bypass = bypassList[i];
+    if (shExpMatch(host, bypass) || host === bypass) {
+      return "DIRECT";
+    }
+  }
+
+  var routeAllTraffic = ${routeAllLiteral};
+  if (routeAllTraffic) {
+    return "${proxyEndpoint}";
+  }
+
+  var targets = [${targetPatterns}];
+  var matched = false;
+  for (var j = 0; j < targets.length; j++) {
+    var pattern = targets[j];
+    if (pattern.indexOf('*.') === 0) {
+      var suffix = pattern.substring(1);
+      var direct = pattern.substring(2);
+      if (dnsDomainIs(host, suffix) || host === direct) {
+        matched = true;
+        break;
+      }
+      continue;
+    }
+    if (host === pattern || dnsDomainIs(host, '.' + pattern)) {
+      matched = true;
+      break;
+    }
+  }
+  if (!matched) {
+    return "DIRECT";
+  }
+  return "${proxyEndpoint}";
+}`.trim();
+}
+
+function buildIpProxyEntrySignature(entry = {}) {
+  return [
+    normalizeIpProxyProtocol(entry?.protocol || DEFAULT_IP_PROXY_PROTOCOL),
+    String(entry?.host || '').trim().toLowerCase(),
+    String(normalizeIpProxyPort(entry?.port) || ''),
+    String(entry?.username || '').trim(),
+    String(entry?.password || ''),
+  ].join('|');
+}
+
+async function clearIpProxySettings(options = {}) {
+  currentIpProxyAuthEntry = null;
+  if (options?.resetAppliedSignature !== false) {
+    lastAppliedIpProxyEntrySignature = '';
+  }
+  if (options?.resetHostVariant !== false) {
+    ipProxyAuthHostVariantToggle = false;
+  }
+  if (options?.resetLastAppliedAuthSnapshot === true) {
+    lastAppliedIpProxyAuthSnapshot = {
+      host: '',
+      port: 0,
+      username: '',
+      password: '',
+    };
+  }
+  await callChromeProxySettings('clear', { scope: IP_PROXY_SETTINGS_SCOPE });
+}
+
+async function clearIpProxyNetworkState() {
+  try {
+    if (chrome.webRequest?.handlerBehaviorChanged) {
+      await new Promise((resolve) => {
+        try {
+          chrome.webRequest.handlerBehaviorChanged(() => resolve());
+        } catch {
+          resolve();
+        }
+      });
+    }
+    if (chrome.browsingData?.remove) {
+      await chrome.browsingData.remove(
+        { since: 0 },
+        {
+          cache: true,
+          cacheStorage: true,
+          serviceWorkers: true,
+        }
+      );
+    }
+  } catch {
+    // ignore cache clear failures; proxy apply can still continue
+  }
+}
+
+async function forceProxyConnectionDrainBeforeAuthSwitch() {
+  try {
+    await callChromeProxySettings('set', {
+      value: { mode: 'direct' },
+      scope: IP_PROXY_SETTINGS_SCOPE,
+    });
+  } catch {
+    // ignore direct mode switch failures
+  }
+  await new Promise((resolve) => setTimeout(resolve, 1200));
+  await clearIpProxyNetworkState().catch(() => {});
+  await new Promise((resolve) => setTimeout(resolve, 800));
+}
+
+async function updateIpProxyRuntimeStatus(status = {}) {
+  const patch = buildIpProxyRoutingStatePatch(status);
+  await setState(patch);
+  broadcastDataUpdate(patch);
+  return patch;
+}
+
+async function applyIpProxySettingsFromState(state = {}, options = {}) {
+  const resolvedState = state || await getState();
+  const enabled = Boolean(resolvedState?.ipProxyEnabled);
+  if (!enabled) {
+    try {
+      await clearIpProxySettings({ resetLastAppliedAuthSnapshot: true });
+    } catch {
+      // ignore clear failures when already clear
+    }
+    await setIpProxyLeakGuardEnabled(false);
+    const status = {
+      enabled: false,
+      applied: false,
+      reason: 'disabled',
+      provider: normalizeIpProxyProviderValue(resolvedState?.ipProxyService),
+      exitDetecting: false,
+      exitIp: '',
+      exitRegion: '',
+      exitError: '',
+      error: '',
+    };
+    await updateIpProxyRuntimeStatus(status);
+    return status;
+  }
+
+  if (!chrome.proxy?.settings?.set) {
+    await setIpProxyLeakGuardEnabled(true);
+    const status = {
+      enabled: true,
+      applied: false,
+      reason: 'proxy_api_unavailable',
+      provider: normalizeIpProxyProviderValue(resolvedState?.ipProxyService),
+      error: '当前浏览器不支持扩展代理 API。',
+      exitDetecting: false,
+      exitIp: '',
+      exitRegion: '',
+      exitError: '',
+    };
+    await updateIpProxyRuntimeStatus(status);
+    return status;
+  }
+
+  const mode = normalizeIpProxyMode(resolvedState?.ipProxyMode);
+  const provider = normalizeIpProxyProviderValue(resolvedState?.ipProxyService);
+  if (mode === 'api' && !isApiModeProxyConfigAvailable(resolvedState)) {
+    const clearRuntimePatch = buildIpProxyRuntimeStatePatch(mode, {
+      pool: [],
+      index: 0,
+      current: null,
+    }, provider);
+    await setState(clearRuntimePatch);
+    broadcastDataUpdate(clearRuntimePatch);
+    try {
+      await clearIpProxySettings({ resetLastAppliedAuthSnapshot: true });
+    } catch {
+      // ignore clear failures
+    }
+    await setIpProxyLeakGuardEnabled(true);
+    const status = {
+      enabled: true,
+      applied: false,
+      reason: 'missing_proxy_entry',
+      provider,
+      error: 'API 模式已启用，但代理 API 为空。',
+      exitDetecting: false,
+      exitIp: '',
+      exitRegion: '',
+      exitError: '',
+      exitSource: '',
+    };
+    await updateIpProxyRuntimeStatus(status);
+    return status;
+  }
+
+  const entry = getIpProxyCurrentEntryFromState(resolvedState);
+  if (!entry) {
+    try {
+      await clearIpProxySettings({ resetLastAppliedAuthSnapshot: true });
+    } catch {
+      // ignore clear failures
+    }
+    await setIpProxyLeakGuardEnabled(true);
+    const status = {
+      enabled: true,
+      applied: false,
+      reason: 'missing_proxy_entry',
+      provider: normalizeIpProxyProviderValue(resolvedState?.ipProxyService),
+      error: mode === 'account'
+        ? getAccountListParseFailureHint(resolvedState, provider)
+        : '',
+      exitDetecting: false,
+      exitIp: '',
+      exitRegion: '',
+      exitError: '',
+    };
+    await updateIpProxyRuntimeStatus(status);
+    return status;
+  }
+
+  const explicitForceAuthRebind = Boolean(options?.forceAuthRebind);
+  const suppressAuthRebind = Boolean(options?.suppressAuthRebind);
+  const hasAccountListConfigured = mode === 'account' && hasConfiguredAccountListEntries(resolvedState);
+  const hasMultipleAccountEntries = mode === 'account'
+    && hasAccountListConfigured
+    && getAccountModeProxyPoolFromState(resolvedState, provider).length > 1;
+  const shouldForceDrain = !suppressAuthRebind && (
+    explicitForceAuthRebind
+    || shouldForceProxyConnectionDrainForEntry(entry)
+    || (
+      provider === '711proxy'
+      && hasAccountListConfigured
+      && Boolean(String(entry?.username || '').trim())
+    )
+  );
+  let effectiveEntry = buildEffectiveProxyEntryForApply(entry, {
+    forceRotateVariant: shouldForceDrain,
+    allow711HostVariant: hasMultipleAccountEntries,
+  });
+  if (shouldForceDrain) {
+    effectiveEntry = await maybeResolveProxyHostVariantForAuthSwitch(effectiveEntry, {
+      force: true,
+      timeoutMs: 3500,
+      allow711ResolvedIp: hasMultipleAccountEntries,
+    }).catch(() => effectiveEntry);
+  }
+
+  const pacScript = buildIpProxyPacScript(effectiveEntry);
+  if (!pacScript) {
+    await setIpProxyLeakGuardEnabled(true);
+    const status = {
+      enabled: true,
+      applied: false,
+      reason: 'missing_proxy_entry',
+      host: entry.host,
+      port: entry.port,
+      region: entry.region,
+      hasAuth: Boolean(entry.username || entry.password),
+      provider: normalizeIpProxyProviderValue(entry.provider || resolvedState?.ipProxyService),
+      error: '代理配置不完整，无法生成 PAC 规则。',
+      exitDetecting: false,
+      exitIp: '',
+      exitRegion: '',
+      exitError: '',
+    };
+    await updateIpProxyRuntimeStatus(status);
+    return status;
+  }
+
+  const entrySignature = buildIpProxyEntrySignature(effectiveEntry);
+  const shouldResetNetworkState = Boolean(
+    entrySignature
+    && entrySignature !== lastAppliedIpProxyEntrySignature
+    && !options.skipExitProbe
+    && options.resetNetworkState !== false
+  );
+
+  try {
+    installIpProxyAuthListener();
+    installIpProxyErrorListener();
+    resetIpProxyRuntimeErrorDiagnostics();
+    if (shouldForceDrain) {
+      if (typeof addLog === 'function') {
+        await addLog(
+          explicitForceAuthRebind
+            ? '正在执行代理鉴权重绑：重置代理连接并切换主机变体，避免复用旧鉴权缓存。'
+            : '检测到同节点切换代理账号，正在重置代理连接并切换主机变体，避免复用旧鉴权缓存。',
+          'info'
+        ).catch(() => {});
+        if (String(effectiveEntry?.host || '').trim() !== String(entry?.host || '').trim()) {
+          await addLog(`代理账号切换：已启用主机缓存隔离（${entry.host} -> ${effectiveEntry.host}）。`, 'info').catch(() => {});
+        }
+      }
+      await setIpProxyLeakGuardEnabled(true);
+      await forceProxyConnectionDrainBeforeAuthSwitch();
+    }
+    currentIpProxyAuthEntry = effectiveEntry?.username
+      ? {
+          host: effectiveEntry.host,
+          port: effectiveEntry.port,
+          username: effectiveEntry.username,
+          password: String(effectiveEntry.password || ''),
+        }
+      : null;
+    await clearIpProxySettings({
+      resetAppliedSignature: false,
+      resetHostVariant: false,
+    }).catch(() => {});
+    currentIpProxyAuthEntry = effectiveEntry?.username
+      ? {
+          host: effectiveEntry.host,
+          port: effectiveEntry.port,
+          username: effectiveEntry.username,
+          password: String(effectiveEntry.password || ''),
+        }
+      : null;
+    if (shouldResetNetworkState) {
+      await clearIpProxyNetworkState();
+    }
+    await callChromeProxySettings('set', {
+      value: {
+        mode: 'pac_script',
+        pacScript: {
+          data: pacScript,
+          // 官方文档建议启用 mandatory，避免 PAC 失效时静默回落到 DIRECT。
+          mandatory: true,
+        },
+      },
+      scope: IP_PROXY_SETTINGS_SCOPE,
+    });
+    const proxySettings = await getChromeProxySettings({ incognito: false }).catch(() => null);
+    const takeoverCheck = validateProxyControlAfterApply(proxySettings || {}, effectiveEntry);
+    if (!takeoverCheck.ok) {
+      throw new Error(takeoverCheck.message || '代理接管校验失败。');
+    }
+    await setIpProxyLeakGuardEnabled(false);
+    lastAppliedIpProxyEntrySignature = entrySignature;
+    lastAppliedIpProxyAuthSnapshot = {
+      host: String(entry?.host || '').trim(),
+      port: normalizeIpProxyPort(entry?.port),
+      username: String(entry?.username || '').trim(),
+      password: String(entry?.password || ''),
+    };
+  } catch (error) {
+    lastAppliedIpProxyEntrySignature = '';
+    await setIpProxyLeakGuardEnabled(true);
+    const status = {
+      enabled: true,
+      applied: false,
+      reason: 'apply_failed',
+      host: entry.host,
+      port: entry.port,
+      region: entry.region,
+      hasAuth: Boolean(entry.username || entry.password),
+      provider: normalizeIpProxyProviderValue(entry.provider || resolvedState?.ipProxyService),
+      error: error?.message || String(error || '代理设置失败'),
+      exitDetecting: false,
+      exitIp: '',
+      exitRegion: '',
+      exitError: '',
+    };
+    await updateIpProxyRuntimeStatus(status);
+    return status;
+  }
+
+  const status = {
+    enabled: true,
+    applied: true,
+    reason: 'applied',
+    host: entry.host,
+    port: entry.port,
+    region: entry.region,
+    username: String(entry.username || '').trim(),
+    entrySource: resolveIpProxyAccountEntrySource(resolvedState, mode),
+    hasAuth: Boolean(entry.username || entry.password),
+    provider: normalizeIpProxyProviderValue(entry.provider || resolvedState?.ipProxyService),
+    error: '',
+    exitDetecting: !options.skipExitProbe,
+    exitIp: '',
+    exitRegion: '',
+    exitError: '',
+    exitSource: '',
+  };
+  await updateIpProxyRuntimeStatus(status);
+
+  if (shouldForceDrain) {
+    // 同节点切换账号后给网络栈一点时间建立新隧道，避免立即探测命中旧连接。
+    await new Promise((resolve) => setTimeout(resolve, 900));
+  }
+
+  if (options.skipExitProbe) {
+    return status;
+  }
+
+  const token = ++ipProxyExitDetectionToken;
+  const diagnostics = [];
+  resetIpProxyAuthDiagnostics();
+  const exit = await detectProxyExitInfo({
+    timeoutMs: 10000,
+    errors: diagnostics,
+    provider: status?.provider || provider,
+    username: status?.username || entry?.username || '',
+    // 优先使用页面上下文探测，确保探测链路与真实浏览器页面一致；
+    // 后台探测仅作为补充兜底，避免单一路径误判。
+    preferPageContext: true,
+    allowBackgroundFallback: true,
+  }).catch(() => ({ ip: '', region: '' }));
+  if (!exit?.ip && Boolean(status?.hasAuth)) {
+    appendIpProxyAuthDiagnosticsToErrors(diagnostics);
+  }
+
+  if (token !== ipProxyExitDetectionToken) {
+    return status;
+  }
+  const latest = await getState();
+  if (!latest?.ipProxyEnabled) {
+    return status;
+  }
+
+  const exitStatus = {
+    ...status,
+    exitDetecting: false,
+    exitIp: String(exit?.ip || '').trim(),
+    exitRegion: String(exit?.region || '').trim(),
+    exitBaselineIp: String(exit?.baselineIp || '').trim(),
+    exitError: exit?.ip ? '' : buildProbeDiagnosticsSummary(diagnostics, IP_PROXY_DIAGNOSTICS_SUMMARY_MAX_ITEMS),
+    exitSource: String(exit?.source || '').trim().toLowerCase(),
+    authDiagnostics: status?.hasAuth ? getIpProxyAuthDiagnosticsSummary() : '',
+  };
+  const expectedRegion = String(entry?.region || '').trim();
+  let normalizedExitStatus = applyExitRegionExpectation(exitStatus, expectedRegion);
+  normalizedExitStatus = applyExitBaselineExpectation(normalizedExitStatus);
+  if (normalizedExitStatus.reason === 'connectivity_failed') {
+    await setIpProxyLeakGuardEnabled(true);
+  }
+  await updateIpProxyRuntimeStatus(normalizedExitStatus);
+  return normalizedExitStatus;
+}
+
+function getNextIpProxyPoolIndex(currentIndex = 0, poolLength = 0, direction = 'next') {
+  const length = Math.max(0, Number(poolLength) || 0);
+  if (length <= 0) return 0;
+  const normalized = normalizeIpProxyCurrentIndex(currentIndex, 0) % length;
+  if (String(direction || '').toLowerCase() === 'prev') {
+    return (normalized - 1 + length) % length;
+  }
+  return (normalized + 1) % length;
+}
+
+async function refreshIpProxyPool(options = {}) {
+  const state = options.state || await getState();
+  const mode = normalizeIpProxyMode(options.mode || state?.ipProxyMode);
+  const maxItems = Math.max(
+    1,
+    Math.min(500, Number(options.maxItems) || resolveIpProxyPoolTargetCountForMode(state, mode))
+  );
+  const provider = normalizeIpProxyProviderValue(state?.ipProxyService);
+  let pool = [];
+
+  if (mode === 'account') {
+    pool = getAccountModeProxyPoolFromState(state, provider).slice(0, maxItems);
+    if (!pool.length) {
+      const parseFailureHint = getAccountListParseFailureHint(state, provider);
+      if (parseFailureHint) {
+        throw new Error(parseFailureHint);
+      }
+      throw new Error('账号密码模式没有可用代理，请先填写代理列表，或填写 Host/Port。');
+    }
+  } else {
+    pool = await pullIpProxyPoolFromApi(state, {
+      maxItems,
+      timeoutMs: options.timeoutMs,
+    });
+    if (!pool.length) {
+      throw new Error('代理列表为空，请检查 API 返回。');
+    }
+  }
+
+  const runtime = getIpProxyRuntimeSnapshot(state, mode, provider);
+  const summary = buildProxyPoolSummary(pool, runtime.index);
+  const updates = {
+    ipProxyService: provider,
+    ...buildIpProxyRuntimeStatePatch(mode, {
+      pool,
+      index: summary.index,
+      current: summary.current,
+    }, provider),
+  };
+  await setState(updates);
+  broadcastDataUpdate(updates);
+
+  let proxyRouting = null;
+  if (state?.ipProxyEnabled) {
+    const applyState = {
+      ...state,
+      ...updates,
+    };
+    const shouldRebindSingleAccountEntry = mode === 'account' && pool.length <= 1;
+    proxyRouting = await applyIpProxySettingsFromState(
+      applyState,
+      shouldRebindSingleAccountEntry
+        ? {
+          forceAuthRebind: true,
+          suppressAuthRebind: false,
+          resetNetworkState: true,
+          skipExitProbe: false,
+        }
+        : undefined
+    );
+  }
+
+  return {
+    mode,
+    provider,
+    count: summary.count,
+    index: summary.index,
+    current: summary.current,
+    display: summary.display,
+    pool,
+    proxyRouting,
+  };
+}
+
+async function switchIpProxy(direction = 'next', options = {}) {
+  const state = options.state || await getState();
+  const mode = normalizeIpProxyMode(options.mode || state?.ipProxyMode);
+  if (mode === 'api' && !isApiModeProxyConfigAvailable(state)) {
+    throw new Error('API 模式代理 URL 为空，请先填写代理 API 地址。');
+  }
+  const maxItems = Math.max(
+    1,
+    Math.min(500, Number(options.maxItems) || resolveIpProxyPoolTargetCountForMode(state, mode))
+  );
+  const provider = normalizeIpProxyProviderValue(state?.ipProxyService);
+  const runtime = getIpProxyRuntimeSnapshot(state, mode, provider);
+  let pool = [];
+  if (mode === 'account') {
+    pool = getAccountModeProxyPoolFromState(state, provider).slice(0, maxItems);
+  } else {
+    pool = runtime.pool.slice(0, maxItems);
+  }
+
+  if (!pool.length) {
+    if (mode === 'api' && options.forceRefresh !== false) {
+      return refreshIpProxyPool({
+        ...options,
+        mode,
+        state,
+      });
+    }
+    throw new Error(mode === 'account'
+      ? '账号密码模式没有可切换的代理，请先填写代理列表或 Host/Port。'
+      : '当前没有可切换代理，请先点击“拉取”获取 IP 列表。');
+  }
+
+  const nextIndex = getNextIpProxyPoolIndex(runtime.index, pool.length, direction);
+  const current = pool[nextIndex];
+  const updates = {
+    ipProxyService: provider,
+    ...buildIpProxyRuntimeStatePatch(mode, {
+      pool,
+      index: nextIndex,
+      current,
+    }, provider),
+  };
+  await setState(updates);
+  broadcastDataUpdate(updates);
+
+  let proxyRouting = null;
+  if (state?.ipProxyEnabled) {
+    const applyState = {
+      ...state,
+      ...updates,
+    };
+    const shouldRebindSingleAccountEntry = mode === 'account' && pool.length <= 1;
+    proxyRouting = await applyIpProxySettingsFromState(
+      applyState,
+      shouldRebindSingleAccountEntry
+        ? {
+          forceAuthRebind: true,
+          suppressAuthRebind: false,
+          resetNetworkState: true,
+          skipExitProbe: false,
+        }
+        : undefined
+    );
+  }
+  const summary = buildProxyPoolSummary(pool, nextIndex);
+  return {
+    mode,
+    provider,
+    count: summary.count,
+    index: summary.index,
+    current: summary.current,
+    display: summary.display,
+    pool,
+    proxyRouting,
+  };
+}
+
+async function changeIpProxyExit(options = {}) {
+  const state = options.state || await getState();
+  if (!state?.ipProxyEnabled) {
+    throw new Error('请先启用 IP 代理。');
+  }
+
+  const mode = normalizeIpProxyMode(options.mode || state?.ipProxyMode);
+  const provider = normalizeIpProxyProviderValue(state?.ipProxyService);
+  if (mode !== 'account') {
+    throw new Error('Change 仅支持账号密码模式。');
+  }
+  if (provider !== '711proxy') {
+    throw new Error('Change 当前仅支持 711Proxy。');
+  }
+
+  const entry = getIpProxyCurrentEntryFromState(state);
+  if (!entry || !entry.host || !entry.port) {
+    throw new Error('当前没有可用代理条目，无法执行 Change。');
+  }
+  const username = String(entry?.username || '').trim();
+  if (!has711SessionToken(username)) {
+    throw new Error('当前账号未配置 session，无法执行 Change。请先在账号中追加 session 参数。');
+  }
+
+  if (typeof addLog === 'function') {
+    await addLog('正在执行 Change：保持当前 session，重绑代理链路并刷新出口。', 'info').catch(() => {});
+  }
+
+  const proxyRouting = await applyIpProxySettingsFromState(state, {
+    forceAuthRebind: true,
+    suppressAuthRebind: false,
+    resetNetworkState: true,
+    skipExitProbe: false,
+  });
+
+  const runtime = getIpProxyRuntimeSnapshot(state, mode, provider);
+  const pool = runtime.pool.length
+    ? runtime.pool
+    : getAccountModeProxyPoolFromState(state, provider);
+  const summary = buildProxyPoolSummary(pool, runtime.index);
+
+  return {
+    mode,
+    provider,
+    count: summary.count,
+    index: summary.index,
+    current: summary.current,
+    display: summary.display,
+    pool,
+    proxyRouting,
+    action: 'change',
+  };
+}
+
+async function tryRecoverApiProxyByRotation(options = {}) {
+  const maxAttempts = Math.max(1, Math.min(12, Number(options?.maxAttempts) || 4));
+  let latestStatus = options?.fallbackStatus || null;
+  let attempts = 0;
+  let refreshedPool = false;
+  const runSingleRotationPass = async () => {
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      const state = await getState();
+      if (!state?.ipProxyEnabled) {
+        break;
+      }
+      const mode = normalizeIpProxyMode(state?.ipProxyMode);
+      if (mode !== 'api') {
+        break;
+      }
+      const provider = normalizeIpProxyProviderValue(state?.ipProxyService);
+      const runtime = getIpProxyRuntimeSnapshot(state, mode, provider);
+      if (!Array.isArray(runtime?.pool) || runtime.pool.length <= 1) {
+        break;
+      }
+      const switched = await switchIpProxy('next', {
+        mode,
+        forceRefresh: false,
+        state,
+      }).catch(() => null);
+      attempts += 1;
+      const status = switched?.proxyRouting || null;
+      if (status) {
+        latestStatus = status;
+      }
+      if (status?.applied && status?.reason !== 'connectivity_failed') {
+        if (typeof addLog === 'function') {
+          const nodeText = Number.isInteger(switched?.index)
+            && Number.isInteger(switched?.count)
+            && switched.count > 0
+            ? `（第 ${switched.index + 1}/${switched.count} 个节点）`
+            : '';
+          const refreshText = refreshedPool ? '（已自动刷新 IP 池）' : '';
+          await addLog(`IP 代理自动恢复成功：API 模式已切换到可用节点${nodeText}${refreshText}。`, 'ok').catch(() => {});
+        }
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const firstPassRecovered = await runSingleRotationPass();
+  if (firstPassRecovered) {
+    return { recovered: true, attempts, status: latestStatus };
+  }
+
+  if (options?.allowRefresh !== false) {
+    const latestState = await getState();
+    if (latestState?.ipProxyEnabled && normalizeIpProxyMode(latestState?.ipProxyMode) === 'api') {
+      await refreshIpProxyPool({
+        mode: 'api',
+        state: latestState,
+        forceRefresh: true,
+      }).catch(() => null);
+      refreshedPool = true;
+      const secondPassRecovered = await runSingleRotationPass();
+      if (secondPassRecovered) {
+        return { recovered: true, attempts, status: latestStatus };
+      }
+    }
+  }
+
+  if (latestStatus && attempts > 0) {
+    const suffix = refreshedPool
+      ? `已自动轮换 ${attempts} 个 API 节点，并刷新 IP 池后重试，仍不可用。`
+      : `已自动轮换 ${attempts} 个 API 节点但仍不可用。`;
+    const currentError = String(latestStatus.error || '').trim();
+    latestStatus = {
+      ...latestStatus,
+      error: currentError
+        ? `${currentError} ${suffix}`
+        : suffix,
+    };
+  }
+
+  return { recovered: false, attempts, status: latestStatus };
+}
+
+async function probeIpProxyExit(options = {}) {
+  const state = options.state || await getState();
+  if (!state?.ipProxyEnabled) {
+    const status = {
+      enabled: false,
+      applied: false,
+      reason: 'disabled',
+      provider: normalizeIpProxyProviderValue(state?.ipProxyService),
+      exitDetecting: false,
+      exitIp: '',
+      exitRegion: '',
+      exitError: '',
+      error: '',
+    };
+    await updateIpProxyRuntimeStatus(status);
+    return { proxyRouting: status };
+  }
+
+  const mode = normalizeIpProxyMode(state?.ipProxyMode);
+  const provider = normalizeIpProxyProviderValue(state?.ipProxyService);
+  const entry = getIpProxyCurrentEntryFromState(state);
+  if (!entry) {
+    const status = {
+      enabled: true,
+      applied: false,
+      reason: 'missing_proxy_entry',
+      provider,
+      error: mode === 'account'
+        ? getAccountListParseFailureHint(state, provider)
+        : '',
+      exitDetecting: false,
+      exitIp: '',
+      exitRegion: '',
+      exitError: '',
+    };
+    await updateIpProxyRuntimeStatus(status);
+    return { proxyRouting: status };
+  }
+
+  installIpProxyAuthListener();
+  installIpProxyErrorListener();
+  resetIpProxyRuntimeErrorDiagnostics();
+  currentIpProxyAuthEntry = entry?.username
+    ? {
+        host: entry.host,
+        port: entry.port,
+        username: entry.username,
+        password: String(entry.password || ''),
+      }
+    : null;
+
+  const probingStatus = {
+    enabled: true,
+    applied: true,
+    reason: String(state?.ipProxyAppliedReason || 'applied'),
+    host: entry.host,
+    port: entry.port,
+    region: entry.region,
+    username: String(entry.username || '').trim(),
+    entrySource: resolveIpProxyAccountEntrySource(state, mode),
+    hasAuth: Boolean(entry.username || entry.password),
+    provider: normalizeIpProxyProviderValue(entry.provider || state?.ipProxyService),
+    error: String(state?.ipProxyAppliedError || ''),
+    exitDetecting: true,
+    exitIp: '',
+    exitRegion: '',
+    exitError: '',
+    exitSource: '',
+  };
+  // 上一轮连通性失败会启用 fail-close 规则，手动检测前先解除，避免自阻断影响探测。
+  await setIpProxyLeakGuardEnabled(false);
+  await updateIpProxyRuntimeStatus(probingStatus);
+
+  const runProbeRound = async (statusSeed = probingStatus, timeoutMs = Number(options?.timeoutMs) || 10000) => {
+    const diagnostics = [];
+    resetIpProxyAuthDiagnostics();
+    const exit = await detectProxyExitInfo({
+      timeoutMs,
+      errors: diagnostics,
+      provider: statusSeed?.provider || probingStatus?.provider || provider,
+      username: statusSeed?.username || probingStatus?.username || '',
+      // 手动探测与自动应用保持一致：先页面上下文，再后台补充。
+      preferPageContext: true,
+      allowBackgroundFallback: true,
+    }).catch(() => ({ ip: '', region: '' }));
+    if (!exit?.ip && Boolean(statusSeed?.hasAuth)) {
+      appendIpProxyAuthDiagnosticsToErrors(diagnostics);
+      if (typeof addLog === 'function') {
+        await addLog(`代理出口探测失败：${buildProbeDiagnosticsSummary(diagnostics, IP_PROXY_DIAGNOSTICS_SUMMARY_MAX_ITEMS)}`, 'warn').catch(() => {});
+      }
+    }
+    const finalStatus = {
+      ...statusSeed,
+      exitDetecting: false,
+      exitIp: String(exit?.ip || '').trim(),
+      exitRegion: String(exit?.region || '').trim(),
+      exitBaselineIp: String(exit?.baselineIp || '').trim(),
+      exitError: exit?.ip ? '' : buildProbeDiagnosticsSummary(diagnostics, IP_PROXY_DIAGNOSTICS_SUMMARY_MAX_ITEMS),
+      exitSource: String(exit?.source || '').trim().toLowerCase(),
+      authDiagnostics: statusSeed?.hasAuth ? getIpProxyAuthDiagnosticsSummary() : '',
+    };
+    const expectedRegion = String(statusSeed?.region || '').trim();
+    let normalized = applyExitRegionExpectation(finalStatus, expectedRegion);
+    normalized = applyExitBaselineExpectation(normalized);
+    return normalized;
+  };
+
+  let normalizedFinalStatus = await runProbeRound(probingStatus, Number(options?.timeoutMs) || 10000);
+  const parsedAuthSummary = parseIpProxyAuthDiagnosticsSummary(String(normalizedFinalStatus?.authDiagnostics || ''));
+  const missingAuthChallenge = Boolean(normalizedFinalStatus?.hasAuth)
+    && parsedAuthSummary
+    && parsedAuthSummary.challenge <= 0
+    && parsedAuthSummary.provided <= 0;
+  const shouldRetryAuthRebind = mode === 'account'
+    && provider === '711proxy'
+    && Boolean(String(entry?.username || '').trim())
+    && missingAuthChallenge
+    && options?.authRebindRetry !== false;
+
+  if (shouldRetryAuthRebind) {
+    const maxRebindAttempts = Math.max(1, Math.min(3, Number(options?.authRebindMaxAttempts) || 2));
+    for (let attempt = 0; attempt < maxRebindAttempts; attempt += 1) {
+      if (typeof addLog === 'function') {
+        const hint = attempt === 0 ? '首次重绑复测' : `第 ${attempt + 1} 次重绑复测`;
+        await addLog(`检测到代理链路未触发 407 挑战，正在执行${hint}。`, 'info').catch(() => {});
+      }
+      const latestBeforeRebind = await getState();
+      const reboundStatus = await applyIpProxySettingsFromState(latestBeforeRebind, {
+        skipExitProbe: true,
+        resetNetworkState: true,
+        forceAuthRebind: true,
+      }).catch(() => null);
+      const latestAfterRebind = await getState();
+      const reboundEntry = getIpProxyCurrentEntryFromState(latestAfterRebind);
+      if (!reboundStatus?.applied || !reboundEntry?.host || !reboundEntry?.port) {
+        break;
+      }
+      currentIpProxyAuthEntry = reboundEntry?.username
+        ? {
+            host: reboundEntry.host,
+            port: reboundEntry.port,
+            username: reboundEntry.username,
+            password: String(reboundEntry.password || ''),
+          }
+        : null;
+      const retryProbingStatus = {
+        ...probingStatus,
+        reason: String(reboundStatus?.reason || probingStatus.reason || 'applied'),
+        host: reboundEntry.host,
+        port: reboundEntry.port,
+        region: String(reboundEntry.region || '').trim(),
+        username: String(reboundEntry.username || '').trim(),
+        entrySource: resolveIpProxyAccountEntrySource(
+          latestAfterRebind,
+          normalizeIpProxyMode(latestAfterRebind?.ipProxyMode)
+        ),
+        hasAuth: Boolean(reboundEntry.username || reboundEntry.password),
+        provider: normalizeIpProxyProviderValue(reboundEntry.provider || latestAfterRebind?.ipProxyService),
+        error: String(reboundStatus?.error || ''),
+        exitDetecting: true,
+        exitIp: '',
+        exitRegion: '',
+        exitError: '',
+        exitSource: '',
+      };
+      await updateIpProxyRuntimeStatus(retryProbingStatus);
+      normalizedFinalStatus = await runProbeRound(
+        retryProbingStatus,
+        Math.max(9000, Number(options?.timeoutMs) || 10000)
+      );
+      const retryAuthSummary = parseIpProxyAuthDiagnosticsSummary(String(normalizedFinalStatus?.authDiagnostics || ''));
+      const stillMissingChallenge = Boolean(normalizedFinalStatus?.hasAuth)
+        && retryAuthSummary
+        && retryAuthSummary.challenge <= 0
+        && retryAuthSummary.provided <= 0;
+      if (!stillMissingChallenge) {
+        break;
+      }
+    }
+  }
+  if (normalizedFinalStatus.reason === 'connectivity_failed'
+    && normalizeIpProxyMode(state?.ipProxyMode) === 'api') {
+    const recovered = await tryRecoverApiProxyByRotation({
+      maxAttempts: options?.autoRotateMaxAttempts,
+      fallbackStatus: normalizedFinalStatus,
+    });
+    if (recovered?.status) {
+      normalizedFinalStatus = recovered.status;
+    }
+  }
+  if (normalizedFinalStatus.reason === 'connectivity_failed') {
+    await setIpProxyLeakGuardEnabled(true);
+  }
+  await updateIpProxyRuntimeStatus(normalizedFinalStatus);
+  return { proxyRouting: normalizedFinalStatus };
+}
+
+async function ensureIpProxySettingsAppliedFromCurrentState(options = {}) {
+  const state = options.state || await getState();
+  return applyIpProxySettingsFromState(state, options);
+}

--- a/background/ip-proxy-provider-lumiproxy.js
+++ b/background/ip-proxy-provider-lumiproxy.js
@@ -1,0 +1,200 @@
+// background/ip-proxy-provider-lumiproxy.js — LumiProxy 专属参数与账号规则
+(function registerLumiProxyProvider(root) {
+  const HOST_COUNTRY_HINTS = new Set([
+    'us', 'de', 'uk', 'fr', 'nl', 'it', 'es', 'ca', 'au', 'sg', 'jp', 'kr', 'tw', 'hk', 'in', 'br', 'mx',
+  ]);
+
+  function normalizeCountryCode(value = '') {
+    const raw = String(value || '').trim().toLowerCase();
+    if (!raw) return '';
+    const simple = raw.replace(/[^a-z]/g, '');
+    return /^[a-z]{2}$/.test(simple) ? simple : '';
+  }
+
+  function normalizeSessionPrefix(value = '') {
+    return String(value || '').trim().replace(/[^A-Za-z0-9_-]/g, '').slice(0, 32);
+  }
+
+  function normalize711SessionId(value = '') {
+    return String(value || '').trim().replace(/[^A-Za-z0-9_-]/g, '').slice(0, 64);
+  }
+
+  function normalizeLifeMinutes(value = '') {
+    const raw = String(value ?? '').trim();
+    if (!raw) return '';
+    const numeric = Number.parseInt(raw, 10);
+    if (!Number.isInteger(numeric)) return '';
+    return String(Math.max(1, Math.min(1440, numeric)));
+  }
+
+  function normalize711SessionMinutes(value = '') {
+    const raw = String(value ?? '').trim();
+    if (!raw) return '';
+    const numeric = Number.parseInt(raw, 10);
+    if (!Number.isInteger(numeric)) return '';
+    return String(Math.max(1, Math.min(180, numeric)));
+  }
+
+  function normalize711RegionCode(value = '') {
+    return normalizeCountryCode(value);
+  }
+
+  function inferCountryFromHost(host = '') {
+    const normalizedHost = String(host || '').trim().toLowerCase();
+    if (!normalizedHost || !normalizedHost.endsWith('.lumiproxy.io')) {
+      return '';
+    }
+    const prefix = normalizedHost.split('.')[0] || '';
+    return HOST_COUNTRY_HINTS.has(prefix) ? prefix : '';
+  }
+
+  function inferAreaFromUsername(username = '') {
+    const text = String(username || '').trim().toLowerCase();
+    if (!text) return '';
+    const areaMatch = text.match(/(?:^|[-_])area[-_:]?([a-z]{2})\b/i);
+    if (areaMatch) {
+      return String(areaMatch[1] || '').toLowerCase();
+    }
+    const countryMatch = text.match(/(?:^|[-_])country[-_:]?([a-z]{2})\b/i);
+    return countryMatch ? String(countryMatch[1] || '').toLowerCase() : '';
+  }
+
+  function applyAreaToUsername(username = '', countryCode = '') {
+    const text = String(username || '').trim();
+    const normalizedCode = normalizeCountryCode(countryCode);
+    if (!text || !normalizedCode) {
+      return text;
+    }
+    if (/(?:^|[-_])area[-_:]?[a-z]{2}\b/i.test(text)) {
+      return text.replace(/((?:^|[-_])area[-_:]?)([a-z]{2})\b/i, `$1${normalizedCode.toUpperCase()}`);
+    }
+    if (/(?:^|[-_])country[-_:]?[a-z]{2}\b/i.test(text)) {
+      return text.replace(/((?:^|[-_])country[-_:]?)([a-z]{2})\b/i, `$1${normalizedCode.toUpperCase()}`);
+    }
+    return `${text}_area-${normalizedCode.toUpperCase()}`;
+  }
+
+  function transformLumiProxyAccountEntry(entry = {}, context = {}) {
+    const state = context?.state || {};
+    const index = Number.isInteger(context?.index) ? context.index : 0;
+    const nextEntry = { ...entry };
+    const configuredRegion = String(state?.ipProxyRegion || '').trim();
+    const entryRegion = String(nextEntry.region || '').trim();
+    const effectiveRegion = entryRegion || configuredRegion;
+    const hostCountry = inferCountryFromHost(nextEntry.host);
+    const regionCountry = normalizeCountryCode(effectiveRegion);
+    const usernameCountry = inferAreaFromUsername(nextEntry.username);
+    const countryCode = hostCountry || regionCountry || usernameCountry;
+
+    if (nextEntry.username && countryCode) {
+      nextEntry.username = applyAreaToUsername(nextEntry.username, countryCode);
+      nextEntry.region = countryCode.toUpperCase();
+    } else if (!entryRegion && configuredRegion) {
+      nextEntry.region = configuredRegion;
+    }
+
+    const sessionPrefix = normalizeSessionPrefix(state?.ipProxyAccountSessionPrefix || '');
+    const lifeMinutes = normalizeLifeMinutes(state?.ipProxyAccountLifeMinutes || '');
+    if (nextEntry.username && sessionPrefix && !/session[-:]/i.test(nextEntry.username)) {
+      const suffix = `${sessionPrefix}-${String(index + 1).padStart(2, '0')}`;
+      nextEntry.username = `${nextEntry.username}-session-${suffix}${lifeMinutes ? `-life-${lifeMinutes}` : ''}`;
+      if (!nextEntry.region && sessionPrefix) {
+        nextEntry.region = `session:${suffix}`;
+      }
+    } else if (nextEntry.username && lifeMinutes && !/-life-\d+/i.test(nextEntry.username)) {
+      nextEntry.username = `${nextEntry.username}-life-${lifeMinutes}`;
+    }
+    return nextEntry;
+  }
+
+  function apply711SessionToUsername(username = '', options = {}) {
+    const text = String(username || '').trim();
+    if (!text) {
+      return text;
+    }
+    const sessionId = normalize711SessionId(options?.sessionId || '');
+    const sessTime = normalize711SessionMinutes(options?.sessTime || '');
+    let next = text;
+
+    if (sessionId) {
+      if (/(?:^|[-_])session[-_:][A-Za-z0-9_-]+?(?=(?:[-_](?:sessTime|sessAuto|region|life|zone|ptype|country|area)\b)|$)/i.test(next)) {
+        next = next.replace(
+          /((?:^|[-_])session[-_:])([A-Za-z0-9_-]+?)(?=(?:[-_](?:sessTime|sessAuto|region|life|zone|ptype|country|area)\b)|$)/i,
+          `$1${sessionId}`
+        );
+      } else {
+        next = `${next}-session-${sessionId}`;
+      }
+    }
+
+    if (sessTime) {
+      if (/(?:^|[-_])sessTime[-_:]?\d+\b/i.test(next)) {
+        next = next.replace(/((?:^|[-_])sessTime[-_:]?)(\d+)\b/i, `$1${sessTime}`);
+      } else {
+        next = `${next}-sessTime-${sessTime}`;
+      }
+    }
+    return next;
+  }
+
+  function apply711RegionToUsername(username = '', regionCode = '') {
+    const text = String(username || '').trim();
+    const normalizedRegion = normalize711RegionCode(regionCode);
+    if (!text || !normalizedRegion) {
+      return text;
+    }
+    if (/(?:^|[-_])region[-_:]?[A-Za-z]{2}\b/i.test(text)) {
+      return text.replace(/((?:^|[-_])region[-_:]?)([A-Za-z]{2})\b/i, `$1${normalizedRegion.toUpperCase()}`);
+    }
+    return `${text}-region-${normalizedRegion.toUpperCase()}`;
+  }
+
+  function transform711ProxyAccountEntry(entry = {}, context = {}) {
+    const state = context?.state || {};
+    const hasAccountList = Boolean(context?.hasAccountList);
+    const nextEntry = { ...entry };
+    if (!String(nextEntry.username || '').trim()) {
+      return nextEntry;
+    }
+
+    const configuredRegion = normalize711RegionCode(state?.ipProxyRegion || '');
+    if (!hasAccountList && configuredRegion) {
+      nextEntry.username = apply711RegionToUsername(nextEntry.username, configuredRegion);
+      if (!String(nextEntry.region || '').trim()) {
+        nextEntry.region = configuredRegion.toUpperCase();
+      }
+    }
+
+    // 账号列表模式下，按每行条目原样生效，不再叠加固定账号区的 session/sessTime。
+    if (hasAccountList) {
+      return nextEntry;
+    }
+
+    const sessionId = normalize711SessionId(state?.ipProxyAccountSessionPrefix || '');
+    const sessTime = normalize711SessionMinutes(state?.ipProxyAccountLifeMinutes || '');
+    if (!sessionId && !sessTime) {
+      return nextEntry;
+    }
+
+    nextEntry.username = apply711SessionToUsername(nextEntry.username, {
+      sessionId,
+      sessTime,
+    });
+    return nextEntry;
+  }
+
+  root.transformIpProxyAccountEntryByProvider = function transformIpProxyAccountEntryByProvider(
+    provider = '',
+    entry = {},
+    context = {}
+  ) {
+    const normalizedProvider = String(provider || '').trim().toLowerCase();
+    if (normalizedProvider === 'lumiproxy') {
+      return transformLumiProxyAccountEntry(entry, context);
+    }
+    if (normalizedProvider === '711proxy') {
+      return transform711ProxyAccountEntry(entry, context);
+    }
+    return entry;
+  };
+})(typeof self !== 'undefined' ? self : globalThis);

--- a/background/message-router.js
+++ b/background/message-router.js
@@ -10,6 +10,7 @@
       buildLuckmailSessionSettingsPayload,
       buildPersistentSettingsPayload,
       broadcastDataUpdate,
+      applyIpProxySettingsFromState,
       cancelScheduledAutoRun,
       checkIcloudSession,
       clearAccountRunHistory,
@@ -58,6 +59,7 @@
       launchAutoRunTimerPlan,
       listIcloudAliases,
       listLuckmailPurchasesForManagement,
+      refreshIpProxyPool,
       normalizeHotmailAccounts,
       normalizeMail2925Accounts,
       normalizeRunCount,
@@ -69,11 +71,14 @@
       pollContributionStatus,
       registerTab,
       requestStop,
+      probeIpProxyExit,
       handleCloudflareSecurityBlocked,
       resetState,
       resumeAutoRun,
       scheduleAutoRun,
       selectLuckmailPurchase,
+      switchIpProxy,
+      changeIpProxyExit,
       setCurrentMail2925Account,
       setCurrentHotmailAccount,
       setContributionMode,
@@ -644,6 +649,19 @@
             stateUpdates.currentStep = 0;
           }
           await setState(stateUpdates);
+          const mergedState = await getState();
+          const hasIpProxyUpdates = Object.keys(updates).some((key) => key.startsWith('ipProxy'));
+          let proxyRouting = null;
+          if (hasIpProxyUpdates && typeof applyIpProxySettingsFromState === 'function') {
+            proxyRouting = await applyIpProxySettingsFromState(mergedState, {
+              skipExitProbe: true,
+              resetNetworkState: false,
+            }).catch((error) => ({
+              applied: false,
+              reason: 'apply_failed',
+              error: error?.message || String(error || '代理应用失败'),
+            }));
+          }
           if (Boolean(currentState?.contributionMode) && typeof setContributionMode === 'function') {
             await setContributionMode(true);
           }
@@ -655,7 +673,50 @@
               'info'
             );
           }
-          return { ok: true, state: await getState() };
+          return { ok: true, state: await getState(), proxyRouting };
+        }
+
+        case 'REFRESH_IP_PROXY_POOL': {
+          if (typeof refreshIpProxyPool !== 'function') {
+            throw new Error('IP 代理池能力尚未接入。');
+          }
+          const result = await refreshIpProxyPool({
+            maxItems: message.payload?.maxItems,
+            mode: message.payload?.mode,
+          });
+          return { ok: true, ...result };
+        }
+
+        case 'SWITCH_IP_PROXY': {
+          if (typeof switchIpProxy !== 'function') {
+            throw new Error('IP 代理切换能力尚未接入。');
+          }
+          const result = await switchIpProxy(message.payload?.direction || 'next', {
+            maxItems: message.payload?.maxItems,
+            mode: message.payload?.mode,
+            forceRefresh: message.payload?.forceRefresh,
+          });
+          return { ok: true, ...result };
+        }
+
+        case 'CHANGE_IP_PROXY_EXIT': {
+          if (typeof changeIpProxyExit !== 'function') {
+            throw new Error('IP 代理 Change 能力尚未接入。');
+          }
+          const result = await changeIpProxyExit({
+            mode: message.payload?.mode,
+          });
+          return { ok: true, ...result };
+        }
+
+        case 'PROBE_IP_PROXY_EXIT': {
+          if (typeof probeIpProxyExit !== 'function') {
+            throw new Error('IP 代理出口检测能力尚未接入。');
+          }
+          const result = await probeIpProxyExit({
+            timeoutMs: message.payload?.timeoutMs,
+          });
+          return { ok: true, ...result };
         }
 
         case 'EXPORT_SETTINGS': {

--- a/docs/ip-proxy-module.md
+++ b/docs/ip-proxy-module.md
@@ -1,0 +1,131 @@
+# IP Proxy 模块说明（Ultra1 集成版）
+
+## 1. 模块定位
+
+`IP Proxy` 是扩展内的网络出口接管模块，用于把自动化流程的页面访问链路切到指定代理节点，并在侧边栏内可视化展示当前代理与出口状态。
+
+本模块目标是解决三件事：
+
+1. 在扩展内统一配置和切换代理，而不是依赖浏览器外部全局代理。
+2. 对“代理已配置但未真正接管/未真正出站”的情况进行显式诊断。
+3. 在自动化流程中可控地切换出口，降低单节点波动影响。
+
+## 2. 代码结构
+
+### 2.1 Background（核心逻辑）
+
+- `background/ip-proxy-core.js`
+  - 代理池解析与运行态管理
+  - 应用/清除代理配置
+  - 出口探测与状态诊断
+  - `SYNC/NEXT/CHANGE/PROBE` 主流程
+- `background/ip-proxy-provider-lumiproxy.js`
+  - Provider 级别参数处理（当前重点是 711 账号串 token 规则）
+- `background/message-router.js`
+  - 暴露消息接口：
+    - `REFRESH_IP_PROXY_POOL`
+    - `SWITCH_IP_PROXY`
+    - `CHANGE_IP_PROXY_EXIT`
+    - `PROBE_IP_PROXY_EXIT`
+- `background.js`
+  - 持久化字段定义与默认值
+  - 启动恢复时的代理状态接管
+  - 自动运行成功后的代理切换钩子
+
+### 2.2 Sidepanel（界面与交互）
+
+- `sidepanel/ip-proxy-panel.js`
+  - 代理 UI 状态渲染
+  - 按钮行为（同步/下一条/Change/检测出口）
+  - 运行态文案和诊断详情展示
+  - 711 账号参数双向同步（`session/sessTime/region`）
+- `sidepanel/ip-proxy-provider-lumiproxy.js`
+  - Provider 级输入辅助（地区推断）
+- `sidepanel/sidepanel.html`
+  - 代理区块 UI
+- `sidepanel/sidepanel.css`
+  - 代理区块样式
+- `sidepanel/sidepanel.js`
+  - 与设置保存流整合、事件绑定
+
+## 3. 当前功能范围（本 PR）
+
+### 3.1 基础能力
+
+1. 启用/禁用代理接管（PAC + 认证回填）。
+2. 固定账号模式（Host/Port/Username/Password/Region）。
+3. 出口探测与状态卡（当前代理、当前出口、诊断详情）。
+4. 四个动作按钮：
+   - `同步`：应用当前配置并刷新运行态
+   - `下一条`：切到下一个可用节点
+   - `Change`：保持 session 的前提下重绑并换出口（711）
+   - `检测出口`：只做出口复测，不改节点
+5. `检查IP`：打开 `https://ipinfo.io/what-is-my-ip`
+
+### 3.2 711 账号串参数联动
+
+支持从用户名中识别并回填：
+
+- `session-xxxx`
+- `sessTime-xx`（兼容 `life-xx`）
+- `region-XX`
+
+支持从表单回写到用户名：
+
+- 修改会话值 -> 更新 `session-*`
+- 修改时长 -> 更新 `sessTime-*`
+- 修改地区 -> 更新 `region-*`
+
+### 3.3 同步后的自动复测
+
+为避免“同步后还要手动点检测出口”：
+
+- `同步/下一条/Change` 执行完成后，自动追加一次静默 `检测出口`。
+
+## 4. 当前发布策略（为了稳定）
+
+本 PR 是“先可用，再扩展”的第一阶段：
+
+1. 服务商主路径按 `711` 优先。
+2. `API 模式`在 UI 中保留但禁用（暂未开放）。
+3. `账号列表模式`目前关闭（防止多条目与鉴权缓存复用带来的不稳定）。
+
+对应开关位于：
+
+- `sidepanel/sidepanel.js`：`IP_PROXY_API_MODE_ENABLED = false`
+- `sidepanel/sidepanel.js`：`IP_PROXY_ACCOUNT_LIST_ENABLED = false`
+- `background.js`：`IP_PROXY_ACCOUNT_LIST_ENABLED = false`
+
+## 5. 使用方式（操作步骤）
+
+1. 打开侧边栏 `IP代理` 开关。
+2. 选择账号模式，填写：
+   - Host
+   - Port
+   - Username
+   - Password
+   - Region（可选）
+3. 点击 `同步`。
+4. 查看状态卡：
+   - 当前代理
+   - 当前出口
+   - 是否有校验提示
+5. 需要换出口时：
+   - 711 + session 场景优先用 `Change`
+   - 或使用 `下一条`
+6. 需要手动复核时点击 `检测出口` 或 `检查IP`。
+
+## 6. 已知限制
+
+1. 某些代理链路不会返回标准 `407`，扩展无法触发认证回填，这类链路可能不稳定。
+2. 地区“期望值”和“实际出口”不一致时，模块会保留接管并提示校验告警（不直接判定全失败）。
+3. 不同探测源（页面探测/后台兜底）在网络波动时可能短时出现差异，状态卡会显示来源与诊断。
+
+## 7. 回归建议
+
+建议至少覆盖以下场景：
+
+1. 固定账号：启用 -> 同步 -> 出口检测成功。
+2. 固定账号：`session/sessTime/region` 双向同步正确。
+3. 固定账号：`同步/下一条/Change` 后无需手动点检测即可刷新出口状态。
+4. 非标准链路失败时，诊断信息可读且不误报“已接管成功”。

--- a/sidepanel/ip-proxy-panel.js
+++ b/sidepanel/ip-proxy-panel.js
@@ -1,0 +1,1509 @@
+// sidepanel/ip-proxy-panel.js — IP代理面板（轻量解耦）
+function normalizeIpProxyService(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  return SUPPORTED_IP_PROXY_SERVICES.includes(normalized) ? normalized : DEFAULT_IP_PROXY_SERVICE;
+}
+
+const ipProxyActionState = {
+  busy: false,
+  action: '',
+};
+
+function normalizeIpProxyActionType(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  return normalized || 'action';
+}
+
+function getIpProxyActionLabel(action = '') {
+  const normalized = normalizeIpProxyActionType(action);
+  if (normalized === 'refresh') return '同步代理';
+  if (normalized === 'next') return '切换代理';
+  if (normalized === 'change') return '会话换出口';
+  if (normalized === 'probe') return '检测出口';
+  return '代理操作';
+}
+
+function isIpProxyActionBusy() {
+  return Boolean(ipProxyActionState.busy);
+}
+
+function getIpProxyActionState() {
+  return {
+    busy: Boolean(ipProxyActionState.busy),
+    action: normalizeIpProxyActionType(ipProxyActionState.action),
+  };
+}
+
+function setIpProxyActionBusy(action = '', busy = false) {
+  ipProxyActionState.busy = Boolean(busy);
+  ipProxyActionState.action = ipProxyActionState.busy ? normalizeIpProxyActionType(action) : '';
+}
+
+async function runIpProxyActionWithLock(action = '', runner) {
+  if (typeof runner !== 'function') {
+    throw new Error('代理操作执行器无效。');
+  }
+  const nextAction = normalizeIpProxyActionType(action);
+  const currentState = getIpProxyActionState();
+  if (currentState.busy) {
+    if (typeof showToast === 'function') {
+      showToast(`${getIpProxyActionLabel(currentState.action)}进行中，请稍候。`, 'info', 1600);
+    }
+    return { skipped: true };
+  }
+
+  setIpProxyActionBusy(nextAction, true);
+  if (typeof updateIpProxyUI === 'function') {
+    updateIpProxyUI(latestState);
+  }
+
+  try {
+    const value = await runner();
+    return { skipped: false, value };
+  } finally {
+    setIpProxyActionBusy(nextAction, false);
+    if (typeof updateIpProxyUI === 'function') {
+      updateIpProxyUI(latestState);
+    }
+  }
+}
+
+function normalizeIpProxyMode(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  return SUPPORTED_IP_PROXY_MODES.includes(normalized) ? normalized : DEFAULT_IP_PROXY_MODE;
+}
+
+function isIpProxyApiModeAvailable() {
+  return Boolean(typeof IP_PROXY_API_MODE_ENABLED === 'undefined'
+    ? false
+    : IP_PROXY_API_MODE_ENABLED);
+}
+
+function isIpProxyAccountListAvailable() {
+  return Boolean(typeof IP_PROXY_ACCOUNT_LIST_ENABLED === 'undefined'
+    ? true
+    : IP_PROXY_ACCOUNT_LIST_ENABLED);
+}
+
+function normalizeIpProxyModeForCurrentRelease(value = '') {
+  const normalized = normalizeIpProxyMode(value);
+  if (!isIpProxyApiModeAvailable() && normalized === 'api') {
+    return 'account';
+  }
+  return normalized;
+}
+
+function normalizeIpProxyProtocol(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  return SUPPORTED_IP_PROXY_PROTOCOLS.includes(normalized) ? normalized : DEFAULT_IP_PROXY_PROTOCOL;
+}
+
+function normalizeIpProxyPort(value = '') {
+  const numeric = Number.parseInt(String(value || '').trim(), 10);
+  if (!Number.isInteger(numeric) || numeric <= 0 || numeric > 65535) {
+    return 0;
+  }
+  return numeric;
+}
+
+function normalizeIpProxyPoolTargetCount(value = '', fallback = 20) {
+  const rawValue = String(value ?? '').trim();
+  if (!rawValue) {
+    return String(Math.max(1, Math.min(500, Number(fallback) || 20)));
+  }
+  const numeric = Number.parseInt(rawValue, 10);
+  if (!Number.isInteger(numeric)) {
+    return String(Math.max(1, Math.min(500, Number(fallback) || 20)));
+  }
+  return String(Math.max(1, Math.min(500, numeric)));
+}
+
+function normalizeIpProxyAccountLifeMinutes(value = '', fallback = '') {
+  const rawValue = String(value ?? '').trim();
+  if (!rawValue) {
+    return String(fallback || '').trim();
+  }
+  const numeric = Number.parseInt(rawValue, 10);
+  if (!Number.isInteger(numeric)) {
+    return String(fallback || '').trim();
+  }
+  return String(Math.max(1, Math.min(1440, numeric)));
+}
+
+function normalizeIpProxyAccountSessionPrefix(value = '') {
+  return String(value || '').trim().replace(/[^A-Za-z0-9_-]/g, '').slice(0, 32);
+}
+
+function normalizeIpProxyAccountList(value = '') {
+  return String(value || '')
+    .replace(/\r/g, '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join('\n');
+}
+
+function normalizeIpProxyServiceProfile(rawValue = {}) {
+  const raw = (rawValue && typeof rawValue === 'object' && !Array.isArray(rawValue))
+    ? rawValue
+    : {};
+  return {
+    mode: normalizeIpProxyModeForCurrentRelease(raw.mode),
+    apiUrl: String(raw.apiUrl || '').trim(),
+    accountList: normalizeIpProxyAccountList(raw.accountList || ''),
+    accountSessionPrefix: normalizeIpProxyAccountSessionPrefix(raw.accountSessionPrefix || ''),
+    accountLifeMinutes: normalizeIpProxyAccountLifeMinutes(raw.accountLifeMinutes || ''),
+    poolTargetCount: normalizeIpProxyPoolTargetCount(raw.poolTargetCount || '', 20),
+    host: String(raw.host || '').trim(),
+    port: String(normalizeIpProxyPort(raw.port || '') || ''),
+    protocol: normalizeIpProxyProtocol(raw.protocol),
+    username: String(raw.username || '').trim(),
+    password: String(raw.password || ''),
+    region: String(raw.region || '').trim(),
+  };
+}
+
+function buildIpProxyServiceProfileFromFlatState(state = {}) {
+  return normalizeIpProxyServiceProfile({
+    mode: state?.ipProxyMode,
+    apiUrl: state?.ipProxyApiUrl,
+    accountList: state?.ipProxyAccountList,
+    accountSessionPrefix: state?.ipProxyAccountSessionPrefix,
+    accountLifeMinutes: state?.ipProxyAccountLifeMinutes,
+    poolTargetCount: state?.ipProxyPoolTargetCount,
+    host: state?.ipProxyHost,
+    port: state?.ipProxyPort,
+    protocol: state?.ipProxyProtocol,
+    username: state?.ipProxyUsername,
+    password: state?.ipProxyPassword,
+    region: state?.ipProxyRegion,
+  });
+}
+
+function normalizeIpProxyServiceProfiles(rawValue = {}, fallbackState = {}) {
+  const raw = (rawValue && typeof rawValue === 'object' && !Array.isArray(rawValue))
+    ? rawValue
+    : {};
+  const fallbackProfile = buildIpProxyServiceProfileFromFlatState(fallbackState);
+  const result = {};
+  SUPPORTED_IP_PROXY_SERVICES.forEach((service) => {
+    const serviceRaw = raw[service];
+    if (serviceRaw && typeof serviceRaw === 'object' && !Array.isArray(serviceRaw)) {
+      result[service] = normalizeIpProxyServiceProfile(serviceRaw);
+      return;
+    }
+    result[service] = normalizeIpProxyServiceProfile(fallbackProfile);
+  });
+  return result;
+}
+
+function getIpProxyServiceProfilesFromState(state = latestState) {
+  return normalizeIpProxyServiceProfiles(state?.ipProxyServiceProfiles || {}, state || {});
+}
+
+function getIpProxyServiceProfile(service = '', state = latestState) {
+  const selectedService = normalizeIpProxyService(service || state?.ipProxyService || DEFAULT_IP_PROXY_SERVICE);
+  const profiles = getIpProxyServiceProfilesFromState(state);
+  const profile = normalizeIpProxyServiceProfile(profiles[selectedService] || {});
+  const resolvedRegion = resolveIpProxyRegionFromInputs({
+    service: selectedService,
+    mode: profile.mode,
+    host: profile.host,
+    username: profile.username,
+    region: profile.region,
+  });
+  if (resolvedRegion) {
+    profile.region = resolvedRegion;
+  }
+  return profile;
+}
+
+function inferRegionFromProxyUsernameForPanel(username = '') {
+  const text = String(username || '').trim();
+  if (!text) return '';
+  const match = text.match(/(?:^|[-_])(?:region|area|country)[-_:]?([A-Za-z]{2})\b/i);
+  if (!match) return '';
+  return String(match[1] || '').trim().toUpperCase();
+}
+
+function inferRegionFromProxyHostForPanel(host = '') {
+  const text = String(host || '').trim().toLowerCase().replace(/\.$/, '');
+  if (!text || !text.includes('.')) return '';
+  const firstLabel = String(text.split('.')[0] || '').trim();
+  if (!/^[a-z]{2}$/.test(firstLabel)) return '';
+  return firstLabel.toUpperCase();
+}
+
+function normalizeExplicitRegionForPanel(region = '') {
+  const text = String(region || '').trim().toUpperCase().replace(/[^A-Z]/g, '');
+  return /^[A-Z]{2}$/.test(text) ? text : '';
+}
+
+function resolveIpProxyRegionFromInputs(options = {}) {
+  const selectedService = normalizeIpProxyService(options?.service || DEFAULT_IP_PROXY_SERVICE);
+  const selectedMode = normalizeIpProxyModeForCurrentRelease(options?.mode || DEFAULT_IP_PROXY_MODE);
+  if (selectedMode !== 'account') {
+    return '';
+  }
+
+  const host = String(options?.host || '').trim();
+  const username = String(options?.username || '').trim();
+  const region = String(options?.region || '').trim();
+  if (selectedService === 'lumiproxy') {
+    const resolvedCode = typeof resolveLumiProxyCountryFromInputs === 'function'
+      ? resolveLumiProxyCountryFromInputs({ host, username, region })
+      : '';
+    if (resolvedCode) {
+      return String(resolvedCode || '').trim().toUpperCase();
+    }
+  }
+
+  const fromUsername = inferRegionFromProxyUsernameForPanel(username);
+  if (fromUsername) {
+    return fromUsername;
+  }
+  const fromHost = inferRegionFromProxyHostForPanel(host);
+  if (fromHost) {
+    return fromHost;
+  }
+  return normalizeExplicitRegionForPanel(region);
+}
+
+function hasCurrentInputAccountListEntries() {
+  if (!isIpProxyAccountListAvailable()) {
+    return false;
+  }
+  return normalizeIpProxyAccountList(inputIpProxyAccountList?.value || '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .length > 0;
+}
+
+function syncIpProxyRegionInputFromCredentials(options = {}) {
+  if (!inputIpProxyRegion) {
+    return '';
+  }
+  const selectedService = normalizeIpProxyService(
+    selectIpProxyService?.value || latestState?.ipProxyService || DEFAULT_IP_PROXY_SERVICE
+  );
+  const selectedMode = normalizeIpProxyModeForCurrentRelease(getSelectedIpProxyMode());
+  if (selectedMode !== 'account' || hasCurrentInputAccountListEntries()) {
+    return '';
+  }
+  const force = Boolean(options?.force);
+  const currentRegion = String(inputIpProxyRegion.value || '').trim();
+  const resolvedRegion = resolveIpProxyRegionFromInputs({
+    service: selectedService,
+    mode: selectedMode,
+    host: inputIpProxyHost?.value || '',
+    username: inputIpProxyUsername?.value || '',
+    region: currentRegion,
+  });
+  if (!resolvedRegion) {
+    return '';
+  }
+  const normalizedCurrent = normalizeExplicitRegionForPanel(currentRegion);
+  if (force || !normalizedCurrent) {
+    inputIpProxyRegion.value = resolvedRegion;
+  }
+  return resolvedRegion;
+}
+
+function buildCurrentIpProxyServiceProfileFromInputs() {
+  const selectedService = normalizeIpProxyService(
+    selectIpProxyService?.value || latestState?.ipProxyService || DEFAULT_IP_PROXY_SERVICE
+  );
+  const selectedMode = normalizeIpProxyMode(getSelectedIpProxyMode());
+  const effectiveMode = normalizeIpProxyModeForCurrentRelease(selectedMode);
+  const rawRegion = String(inputIpProxyRegion?.value || '').trim();
+  const finalRegion = resolveIpProxyRegionFromInputs({
+    service: selectedService,
+    mode: effectiveMode,
+    host: inputIpProxyHost?.value || '',
+    username: inputIpProxyUsername?.value || '',
+    region: rawRegion,
+  }) || rawRegion;
+  return normalizeIpProxyServiceProfile({
+    mode: effectiveMode,
+    apiUrl: inputIpProxyApiUrl?.value || '',
+    accountList: isIpProxyAccountListAvailable() ? (inputIpProxyAccountList?.value || '') : '',
+    accountSessionPrefix: inputIpProxyAccountSessionPrefix?.value || '',
+    accountLifeMinutes: inputIpProxyAccountLifeMinutes?.value || '',
+    poolTargetCount: inputIpProxyPoolTargetCount?.value || '',
+    host: inputIpProxyHost?.value || '',
+    port: inputIpProxyPort?.value || '',
+    protocol: selectIpProxyProtocol?.value || '',
+    username: inputIpProxyUsername?.value || '',
+    password: inputIpProxyPassword?.value || '',
+    region: finalRegion,
+  });
+}
+
+function buildIpProxyServiceProfilesPatch(selectedService = '', state = latestState) {
+  const nextService = normalizeIpProxyService(
+    selectedService
+    || selectIpProxyService?.value
+    || state?.ipProxyService
+    || DEFAULT_IP_PROXY_SERVICE
+  );
+  const profiles = getIpProxyServiceProfilesFromState(state || {});
+  profiles[nextService] = buildCurrentIpProxyServiceProfileFromInputs();
+  return normalizeIpProxyServiceProfiles(profiles, state || {});
+}
+
+function buildIpProxyStatePatchFromServiceProfile(service = '', profile = {}) {
+  const normalizedService = normalizeIpProxyService(service || DEFAULT_IP_PROXY_SERVICE);
+  const normalizedProfile = normalizeIpProxyServiceProfile(profile);
+  return {
+    ipProxyService: normalizedService,
+    ipProxyMode: normalizedProfile.mode,
+    ipProxyApiUrl: normalizedProfile.apiUrl,
+    ipProxyAccountList: normalizedProfile.accountList,
+    ipProxyAccountSessionPrefix: normalizedProfile.accountSessionPrefix,
+    ipProxyAccountLifeMinutes: normalizedProfile.accountLifeMinutes,
+    ipProxyPoolTargetCount: normalizedProfile.poolTargetCount,
+    ipProxyHost: normalizedProfile.host,
+    ipProxyPort: normalizedProfile.port,
+    ipProxyProtocol: normalizedProfile.protocol,
+    ipProxyUsername: normalizedProfile.username,
+    ipProxyPassword: normalizedProfile.password,
+    ipProxyRegion: normalizedProfile.region,
+  };
+}
+
+function applyIpProxyServiceProfileToInputs(profile = {}, options = {}) {
+  const { keepMode = false } = options;
+  const normalizedProfile = normalizeIpProxyServiceProfile(profile);
+  if (!keepMode) {
+    setIpProxyMode(normalizedProfile.mode);
+  }
+  if (inputIpProxyApiUrl) {
+    inputIpProxyApiUrl.value = normalizedProfile.apiUrl;
+  }
+  if (inputIpProxyAccountList) {
+    inputIpProxyAccountList.value = normalizedProfile.accountList;
+  }
+  if (inputIpProxyAccountSessionPrefix) {
+    inputIpProxyAccountSessionPrefix.value = normalizedProfile.accountSessionPrefix;
+  }
+  if (inputIpProxyAccountLifeMinutes) {
+    inputIpProxyAccountLifeMinutes.value = normalizedProfile.accountLifeMinutes;
+  }
+  if (inputIpProxyPoolTargetCount) {
+    inputIpProxyPoolTargetCount.value = normalizedProfile.poolTargetCount;
+  }
+  if (inputIpProxyHost) {
+    inputIpProxyHost.value = normalizedProfile.host;
+  }
+  if (inputIpProxyPort) {
+    inputIpProxyPort.value = normalizedProfile.port;
+  }
+  if (selectIpProxyProtocol) {
+    selectIpProxyProtocol.value = normalizedProfile.protocol;
+  }
+  if (inputIpProxyUsername) {
+    inputIpProxyUsername.value = normalizedProfile.username;
+  }
+  if (inputIpProxyPassword) {
+    inputIpProxyPassword.value = normalizedProfile.password;
+  }
+  if (inputIpProxyRegion) {
+    inputIpProxyRegion.value = normalizedProfile.region;
+  }
+}
+
+function getSelectedIpProxyEnabled() {
+  if (inputIpProxyEnabled) {
+    return Boolean(inputIpProxyEnabled.checked);
+  }
+  const activeButton = ipProxyEnabledButtons.find((button) => button.classList.contains('is-active'));
+  return String(activeButton?.dataset?.ipProxyEnabled) === 'true';
+}
+
+function setIpProxyEnabled(enabled) {
+  const nextEnabled = Boolean(enabled);
+  if (inputIpProxyEnabled) {
+    inputIpProxyEnabled.checked = nextEnabled;
+  }
+  ipProxyEnabledButtons.forEach((button) => {
+    const buttonValue = String(button?.dataset?.ipProxyEnabled) === 'true';
+    button.classList.toggle('is-active', buttonValue === nextEnabled);
+    button.setAttribute('aria-pressed', String(buttonValue === nextEnabled));
+  });
+}
+
+function getSelectedIpProxyMode() {
+  const activeButton = ipProxyModeButtons.find((button) => button.classList.contains('is-active'));
+  return normalizeIpProxyModeForCurrentRelease(activeButton?.dataset?.ipProxyMode || DEFAULT_IP_PROXY_MODE);
+}
+
+function setIpProxyMode(mode) {
+  const nextMode = normalizeIpProxyModeForCurrentRelease(mode);
+  ipProxyModeButtons.forEach((button) => {
+    const buttonMode = normalizeIpProxyMode(button?.dataset?.ipProxyMode || DEFAULT_IP_PROXY_MODE);
+    button.classList.toggle('is-active', buttonMode === nextMode);
+    button.setAttribute('aria-pressed', String(buttonMode === nextMode));
+  });
+}
+
+function getIpProxyRuntimeFieldNames(mode = DEFAULT_IP_PROXY_MODE) {
+  const normalizedMode = normalizeIpProxyModeForCurrentRelease(mode);
+  if (normalizedMode === 'account') {
+    return {
+      poolKey: 'ipProxyAccountPool',
+      indexKey: 'ipProxyAccountCurrentIndex',
+      currentKey: 'ipProxyAccountCurrent',
+    };
+  }
+  return {
+    poolKey: 'ipProxyApiPool',
+    indexKey: 'ipProxyApiCurrentIndex',
+    currentKey: 'ipProxyApiCurrent',
+  };
+}
+
+function getIpProxyRuntimeSnapshot(state = latestState, mode = normalizeIpProxyModeForCurrentRelease(state?.ipProxyMode)) {
+  const normalizedMode = normalizeIpProxyModeForCurrentRelease(mode);
+  const fields = getIpProxyRuntimeFieldNames(normalizedMode);
+  const hasModePool = Array.isArray(state?.[fields.poolKey]);
+  const hasModeCurrent = state?.[fields.currentKey] !== undefined && state?.[fields.currentKey] !== null;
+  const hasModeIndex = state?.[fields.indexKey] !== undefined && state?.[fields.indexKey] !== null;
+  const modePool = Array.isArray(state?.[fields.poolKey]) ? state[fields.poolKey] : [];
+  const pool = hasModePool ? modePool : [];
+  const current = hasModeCurrent ? state?.[fields.currentKey] : null;
+  const rawIndex = hasModeIndex ? state?.[fields.indexKey] : 0;
+  const index = Number.isFinite(Number(rawIndex)) ? Math.max(0, Math.floor(Number(rawIndex))) : 0;
+  return {
+    mode: normalizedMode,
+    ...fields,
+    hasModePool,
+    hasModeCurrent,
+    hasModeIndex,
+    pool,
+    current,
+    index,
+  };
+}
+
+function buildIpProxyRuntimeStatePatchForMode(mode = DEFAULT_IP_PROXY_MODE, response = {}) {
+  const normalizedMode = normalizeIpProxyModeForCurrentRelease(mode);
+  const fields = getIpProxyRuntimeFieldNames(normalizedMode);
+  const patch = {};
+  if (response?.pool !== undefined) {
+    patch[fields.poolKey] = Array.isArray(response.pool) ? response.pool : [];
+    // 兼容旧字段：始终反映当前激活模式的运行态。
+    patch.ipProxyPool = patch[fields.poolKey];
+  }
+  if (response?.index !== undefined) {
+    const index = Number.isFinite(Number(response.index)) ? Math.max(0, Math.floor(Number(response.index))) : 0;
+    patch[fields.indexKey] = index;
+    patch.ipProxyCurrentIndex = index;
+  }
+  if (response?.current !== undefined) {
+    patch[fields.currentKey] = response.current || null;
+    patch.ipProxyCurrent = response.current || null;
+  }
+  return patch;
+}
+
+function getIpProxyCurrentEntry(state = latestState) {
+  const mode = normalizeIpProxyModeForCurrentRelease(state?.ipProxyMode);
+  if (mode === 'account') {
+    const runtime = getIpProxyRuntimeSnapshot(state, mode);
+    const poolEntry = runtime.hasModePool && runtime.pool.length
+      ? runtime.pool[runtime.index % runtime.pool.length]
+      : null;
+    const modeCurrent = runtime.hasModeCurrent ? runtime.current : null;
+    const hasRuntimeEntry = Boolean(poolEntry || modeCurrent);
+    const current = poolEntry || modeCurrent || {};
+    const host = String(current?.host || state?.ipProxyHost || '').trim();
+    const port = Number(current?.port || normalizeIpProxyPort(state?.ipProxyPort));
+    if (!host || !Number.isInteger(port) || port <= 0 || port > 65535) {
+      return null;
+    }
+    return {
+      host,
+      port,
+      username: hasRuntimeEntry
+        ? String(current?.username || '').trim()
+        : String(current?.username || state?.ipProxyUsername || '').trim(),
+      password: hasRuntimeEntry
+        ? String(current?.password || '')
+        : String(current?.password || state?.ipProxyPassword || ''),
+      protocol: normalizeIpProxyProtocol(current?.protocol || state?.ipProxyProtocol),
+      region: hasRuntimeEntry
+        ? String(current?.region || '').trim()
+        : String(current?.region || state?.ipProxyRegion || '').trim(),
+      provider: normalizeIpProxyService(state?.ipProxyService),
+    };
+  }
+
+  const runtime = getIpProxyRuntimeSnapshot(state, mode);
+  if (runtime.pool.length) {
+    const index = runtime.index % runtime.pool.length;
+    const current = runtime.pool[index];
+    if (current?.host && current?.port) {
+      return current;
+    }
+  }
+  const current = runtime.current;
+  return current && current.host && current.port ? current : null;
+}
+
+function has711SessionTokenForPanel(username = '') {
+  const text = String(username || '').trim();
+  if (!text) {
+    return false;
+  }
+  return /(?:^|[-_])session[-_:][A-Za-z0-9_-]+?(?=(?:[-_](?:sessTime|sessAuto|region|life|zone|ptype|country|area)\b)|$)/i.test(text);
+}
+
+function normalize711SessionIdForPanel(value = '') {
+  return String(value || '').trim().replace(/[^A-Za-z0-9_-]/g, '').slice(0, 64);
+}
+
+function normalize711SessTimeForPanel(value = '') {
+  const raw = String(value ?? '').trim();
+  if (!raw) {
+    return '';
+  }
+  const numeric = Number.parseInt(raw, 10);
+  if (!Number.isInteger(numeric)) {
+    return '';
+  }
+  return String(Math.max(1, Math.min(180, numeric)));
+}
+
+function normalize711RegionCodeForPanel(value = '') {
+  const text = String(value || '').trim().toUpperCase().replace(/[^A-Z]/g, '');
+  return /^[A-Z]{2}$/.test(text) ? text : '';
+}
+
+function shouldAutoSync711SessionFieldsForPanel(state = latestState) {
+  const service = normalizeIpProxyService(
+    selectIpProxyService?.value || state?.ipProxyService || DEFAULT_IP_PROXY_SERVICE
+  );
+  const mode = normalizeIpProxyModeForCurrentRelease(getSelectedIpProxyMode());
+  if (service !== '711proxy' || mode !== 'account') {
+    return false;
+  }
+  return !hasCurrentInputAccountListEntries();
+}
+
+function parse711RegionFromUsernameForPanel(username = '') {
+  const text = String(username || '').trim();
+  if (!text) {
+    return '';
+  }
+  const match = text.match(/(?:^|[-_])region[-_:]?([A-Za-z]{2})\b/i);
+  return normalize711RegionCodeForPanel(match ? match[1] : '');
+}
+
+function apply711RegionToUsernameForPanel(username = '', regionCode = '', options = {}) {
+  const text = String(username || '').trim();
+  if (!text) {
+    return '';
+  }
+
+  const normalizedRegion = normalize711RegionCodeForPanel(regionCode);
+  const removeWhenEmpty = Boolean(options?.removeWhenEmpty);
+
+  if (normalizedRegion) {
+    if (/(?:^|[-_])region[-_:]?[A-Za-z]{2}\b/i.test(text)) {
+      return text.replace(/((?:^|[-_])region[-_:]?)([A-Za-z]{2})\b/i, `$1${normalizedRegion}`);
+    }
+    return `${text}-region-${normalizedRegion}`;
+  }
+
+  if (!removeWhenEmpty) {
+    return text;
+  }
+
+  return String(text.replace(/(^|[-_])region[-_:]?[A-Za-z]{2}\b/ig, '$1') || '')
+    .replace(/[-_]{2,}/g, '-')
+    .replace(/^[-_]+|[-_]+$/g, '')
+    .trim();
+}
+
+function parse711SessionConfigFromUsernameForPanel(username = '') {
+  const text = String(username || '').trim();
+  if (!text) {
+    return { sessionId: '', sessTime: '' };
+  }
+  const sessionMatch = text.match(/(?:^|[-_])session[-_:]([A-Za-z0-9_-]+?)(?=(?:[-_](?:sessTime|sessAuto|region|life|zone|ptype|country|area)\b)|$)/i);
+  const sessTimeMatch = text.match(/(?:^|[-_])sessTime[-_:]?(\d+)\b/i);
+  const lifeMatch = text.match(/(?:^|[-_])life[-_:]?(\d+)\b/i);
+  return {
+    sessionId: normalize711SessionIdForPanel(sessionMatch ? sessionMatch[1] : ''),
+    sessTime: normalize711SessTimeForPanel(
+      sessTimeMatch ? sessTimeMatch[1] : (lifeMatch ? lifeMatch[1] : '')
+    ),
+  };
+}
+
+function apply711SessionConfigToUsernameForPanel(username = '', options = {}) {
+  const text = String(username || '').trim();
+  if (!text) {
+    return '';
+  }
+
+  const sessionId = normalize711SessionIdForPanel(options?.sessionId || '');
+  const sessTime = normalize711SessTimeForPanel(options?.sessTime || '');
+  const removeWhenEmpty = Boolean(options?.removeWhenEmpty);
+  let next = text;
+
+  if (sessionId) {
+    if (/(?:^|[-_])session[-_:][A-Za-z0-9_-]+?(?=(?:[-_](?:sessTime|sessAuto|region|life|zone|ptype|country|area)\b)|$)/i.test(next)) {
+      next = next.replace(
+        /((?:^|[-_])session[-_:])([A-Za-z0-9_-]+?)(?=(?:[-_](?:sessTime|sessAuto|region|life|zone|ptype|country|area)\b)|$)/i,
+        `$1${sessionId}`
+      );
+    } else {
+      next = `${next}-session-${sessionId}`;
+    }
+  } else if (removeWhenEmpty) {
+    next = next.replace(
+      /(^|[-_])session[-_:][A-Za-z0-9_-]+?(?=(?:[-_](?:sessTime|sessAuto|region|life|zone|ptype|country|area)\b)|$)/ig,
+      '$1'
+    );
+  }
+
+  if (sessTime) {
+    if (/(?:^|[-_])sessTime[-_:]?\d+\b/i.test(next)) {
+      next = next.replace(/((?:^|[-_])sessTime[-_:]?)(\d+)\b/i, `$1${sessTime}`);
+    } else if (/(?:^|[-_])life[-_:]?\d+\b/i.test(next)) {
+      next = next.replace(/((?:^|[-_])life[-_:]?)(\d+)\b/i, `$1${sessTime}`);
+    } else {
+      next = `${next}-sessTime-${sessTime}`;
+    }
+  } else if (removeWhenEmpty) {
+    next = next.replace(/(^|[-_])sessTime[-_:]?\d+\b/ig, '$1');
+    next = next.replace(/(^|[-_])life[-_:]?\d+\b/ig, '$1');
+  }
+
+  return String(next || '')
+    .replace(/[-_]{2,}/g, '-')
+    .replace(/^[-_]+|[-_]+$/g, '')
+    .trim();
+}
+
+function sync711SessionFieldsFromUsernameForPanel(options = {}) {
+  if (!shouldAutoSync711SessionFieldsForPanel(options?.state || latestState)) {
+    return { updated: false, sessionId: '', sessTime: '' };
+  }
+  const username = String(
+    options?.username !== undefined
+      ? options.username
+      : (inputIpProxyUsername?.value || '')
+  ).trim();
+  if (!username) {
+    return { updated: false, sessionId: '', sessTime: '' };
+  }
+
+  const parsed = parse711SessionConfigFromUsernameForPanel(username);
+  let updated = false;
+
+  if (parsed.sessionId && inputIpProxyAccountSessionPrefix) {
+    const currentSession = normalizeIpProxyAccountSessionPrefix(
+      inputIpProxyAccountSessionPrefix.value || ''
+    );
+    if (currentSession !== parsed.sessionId) {
+      inputIpProxyAccountSessionPrefix.value = parsed.sessionId;
+      updated = true;
+    }
+  }
+
+  if (parsed.sessTime && inputIpProxyAccountLifeMinutes) {
+    const currentLife = normalizeIpProxyAccountLifeMinutes(
+      inputIpProxyAccountLifeMinutes.value || ''
+    );
+    if (currentLife !== parsed.sessTime) {
+      inputIpProxyAccountLifeMinutes.value = parsed.sessTime;
+      updated = true;
+    }
+  }
+
+  return {
+    updated,
+    sessionId: parsed.sessionId,
+    sessTime: parsed.sessTime,
+  };
+}
+
+function sync711RegionFieldFromUsernameForPanel(options = {}) {
+  if (!shouldAutoSync711SessionFieldsForPanel(options?.state || latestState)) {
+    return { updated: false, region: '' };
+  }
+  if (!inputIpProxyRegion) {
+    return { updated: false, region: '' };
+  }
+
+  const username = String(
+    options?.username !== undefined
+      ? options.username
+      : (inputIpProxyUsername?.value || '')
+  ).trim();
+  const parsedRegion = parse711RegionFromUsernameForPanel(username);
+  if (!parsedRegion) {
+    return { updated: false, region: '' };
+  }
+
+  const currentRegion = normalize711RegionCodeForPanel(inputIpProxyRegion.value || '');
+  if (currentRegion === parsedRegion) {
+    return { updated: false, region: parsedRegion };
+  }
+  inputIpProxyRegion.value = parsedRegion;
+  return { updated: true, region: parsedRegion };
+}
+
+function sync711UsernameFromSessionFieldsForPanel(options = {}) {
+  if (!shouldAutoSync711SessionFieldsForPanel(options?.state || latestState)) {
+    return { updated: false, username: '' };
+  }
+  if (!inputIpProxyUsername) {
+    return { updated: false, username: '' };
+  }
+
+  const currentUsername = String(inputIpProxyUsername.value || '').trim();
+  if (!currentUsername) {
+    return { updated: false, username: '' };
+  }
+
+  const sessionId = normalize711SessionIdForPanel(
+    options?.sessionId !== undefined
+      ? options.sessionId
+      : (inputIpProxyAccountSessionPrefix?.value || '')
+  );
+  const lifeMinutes = normalizeIpProxyAccountLifeMinutes(
+    options?.sessTime !== undefined
+      ? options.sessTime
+      : (inputIpProxyAccountLifeMinutes?.value || '')
+  );
+  const sessTime = normalize711SessTimeForPanel(lifeMinutes);
+  const nextUsername = apply711SessionConfigToUsernameForPanel(currentUsername, {
+    sessionId,
+    sessTime,
+    removeWhenEmpty: Boolean(options?.removeWhenEmpty),
+  });
+
+  if (!nextUsername || nextUsername === currentUsername) {
+    return { updated: false, username: currentUsername };
+  }
+
+  inputIpProxyUsername.value = nextUsername;
+  return { updated: true, username: nextUsername };
+}
+
+function sync711UsernameFromRegionForPanel(options = {}) {
+  if (!shouldAutoSync711SessionFieldsForPanel(options?.state || latestState)) {
+    return { updated: false, username: '' };
+  }
+  if (!inputIpProxyUsername) {
+    return { updated: false, username: '' };
+  }
+
+  const currentUsername = String(inputIpProxyUsername.value || '').trim();
+  if (!currentUsername) {
+    return { updated: false, username: '' };
+  }
+
+  const rawRegion = String(
+    options?.region !== undefined
+      ? options.region
+      : (inputIpProxyRegion?.value || '')
+  ).trim();
+  const normalizedRegion = normalize711RegionCodeForPanel(rawRegion);
+  const nextUsername = apply711RegionToUsernameForPanel(
+    currentUsername,
+    normalizedRegion,
+    { removeWhenEmpty: Boolean(options?.removeWhenEmpty) }
+  );
+
+  if (!nextUsername || nextUsername === currentUsername) {
+    return { updated: false, username: currentUsername };
+  }
+
+  inputIpProxyUsername.value = nextUsername;
+  return { updated: true, username: nextUsername };
+}
+
+function canChangeIpProxyExitWithCurrentSession(state = latestState) {
+  const mode = getSelectedIpProxyMode();
+  const service = normalizeIpProxyService(
+    selectIpProxyService?.value || state?.ipProxyService || DEFAULT_IP_PROXY_SERVICE
+  );
+  if (mode !== 'account' || service !== '711proxy') {
+    return false;
+  }
+  const currentEntry = getIpProxyCurrentEntry(state);
+  const username = String(currentEntry?.username || inputIpProxyUsername?.value || '').trim();
+  return has711SessionTokenForPanel(username);
+}
+
+function buildIpProxyActionHintText(options = {}) {
+  const mode = normalizeIpProxyModeForCurrentRelease(options?.mode || DEFAULT_IP_PROXY_MODE);
+  const poolCount = Math.max(0, Number(options?.poolCount) || 0);
+  const changeAvailable = Boolean(options?.changeAvailable);
+
+  if (mode === 'api') {
+    return '下一条：切到已拉取代理池的下一条。Change：仅账号模式可用。';
+  }
+
+  const nextPart = poolCount > 1
+    ? '下一条：切到代理池的下一条节点。'
+    : '下一条：当前仅 1 条节点，执行重绑复测（不保证更换出口）。';
+  const changePart = changeAvailable
+    ? 'Change：保持当前 session 重绑链路并复测出口。'
+    : 'Change：需 711 账号模式且用户名包含 session。';
+  return `${nextPart} ${changePart}`;
+}
+
+function setIpProxyCurrentDisplay(text = '', hasValue = false) {
+  if (!ipProxyCurrent) return;
+  ipProxyCurrent.textContent = text || '暂无可用代理';
+  ipProxyCurrent.title = text || '暂无可用代理';
+  ipProxyCurrent.classList.toggle('has-value', Boolean(hasValue));
+}
+
+function formatIpProxyCurrentDisplay(state = latestState) {
+  const mode = normalizeIpProxyModeForCurrentRelease(state?.ipProxyMode);
+  if (mode === 'account') {
+    const runtime = getIpProxyRuntimeSnapshot(state, mode);
+    const current = getIpProxyCurrentEntry(state);
+    if (!current) {
+      return {
+        text: '账号模式：请填写代理列表，或填写 Host / Port',
+        hasValue: false,
+      };
+    }
+    const count = runtime.pool.length > 0 ? runtime.pool.length : 1;
+    const index = runtime.index;
+    return {
+      text: `${current.host}:${current.port}${current.region ? ` [${current.region}]` : ''} (${Math.min(index + 1, count)}/${count})`,
+      hasValue: true,
+    };
+  }
+
+  const runtime = getIpProxyRuntimeSnapshot(state, mode);
+  const current = getIpProxyCurrentEntry(state);
+  const count = runtime.pool.length;
+  const index = runtime.index;
+  if (!current) {
+    return {
+      text: count ? `已拉取 ${count} 条，点击“下一条”切换` : '暂无可用代理',
+      hasValue: false,
+    };
+  }
+  const region = String(current.region || '').trim();
+  const label = region ? `${current.host}:${current.port} [${region}]` : `${current.host}:${current.port}`;
+  return {
+    text: `${label}${count ? ` (${Math.min(index + 1, count)}/${count})` : ''}`,
+    hasValue: true,
+  };
+}
+
+function extractIpProxyEndpointToken(text = '') {
+  const raw = String(text || '').trim();
+  if (!raw) return '';
+  const match = raw.match(/^([^\s\[]+:\d+)/);
+  return match ? String(match[1]).toLowerCase() : '';
+}
+
+function extractIpProxyIndexToken(text = '') {
+  const raw = String(text || '').trim();
+  if (!raw) return '';
+  const match = raw.match(/\((\d+\s*\/\s*\d+)\)\s*$/);
+  if (!match) return '';
+  return String(match[1]).replace(/\s+/g, '');
+}
+
+function buildIpProxyCurrentDisplayText(display = {}, runtimeStatus = {}) {
+  const rawText = String(display?.text || '').trim();
+  const hasValue = Boolean(display?.hasValue);
+  if (!hasValue || !rawText) {
+    return rawText;
+  }
+  const runtimeText = String(runtimeStatus?.text || '').trim().toLowerCase();
+  if (!runtimeText) {
+    return rawText;
+  }
+  const endpointToken = extractIpProxyEndpointToken(rawText);
+  if (!endpointToken || !runtimeText.includes(endpointToken)) {
+    return rawText;
+  }
+  const indexToken = extractIpProxyIndexToken(rawText);
+  if (indexToken) {
+    return `节点 ${indexToken}`;
+  }
+  return '当前节点';
+}
+
+function formatIpProxyRuntimeStatus(state = latestState) {
+  const enabled = Boolean(state?.ipProxyEnabled);
+  const mode = normalizeIpProxyModeForCurrentRelease(state?.ipProxyMode);
+  const hasAccountListConfigured = mode === 'account'
+    && normalizeIpProxyAccountList(state?.ipProxyAccountList || '').split('\n').filter(Boolean).length > 0;
+  const accountSourceTag = mode === 'account'
+    ? (hasAccountListConfigured ? '（账号列表）' : '（固定账号）')
+    : '';
+  const accountSourceDetail = mode === 'account'
+    ? (
+      hasAccountListConfigured
+        ? '当前生效来源：账号列表（固定账号字段已忽略）。'
+        : '当前生效来源：固定账号字段。'
+    )
+    : '';
+  const activeEntry = getIpProxyCurrentEntry(state);
+  const applied = Boolean(state?.ipProxyApplied);
+  const reason = String(state?.ipProxyAppliedReason || '').trim().toLowerCase();
+  const host = String(
+    state?.ipProxyAppliedHost
+    || activeEntry?.host
+    || (mode === 'account' ? state?.ipProxyHost : '')
+    || ''
+  ).trim();
+  const portValue = Number(
+    state?.ipProxyAppliedPort
+    || activeEntry?.port
+    || (mode === 'account' ? normalizeIpProxyPort(state?.ipProxyPort) : 0)
+  );
+  const port = Number.isInteger(portValue) && portValue > 0 && portValue <= 65535 ? portValue : 0;
+  const region = String(
+    state?.ipProxyAppliedRegion
+    || activeEntry?.region
+    || (mode === 'account' ? state?.ipProxyRegion : '')
+    || ''
+  ).trim();
+  const endpoint = host && port > 0 ? `${host}:${port}` : '';
+  const endpointWithRegion = endpoint ? `${endpoint}${region ? ` [${region}]` : ''}` : '';
+  const hasAuth = Boolean(state?.ipProxyAppliedHasAuth);
+  const authSuffix = hasAuth ? '（需要鉴权）' : '';
+  const errorText = String(state?.ipProxyAppliedError || '').trim();
+  const warningText = String(state?.ipProxyAppliedWarning || '').trim();
+  const exitIp = String(state?.ipProxyAppliedExitIp || '').trim();
+  const exitRegion = String(state?.ipProxyAppliedExitRegion || '').trim();
+  const exitDetecting = Boolean(state?.ipProxyAppliedExitDetecting);
+  const exitError = String(state?.ipProxyAppliedExitError || '').trim();
+  const exitSource = String(state?.ipProxyAppliedExitSource || '').trim().toLowerCase();
+  const exitSourceSuffix = exitSource === 'page_context'
+    ? '（页面探测）'
+    : (exitSource === 'background_fallback'
+      ? '（后台兜底，可能受全局代理影响）'
+      : '');
+  const endpointSummary = endpointWithRegion
+    ? `${endpointWithRegion}${authSuffix}`
+    : (endpoint ? `${endpoint}${authSuffix}` : '');
+  const exitSummary = exitIp
+    ? `${exitIp}${exitRegion ? ` [${exitRegion}]` : ''}${exitSourceSuffix}`
+    : (exitDetecting ? '检测中...' : '未检测到');
+  const details = [accountSourceDetail, errorText, warningText, exitError]
+    .map((item) => String(item || '').trim())
+    .filter(Boolean)
+    .join('\n');
+
+  if (!enabled) {
+    return {
+      stateClass: 'state-idle',
+      text: '未启用，沿用浏览器默认/全局代理。',
+      details: '',
+    };
+  }
+
+  if (applied) {
+    const statusPrefix = endpointSummary
+      ? `当前代理：${endpointSummary}${accountSourceTag}`
+      : '当前代理：已启用';
+    const statusText = `${statusPrefix}；当前出口：${exitSummary}`;
+    const briefWarning = warningText
+      ? '；地区校验未通过（详情可展开查看）'
+      : '';
+    return {
+      stateClass: warningText ? 'state-warning' : 'state-applied',
+      text: `${statusText}${briefWarning}`,
+      details,
+    };
+  }
+
+  if (reason === 'missing_proxy_entry') {
+    if (errorText) {
+      return {
+        stateClass: 'state-warning',
+        text: '已启用，但当前没有可用代理（已阻断直连）。',
+        details: errorText,
+      };
+    }
+    return {
+      stateClass: 'state-warning',
+      text: mode === 'account'
+        ? '已启用，但账号模式没有可用代理。请先填写代理列表，或填写 Host/Port。已阻断所有网站直连。'
+        : '已启用，但当前没有可用代理。请先点击“拉取”获取 IP 列表。已阻断所有网站直连。',
+      details: '',
+    };
+  }
+  if (reason === 'proxy_api_unavailable') {
+    return {
+      stateClass: 'state-error',
+      text: '已启用，但当前浏览器不支持扩展代理 API，无法应用。',
+      details,
+    };
+  }
+  if (reason === 'apply_failed') {
+    return {
+      stateClass: 'state-error',
+      text: '已启用，但代理应用失败（已回退默认代理）。',
+      details: errorText || details,
+    };
+  }
+  if (reason === 'connectivity_failed') {
+    const prefix = endpointSummary ? `当前代理：${endpointSummary}${accountSourceTag}` : '当前代理：未知';
+    return {
+      stateClass: 'state-error',
+      text: `${prefix}；连通性失败，请切换节点或重试。`,
+      details: errorText || details,
+    };
+  }
+
+  return {
+    stateClass: 'state-warning',
+    text: endpointWithRegion
+      ? `已启用，等待生效：${endpointWithRegion}${authSuffix}`
+      : '已启用，等待拉取并应用代理。',
+    details,
+  };
+}
+
+function setIpProxyRuntimeStatusDisplay(status = {}) {
+  if (!ipProxyRuntimeStatus || !ipProxyRuntimeText) {
+    return;
+  }
+  const text = String(status?.text || '未启用，沿用浏览器默认/全局代理。').trim();
+  const stateClass = String(status?.stateClass || 'state-idle').trim() || 'state-idle';
+  ipProxyRuntimeStatus.classList.remove('state-idle', 'state-applied', 'state-warning', 'state-error');
+  ipProxyRuntimeStatus.classList.add(stateClass);
+  ipProxyRuntimeText.textContent = text;
+  ipProxyRuntimeText.title = text;
+  if (ipProxyRuntimeDot) {
+    ipProxyRuntimeDot.title = text;
+  }
+  const detailsText = String(status?.details || '').trim();
+  if (ipProxyRuntimeDetails && ipProxyRuntimeDetailsText) {
+    if (detailsText) {
+      ipProxyRuntimeDetails.hidden = false;
+      ipProxyRuntimeDetailsText.textContent = detailsText;
+    } else {
+      ipProxyRuntimeDetails.hidden = true;
+      ipProxyRuntimeDetails.open = false;
+      ipProxyRuntimeDetailsText.textContent = '';
+    }
+  }
+}
+
+function normalizeIpProxyEnabledInlineRegion(value = '') {
+  const normalized = String(value || '').trim();
+  return normalized ? normalized.toUpperCase() : '';
+}
+
+function setIpProxyEnabledInlineStatus(state = {}, enabled = getSelectedIpProxyEnabled()) {
+  if (!ipProxyEnabledStatus || !ipProxyEnabledStatusText) {
+    return;
+  }
+  ipProxyEnabledStatus.classList.remove('is-off', 'is-on');
+
+  if (!enabled) {
+    const text = '未开启';
+    ipProxyEnabledStatus.classList.add('is-off');
+    ipProxyEnabledStatusText.textContent = text;
+    ipProxyEnabledStatusText.title = text;
+    ipProxyEnabledStatus.title = text;
+    if (ipProxyEnabledStatusDot) {
+      ipProxyEnabledStatusDot.title = text;
+    }
+    return;
+  }
+
+  const region = normalizeIpProxyEnabledInlineRegion(state?.ipProxyAppliedExitRegion)
+    || normalizeIpProxyEnabledInlineRegion(state?.ipProxyAppliedRegion)
+    || normalizeIpProxyEnabledInlineRegion(state?.ipProxyRegion);
+  const text = region ? `已开启 · ${region}` : '已开启';
+  ipProxyEnabledStatus.classList.add('is-on');
+  ipProxyEnabledStatusText.textContent = text;
+  ipProxyEnabledStatusText.title = text;
+  ipProxyEnabledStatus.title = text;
+  if (ipProxyEnabledStatusDot) {
+    ipProxyEnabledStatusDot.title = text;
+  }
+}
+
+function updateIpProxyUI(state = latestState) {
+  const enabled = getSelectedIpProxyEnabled();
+  const mode = getSelectedIpProxyMode();
+  const service = normalizeIpProxyService(selectIpProxyService?.value || state?.ipProxyService || DEFAULT_IP_PROXY_SERVICE);
+  const apiModeAvailable = isIpProxyApiModeAvailable();
+  const accountListAvailable = isIpProxyAccountListAvailable();
+  const isApiMode = mode === 'api' && apiModeAvailable;
+  const isAccountMode = mode === 'account';
+  const showSessionOptions = isAccountMode && (service === 'lumiproxy' || service === '711proxy');
+  const hasAccountListConfigured = accountListAvailable && isAccountMode && hasCurrentInputAccountListEntries();
+  const canOperate = !isAutoRunLockedPhase() && !isAutoRunScheduledPhase();
+  const actionState = getIpProxyActionState();
+  const actionBusy = Boolean(actionState.busy);
+  const busyAction = normalizeIpProxyActionType(actionState.action);
+  const runtimeState = state || latestState || {};
+
+  setIpProxyEnabledInlineStatus(runtimeState, enabled);
+
+  if (rowIpProxyEnabled) {
+    rowIpProxyEnabled.style.display = '';
+  }
+  if (rowIpProxyFold) {
+    rowIpProxyFold.style.display = enabled ? '' : 'none';
+  }
+  if (rowIpProxyService) {
+    rowIpProxyService.style.display = enabled ? '' : 'none';
+  }
+  if (rowIpProxyMode) {
+    rowIpProxyMode.style.display = enabled ? '' : 'none';
+  }
+  if (rowIpProxyLayout) {
+    rowIpProxyLayout.style.display = enabled ? '' : 'none';
+  }
+  if (rowIpProxyApiUrl) {
+    rowIpProxyApiUrl.style.display = enabled && apiModeAvailable && isApiMode ? '' : 'none';
+  }
+  if (rowIpProxyAccountList) {
+    rowIpProxyAccountList.style.display = enabled && isAccountMode && accountListAvailable ? '' : 'none';
+  }
+  if (rowIpProxyAccountSessionPrefix) {
+    rowIpProxyAccountSessionPrefix.style.display = enabled && showSessionOptions ? '' : 'none';
+  }
+  if (rowIpProxyAccountLifeMinutes) {
+    rowIpProxyAccountLifeMinutes.style.display = enabled && showSessionOptions ? '' : 'none';
+  }
+  if (rowIpProxyPoolTargetCount) {
+    rowIpProxyPoolTargetCount.style.display = enabled ? '' : 'none';
+  }
+  if (rowIpProxyHost) {
+    rowIpProxyHost.style.display = enabled && isAccountMode ? '' : 'none';
+  }
+  if (rowIpProxyPort) {
+    rowIpProxyPort.style.display = enabled && isAccountMode ? '' : 'none';
+  }
+  if (rowIpProxyProtocol) {
+    rowIpProxyProtocol.style.display = enabled ? '' : 'none';
+  }
+  if (rowIpProxyUsername) {
+    rowIpProxyUsername.style.display = enabled && isAccountMode ? '' : 'none';
+  }
+  if (rowIpProxyPassword) {
+    rowIpProxyPassword.style.display = enabled && isAccountMode ? '' : 'none';
+  }
+  if (rowIpProxyRegion) {
+    rowIpProxyRegion.style.display = enabled && isAccountMode ? '' : 'none';
+  }
+  if (rowIpProxyActions) {
+    rowIpProxyActions.style.display = enabled ? '' : 'none';
+  }
+  if (ipProxyActionButtons) {
+    ipProxyActionButtons.style.display = enabled ? '' : 'none';
+  }
+  if (rowIpProxyRuntimeStatus) {
+    rowIpProxyRuntimeStatus.style.display = enabled ? '' : 'none';
+  }
+  if (ipProxyLayout) {
+    ipProxyLayout.classList.toggle('is-account-only', !apiModeAvailable);
+  }
+  if (selectIpProxyService) {
+    selectIpProxyService.value = service;
+    selectIpProxyService.disabled = true;
+  }
+  ipProxyModeButtons.forEach((button) => {
+    const buttonMode = normalizeIpProxyMode(button?.dataset?.ipProxyMode || DEFAULT_IP_PROXY_MODE);
+    const apiButton = buttonMode === 'api';
+    button.disabled = apiButton && !apiModeAvailable;
+    if (apiButton) {
+      button.hidden = false;
+    }
+  });
+  if (ipProxyApiPanel) {
+    ipProxyApiPanel.classList.toggle('is-disabled', !apiModeAvailable);
+    ipProxyApiPanel.setAttribute('aria-disabled', String(!apiModeAvailable));
+    ipProxyApiPanel.hidden = !apiModeAvailable;
+    ipProxyApiPanel.style.display = enabled && apiModeAvailable ? '' : 'none';
+  }
+  if (inputIpProxyApiUrl) {
+    inputIpProxyApiUrl.disabled = !enabled || !apiModeAvailable;
+  }
+  if (btnToggleIpProxyApiUrl) {
+    btnToggleIpProxyApiUrl.disabled = !enabled || !apiModeAvailable;
+  }
+  if (inputIpProxyHost) {
+    inputIpProxyHost.disabled = !enabled || !isAccountMode || hasAccountListConfigured;
+  }
+  if (inputIpProxyPort) {
+    inputIpProxyPort.disabled = !enabled || !isAccountMode || hasAccountListConfigured;
+  }
+  if (selectIpProxyProtocol) {
+    selectIpProxyProtocol.disabled = !enabled || (isAccountMode && hasAccountListConfigured);
+  }
+  if (inputIpProxyUsername) {
+    inputIpProxyUsername.disabled = !enabled || !isAccountMode || hasAccountListConfigured;
+  }
+  if (inputIpProxyPassword) {
+    inputIpProxyPassword.disabled = !enabled || !isAccountMode || hasAccountListConfigured;
+  }
+  if (btnToggleIpProxyUsername) {
+    btnToggleIpProxyUsername.disabled = !enabled || !isAccountMode || hasAccountListConfigured;
+  }
+  if (btnToggleIpProxyPassword) {
+    btnToggleIpProxyPassword.disabled = !enabled || !isAccountMode || hasAccountListConfigured;
+  }
+  if (inputIpProxyRegion) {
+    inputIpProxyRegion.disabled = !enabled || !isAccountMode || hasAccountListConfigured;
+  }
+  if (inputIpProxyAccountSessionPrefix) {
+    inputIpProxyAccountSessionPrefix.disabled = !enabled || !isAccountMode || hasAccountListConfigured;
+  }
+  if (inputIpProxyAccountLifeMinutes) {
+    inputIpProxyAccountLifeMinutes.disabled = !enabled || !isAccountMode || hasAccountListConfigured;
+  }
+  if (inputIpProxyAccountList) {
+    inputIpProxyAccountList.disabled = !enabled || !isAccountMode || !accountListAvailable;
+  }
+
+  const runtimeStatus = formatIpProxyRuntimeStatus(runtimeState);
+  setIpProxyRuntimeStatusDisplay(runtimeStatus);
+  const currentDisplay = formatIpProxyCurrentDisplay(runtimeState);
+  const currentDisplayText = buildIpProxyCurrentDisplayText(currentDisplay, runtimeStatus);
+  setIpProxyCurrentDisplay(currentDisplayText, currentDisplay.hasValue);
+  const runtimeSnapshot = getIpProxyRuntimeSnapshot(runtimeState, mode, service);
+  const runtimePoolCount = Array.isArray(runtimeSnapshot?.pool) ? runtimeSnapshot.pool.length : 0;
+  const hasCurrentEntry = Boolean(getIpProxyCurrentEntry(runtimeState));
+  const changeAvailable = canChangeIpProxyExitWithCurrentSession(runtimeState);
+  const nextActionTitle = runtimePoolCount > 1
+    ? '切换到代理池下一条节点并应用'
+    : '当前仅 1 条节点：重绑当前节点并复测连通性（不保证更换出口）';
+
+  if (btnIpProxyRefresh) {
+    btnIpProxyRefresh.disabled = actionBusy || !enabled || !canOperate;
+    btnIpProxyRefresh.textContent = busyAction === 'refresh'
+      ? (isApiMode ? '拉取中...' : '同步中...')
+      : (isApiMode ? '拉取' : '同步');
+    btnIpProxyRefresh.title = isApiMode ? '拉取代理池并应用当前代理' : '同步账号代理列表并应用当前代理';
+  }
+  if (btnIpProxyNext) {
+    btnIpProxyNext.disabled = actionBusy || !enabled || !canOperate || !hasCurrentEntry;
+    btnIpProxyNext.textContent = busyAction === 'next' ? '切换中...' : '下一条';
+    btnIpProxyNext.title = nextActionTitle;
+  }
+  if (btnIpProxyChange) {
+    btnIpProxyChange.disabled = actionBusy || !enabled || !canOperate || !changeAvailable;
+    btnIpProxyChange.textContent = busyAction === 'change' ? 'Change中...' : 'Change';
+    btnIpProxyChange.title = changeAvailable
+      ? '保持当前会话并刷新出口（仅 711 + session）'
+      : '当前模式不支持 Change（需 711 账号模式且用户名包含 session）';
+  }
+  if (btnIpProxyProbe) {
+    btnIpProxyProbe.disabled = actionBusy || !enabled || !canOperate;
+    btnIpProxyProbe.textContent = busyAction === 'probe' ? '检测中...' : '检测出口';
+  }
+  if (btnIpProxyCheckIp) {
+    btnIpProxyCheckIp.disabled = false;
+    btnIpProxyCheckIp.title = '打开公网 IP 检测页';
+  }
+  if (ipProxyActionHint) {
+    const actionHint = buildIpProxyActionHintText({
+      mode,
+      poolCount: runtimePoolCount,
+      changeAvailable,
+    });
+    ipProxyActionHint.textContent = actionHint;
+    ipProxyActionHint.title = actionHint;
+  }
+}
+
+async function refreshIpProxyPoolByApi(options = {}) {
+  const { silent = false } = options;
+  const mode = normalizeIpProxyModeForCurrentRelease(getSelectedIpProxyMode());
+  const response = await chrome.runtime.sendMessage({
+    type: 'REFRESH_IP_PROXY_POOL',
+    source: 'sidepanel',
+    payload: {
+      mode,
+    },
+  });
+  if (response?.error) {
+    throw new Error(response.error);
+  }
+
+  const responseMode = normalizeIpProxyModeForCurrentRelease(response?.mode || mode);
+  const patch = {};
+  Object.assign(patch, buildIpProxyRuntimeStatePatchForMode(responseMode, response));
+  if (response?.proxyRouting && typeof response.proxyRouting === 'object') {
+    patch.ipProxyApplied = Boolean(response.proxyRouting.applied);
+    patch.ipProxyAppliedReason = String(response.proxyRouting.reason || '').trim().toLowerCase();
+    patch.ipProxyAppliedHost = String(response.proxyRouting.host || '').trim();
+    patch.ipProxyAppliedPort = Number(response.proxyRouting.port) || 0;
+    patch.ipProxyAppliedRegion = String(response.proxyRouting.region || '').trim();
+    patch.ipProxyAppliedHasAuth = Boolean(response.proxyRouting.hasAuth);
+    patch.ipProxyAppliedProvider = normalizeIpProxyService(response.proxyRouting.provider || '');
+    patch.ipProxyAppliedError = String(response.proxyRouting.error || '').trim();
+    patch.ipProxyAppliedWarning = String(response.proxyRouting.warning || '').trim();
+    patch.ipProxyAppliedExitIp = String(response.proxyRouting.exitIp || '').trim();
+    patch.ipProxyAppliedExitRegion = String(response.proxyRouting.exitRegion || '').trim();
+    patch.ipProxyAppliedExitDetecting = Boolean(response.proxyRouting.exitDetecting);
+    patch.ipProxyAppliedExitError = String(response.proxyRouting.exitError || '').trim();
+    patch.ipProxyAppliedExitSource = String(response.proxyRouting.exitSource || '').trim().toLowerCase();
+    patch.ipProxyAppliedAt = Date.now();
+  }
+  if (Object.keys(patch).length) {
+    syncLatestState(patch);
+  }
+  updateIpProxyUI(latestState);
+  await probeIpProxyExit({ silent: true }).catch(() => {});
+
+  if (!silent) {
+    if (mode === 'account') {
+      showToast(`已同步账号代理：${response?.display || formatIpProxyCurrentDisplay(latestState).text}`, 'success', 1800);
+    } else {
+      showToast(`已拉取代理池：${Number(response?.count) || 0} 条`, 'success', 1800);
+    }
+  }
+  return response;
+}
+
+async function switchIpProxyToNext(options = {}) {
+  const { silent = false } = options;
+  const mode = normalizeIpProxyModeForCurrentRelease(getSelectedIpProxyMode());
+  const response = await chrome.runtime.sendMessage({
+    type: 'SWITCH_IP_PROXY',
+    source: 'sidepanel',
+    payload: {
+      direction: 'next',
+      mode,
+      forceRefresh: false,
+    },
+  });
+  if (response?.error) {
+    throw new Error(response.error);
+  }
+  const responseMode = normalizeIpProxyModeForCurrentRelease(response?.mode || mode);
+  const patch = {};
+  Object.assign(patch, buildIpProxyRuntimeStatePatchForMode(responseMode, response));
+  if (response?.proxyRouting && typeof response.proxyRouting === 'object') {
+    patch.ipProxyApplied = Boolean(response.proxyRouting.applied);
+    patch.ipProxyAppliedReason = String(response.proxyRouting.reason || '').trim().toLowerCase();
+    patch.ipProxyAppliedHost = String(response.proxyRouting.host || '').trim();
+    patch.ipProxyAppliedPort = Number(response.proxyRouting.port) || 0;
+    patch.ipProxyAppliedRegion = String(response.proxyRouting.region || '').trim();
+    patch.ipProxyAppliedHasAuth = Boolean(response.proxyRouting.hasAuth);
+    patch.ipProxyAppliedProvider = normalizeIpProxyService(response.proxyRouting.provider || '');
+    patch.ipProxyAppliedError = String(response.proxyRouting.error || '').trim();
+    patch.ipProxyAppliedWarning = String(response.proxyRouting.warning || '').trim();
+    patch.ipProxyAppliedExitIp = String(response.proxyRouting.exitIp || '').trim();
+    patch.ipProxyAppliedExitRegion = String(response.proxyRouting.exitRegion || '').trim();
+    patch.ipProxyAppliedExitDetecting = Boolean(response.proxyRouting.exitDetecting);
+    patch.ipProxyAppliedExitError = String(response.proxyRouting.exitError || '').trim();
+    patch.ipProxyAppliedExitSource = String(response.proxyRouting.exitSource || '').trim().toLowerCase();
+    patch.ipProxyAppliedAt = Date.now();
+  }
+  if (Object.keys(patch).length) {
+    syncLatestState(patch);
+  }
+  updateIpProxyUI(latestState);
+  await probeIpProxyExit({ silent: true }).catch(() => {});
+  if (!silent) {
+    showToast(`已切换代理：${response?.display || formatIpProxyCurrentDisplay(latestState).text}`, 'success', 1800);
+  }
+  return response;
+}
+
+async function changeIpProxyExitBySession(options = {}) {
+  const { silent = false } = options;
+  const mode = normalizeIpProxyModeForCurrentRelease(getSelectedIpProxyMode());
+  const response = await chrome.runtime.sendMessage({
+    type: 'CHANGE_IP_PROXY_EXIT',
+    source: 'sidepanel',
+    payload: {
+      mode,
+    },
+  });
+  if (response?.error) {
+    throw new Error(response.error);
+  }
+  const responseMode = normalizeIpProxyModeForCurrentRelease(response?.mode || mode);
+  const patch = {};
+  Object.assign(patch, buildIpProxyRuntimeStatePatchForMode(responseMode, response));
+  if (response?.proxyRouting && typeof response.proxyRouting === 'object') {
+    patch.ipProxyApplied = Boolean(response.proxyRouting.applied);
+    patch.ipProxyAppliedReason = String(response.proxyRouting.reason || '').trim().toLowerCase();
+    patch.ipProxyAppliedHost = String(response.proxyRouting.host || '').trim();
+    patch.ipProxyAppliedPort = Number(response.proxyRouting.port) || 0;
+    patch.ipProxyAppliedRegion = String(response.proxyRouting.region || '').trim();
+    patch.ipProxyAppliedHasAuth = Boolean(response.proxyRouting.hasAuth);
+    patch.ipProxyAppliedProvider = normalizeIpProxyService(response.proxyRouting.provider || '');
+    patch.ipProxyAppliedError = String(response.proxyRouting.error || '').trim();
+    patch.ipProxyAppliedWarning = String(response.proxyRouting.warning || '').trim();
+    patch.ipProxyAppliedExitIp = String(response.proxyRouting.exitIp || '').trim();
+    patch.ipProxyAppliedExitRegion = String(response.proxyRouting.exitRegion || '').trim();
+    patch.ipProxyAppliedExitDetecting = Boolean(response.proxyRouting.exitDetecting);
+    patch.ipProxyAppliedExitError = String(response.proxyRouting.exitError || '').trim();
+    patch.ipProxyAppliedExitSource = String(response.proxyRouting.exitSource || '').trim().toLowerCase();
+    patch.ipProxyAppliedAt = Date.now();
+  }
+  if (Object.keys(patch).length) {
+    syncLatestState(patch);
+  }
+  updateIpProxyUI(latestState);
+  await probeIpProxyExit({ silent: true }).catch(() => {});
+  if (!silent) {
+    showToast(`已执行 Change：${response?.display || formatIpProxyCurrentDisplay(latestState).text}`, 'success', 1800);
+  }
+  return response;
+}
+
+async function probeIpProxyExit(options = {}) {
+  const { silent = false } = options;
+  const response = await chrome.runtime.sendMessage({
+    type: 'PROBE_IP_PROXY_EXIT',
+    source: 'sidepanel',
+    payload: {},
+  });
+  if (response?.error) {
+    throw new Error(response.error);
+  }
+  const routing = response?.proxyRouting || {};
+  syncLatestState({
+    ipProxyApplied: Boolean(routing.applied),
+    ipProxyAppliedReason: String(routing.reason || '').trim().toLowerCase(),
+    ipProxyAppliedHost: String(routing.host || '').trim(),
+    ipProxyAppliedPort: Number(routing.port) || 0,
+    ipProxyAppliedRegion: String(routing.region || '').trim(),
+    ipProxyAppliedHasAuth: Boolean(routing.hasAuth),
+    ipProxyAppliedProvider: normalizeIpProxyService(routing.provider || ''),
+    ipProxyAppliedError: String(routing.error || '').trim(),
+    ipProxyAppliedWarning: String(routing.warning || '').trim(),
+    ipProxyAppliedExitIp: String(routing.exitIp || '').trim(),
+    ipProxyAppliedExitRegion: String(routing.exitRegion || '').trim(),
+    ipProxyAppliedExitDetecting: Boolean(routing.exitDetecting),
+    ipProxyAppliedExitError: String(routing.exitError || '').trim(),
+    ipProxyAppliedExitSource: String(routing.exitSource || '').trim().toLowerCase(),
+    ipProxyAppliedAt: Date.now(),
+  });
+  updateIpProxyUI(latestState);
+
+  if (!silent) {
+    const exitIp = String(routing?.exitIp || '').trim();
+    const exitRegion = String(routing?.exitRegion || '').trim();
+    const exitSource = String(routing?.exitSource || '').trim().toLowerCase();
+    const sourceHint = exitSource === 'background_fallback'
+      ? '（后台兜底，可能受全局代理影响）'
+      : '';
+    if (exitIp) {
+      showToast(`出口检测成功：${exitIp}${exitRegion ? ` [${exitRegion}]` : ''}${sourceHint}`, 'success', 2600);
+    } else {
+      showToast('出口检测完成，但未获取到出口 IP', 'warn', 2200);
+    }
+  }
+  return response;
+}

--- a/sidepanel/ip-proxy-provider-lumiproxy.js
+++ b/sidepanel/ip-proxy-provider-lumiproxy.js
@@ -1,0 +1,78 @@
+// sidepanel/ip-proxy-provider-lumiproxy.js — LumiProxy 面板专属逻辑
+function normalizeIpProxyCountryCode(value = '') {
+  const raw = String(value || '').trim().toLowerCase();
+  if (!raw) return '';
+  const simple = raw.replace(/[^a-z]/g, '');
+  return /^[a-z]{2}$/.test(simple) ? simple : '';
+}
+
+const LUMIPROXY_HOST_COUNTRY_HINTS = new Set([
+  'us', 'de', 'uk', 'fr', 'nl', 'it', 'es', 'ca', 'au', 'sg', 'jp', 'kr', 'tw', 'hk', 'in', 'br', 'mx',
+]);
+
+function inferLumiProxyCountryFromHost(host = '') {
+  const normalizedHost = String(host || '').trim().toLowerCase();
+  if (!normalizedHost || !normalizedHost.endsWith('.lumiproxy.io')) {
+    return '';
+  }
+  const prefix = normalizedHost.split('.')[0] || '';
+  return LUMIPROXY_HOST_COUNTRY_HINTS.has(prefix) ? prefix : '';
+}
+
+function inferLumiAreaFromUsername(username = '') {
+  const text = String(username || '').trim().toLowerCase();
+  if (!text) return '';
+  const areaMatch = text.match(/(?:^|[-_])area[-_:]?([a-z]{2})\b/i);
+  if (areaMatch) {
+    return String(areaMatch[1] || '').toLowerCase();
+  }
+  const countryMatch = text.match(/(?:^|[-_])country[-_:]?([a-z]{2})\b/i);
+  return countryMatch ? String(countryMatch[1] || '').toLowerCase() : '';
+}
+
+function resolveLumiProxyCountryFromInputs({ host = '', username = '', region = '' } = {}) {
+  const hostCode = inferLumiProxyCountryFromHost(host);
+  const usernameCode = inferLumiAreaFromUsername(username);
+  const regionCode = normalizeIpProxyCountryCode(region);
+  return hostCode || usernameCode || regionCode;
+}
+
+function syncLumiProxyRegionInputFromCredentials(options = {}) {
+  const { force = false } = options;
+  const normalizeService = typeof normalizeIpProxyService === 'function'
+    ? normalizeIpProxyService
+    : ((value = '') => String(value || '').trim().toLowerCase() || 'lumiproxy');
+  const normalizeMode = typeof normalizeIpProxyMode === 'function'
+    ? normalizeIpProxyMode
+    : ((value = '') => String(value || '').trim().toLowerCase() || 'api');
+  const getMode = typeof getSelectedIpProxyMode === 'function'
+    ? getSelectedIpProxyMode
+    : (() => 'api');
+
+  const service = normalizeService(
+    (typeof selectIpProxyService !== 'undefined' ? selectIpProxyService?.value : '')
+      || (typeof latestState !== 'undefined' ? latestState?.ipProxyService : '')
+      || 'lumiproxy'
+  );
+  const mode = normalizeMode(getMode());
+  if (service !== 'lumiproxy' || mode !== 'account' || typeof inputIpProxyRegion === 'undefined' || !inputIpProxyRegion) {
+    return '';
+  }
+
+  const currentRegion = String(inputIpProxyRegion.value || '').trim();
+  const resolvedCode = resolveLumiProxyCountryFromInputs({
+    host: (typeof inputIpProxyHost !== 'undefined' && inputIpProxyHost) ? inputIpProxyHost.value : '',
+    username: (typeof inputIpProxyUsername !== 'undefined' && inputIpProxyUsername) ? inputIpProxyUsername.value : '',
+    region: currentRegion,
+  });
+  if (!resolvedCode) {
+    return '';
+  }
+
+  const normalizedCurrent = normalizeIpProxyCountryCode(currentRegion);
+  if (force || !normalizedCurrent) {
+    inputIpProxyRegion.value = resolvedCode.toUpperCase();
+  }
+  return resolvedCode.toUpperCase();
+}
+

--- a/sidepanel/sidepanel.css
+++ b/sidepanel/sidepanel.css
@@ -781,6 +781,248 @@ header {
   min-width: 0;
 }
 
+.ip-proxy-fold-row {
+  display: block;
+}
+
+.ip-proxy-fold {
+  width: 100%;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.ip-proxy-fold-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-top: none;
+  padding-top: 0;
+}
+
+.ip-proxy-layout-row {
+  display: block;
+}
+
+.ip-proxy-layout {
+  width: 100%;
+  display: block;
+}
+
+.ip-proxy-layout.is-account-only {
+  display: block;
+}
+
+.ip-proxy-column {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+}
+
+.ip-proxy-column-header {
+  display: none;
+}
+
+.ip-proxy-column-hint {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.ip-proxy-column-mode-btn {
+  width: 100%;
+  justify-content: center;
+}
+
+.ip-proxy-column-api.is-disabled {
+  opacity: 0.55;
+}
+
+.ip-proxy-column-api.is-disabled .data-input,
+.ip-proxy-column-api.is-disabled .data-select,
+.ip-proxy-column-api.is-disabled .data-textarea,
+.ip-proxy-column-api.is-disabled .input-icon-btn,
+.ip-proxy-column-api.is-disabled .btn,
+.ip-proxy-column-api.is-disabled .choice-btn {
+  cursor: not-allowed;
+}
+
+@media (max-width: 900px) {
+  .ip-proxy-layout {
+    display: block;
+  }
+}
+
+.ip-proxy-enabled-inline {
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.ip-proxy-actions-inline {
+  flex-wrap: wrap;
+  align-items: center;
+  row-gap: 6px;
+}
+
+.ip-proxy-action-grid {
+  width: 100%;
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 8px;
+}
+
+.ip-proxy-action-grid .data-inline-btn {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.ip-proxy-action-hint {
+  flex: 1 1 100%;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.ip-proxy-enabled-status {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  min-width: 92px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.ip-proxy-enabled-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--text-muted);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--text-muted) 25%, transparent);
+  flex-shrink: 0;
+}
+
+.ip-proxy-enabled-status.is-on {
+  color: var(--green);
+}
+
+.ip-proxy-enabled-status.is-on .ip-proxy-enabled-status-dot {
+  background: var(--green);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--green) 30%, transparent);
+}
+
+.ip-proxy-enabled-status.is-off {
+  color: var(--text-muted);
+}
+
+.ip-proxy-runtime-status {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+  min-height: 32px;
+  padding: 6px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+}
+
+.ip-proxy-runtime-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ip-proxy-runtime-main {
+  min-width: 0;
+}
+
+.ip-proxy-runtime-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.ip-proxy-check-ip-btn {
+  min-width: 64px;
+  padding-inline: 10px;
+  flex-shrink: 0;
+}
+
+.ip-proxy-runtime-current {
+  flex: 1;
+  min-width: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.ip-proxy-runtime-current.has-value {
+  color: var(--text-primary);
+}
+
+.ip-proxy-runtime-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--text-muted);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--text-muted) 28%, transparent);
+  flex-shrink: 0;
+  margin-top: 6px;
+}
+
+.ip-proxy-runtime-status.state-applied .ip-proxy-runtime-dot {
+  background: var(--green);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--green) 28%, transparent);
+}
+
+.ip-proxy-runtime-status.state-warning .ip-proxy-runtime-dot {
+  background: var(--orange);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--orange) 28%, transparent);
+}
+
+.ip-proxy-runtime-status.state-error .ip-proxy-runtime-dot {
+  background: var(--red);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--red) 28%, transparent);
+}
+
+.ip-proxy-runtime-details {
+  margin: 0;
+  padding: 0;
+}
+
+.ip-proxy-runtime-details summary {
+  cursor: pointer;
+  user-select: none;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.ip-proxy-runtime-details[open] summary {
+  color: var(--text-primary);
+}
+
+.ip-proxy-runtime-details-text {
+  margin-top: 4px;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .mail2925-base-inline {
   gap: 10px;
 }

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -194,6 +194,158 @@
         <span class="data-label">默认代理</span>
         <input type="text" id="input-sub2api-default-proxy" class="data-input" placeholder="留空则不使用代理；或填写代理名称 / ID" />
       </div>
+      <div class="data-row" id="row-ip-proxy-enabled">
+        <span class="data-label">IP代理</span>
+        <div class="data-inline ip-proxy-enabled-inline">
+          <label class="toggle-switch" for="input-ip-proxy-enabled" title="启用或禁用 IP 代理接管">
+            <input type="checkbox" id="input-ip-proxy-enabled" />
+            <span class="toggle-switch-track" aria-hidden="true">
+              <span class="toggle-switch-thumb"></span>
+            </span>
+          </label>
+          <span id="ip-proxy-enabled-status" class="ip-proxy-enabled-status" aria-live="polite">
+            <span id="ip-proxy-enabled-status-dot" class="ip-proxy-enabled-status-dot" aria-hidden="true"></span>
+            <span id="ip-proxy-enabled-status-text" class="ip-proxy-enabled-status-text">未开启</span>
+          </span>
+        </div>
+      </div>
+      <div class="data-row ip-proxy-fold-row" id="row-ip-proxy-fold" style="display:none;">
+        <div id="ip-proxy-fold" class="ip-proxy-fold">
+          <div class="ip-proxy-fold-body">
+            <div class="data-row" id="row-ip-proxy-service" style="display:none;">
+              <span class="data-label">代理服务</span>
+              <select id="select-ip-proxy-service" class="data-select" disabled>
+                <option value="711proxy">711Proxy（首版）</option>
+              </select>
+            </div>
+            <div class="data-row" id="row-ip-proxy-mode" style="display:none;">
+              <span class="data-label">代理模式</span>
+              <div id="ip-proxy-mode-group" class="choice-group" role="group" aria-label="IP代理模式">
+                <button type="button" class="choice-btn" data-ip-proxy-mode="account">账号密码</button>
+                <button type="button" class="choice-btn" data-ip-proxy-mode="api" disabled title="首版暂未开放">API 拉取（暂未开放）</button>
+              </div>
+            </div>
+            <div class="data-row ip-proxy-layout-row" id="row-ip-proxy-layout" style="display:none;">
+              <div class="ip-proxy-layout" id="ip-proxy-layout">
+                <div class="ip-proxy-column ip-proxy-column-account" id="ip-proxy-account-panel">
+                  <div class="ip-proxy-column-header">账号密码模式</div>
+                  <div class="data-row ip-proxy-column-row" id="row-ip-proxy-account-list" style="display:none;">
+                    <span class="data-label">账号代理列表</span>
+                    <textarea id="input-ip-proxy-account-list" class="data-textarea mono"
+                      placeholder="每行一条：host:port 或 host:port:username:password&#10;例如 global.rotgb.711proxy.com:10000:username:password"></textarea>
+                  </div>
+                  <div class="data-row ip-proxy-column-row" id="row-ip-proxy-account-session-prefix" style="display:none;">
+                    <span class="data-label">会话(session)</span>
+                    <input type="text" id="input-ip-proxy-account-session-prefix" class="data-input mono"
+                      placeholder="会话前缀，例如 ZC28qZ0KQL" />
+                  </div>
+                  <div class="data-row ip-proxy-column-row" id="row-ip-proxy-account-life-minutes" style="display:none;">
+                    <span class="data-label">时长(life)</span>
+                    <div class="data-inline">
+                      <input type="number" id="input-ip-proxy-account-life-minutes" class="data-input" min="1" max="1440" step="1"
+                        placeholder="5-180（分钟）" title="711Proxy 会话时长范围：5-180 分钟" />
+                      <span class="data-unit">分钟</span>
+                    </div>
+                  </div>
+                  <div class="data-row ip-proxy-column-row" id="row-ip-proxy-host" style="display:none;">
+                    <span class="data-label">代理 Host</span>
+                    <input type="text" id="input-ip-proxy-host" class="data-input" placeholder="例如 global.rotgb.711proxy.com" />
+                  </div>
+                  <div class="data-row ip-proxy-column-row" id="row-ip-proxy-port" style="display:none;">
+                    <span class="data-label">代理 Port</span>
+                    <input type="number" id="input-ip-proxy-port" class="data-input" min="1" max="65535" step="1"
+                      placeholder="例如 10000" />
+                  </div>
+                  <div class="data-row ip-proxy-column-row" id="row-ip-proxy-protocol" style="display:none;">
+                    <span class="data-label">代理协议</span>
+                    <select id="select-ip-proxy-protocol" class="data-select">
+                      <option value="http">HTTP</option>
+                      <option value="https">HTTPS</option>
+                      <option value="socks5">SOCKS5</option>
+                      <option value="socks4">SOCKS4</option>
+                    </select>
+                  </div>
+                  <div class="data-row ip-proxy-column-row" id="row-ip-proxy-username" style="display:none;">
+                    <span class="data-label">代理账号</span>
+                    <div class="input-with-icon">
+                      <input type="password" id="input-ip-proxy-username" class="data-input data-input-with-icon"
+                        placeholder="例如 USER047152-zone-custom-region-US-asn-ASN81" />
+                      <button id="btn-toggle-ip-proxy-username" class="input-icon-btn" type="button" aria-label="显示代理账号"
+                        title="显示代理账号"></button>
+                    </div>
+                  </div>
+                  <div class="data-row ip-proxy-column-row" id="row-ip-proxy-password" style="display:none;">
+                    <span class="data-label">代理密码</span>
+                    <div class="input-with-icon">
+                      <input type="password" id="input-ip-proxy-password" class="data-input data-input-with-icon"
+                        placeholder="账号密码代理的密码" />
+                      <button id="btn-toggle-ip-proxy-password" class="input-icon-btn" type="button" aria-label="显示代理密码"
+                        title="显示代理密码"></button>
+                    </div>
+                  </div>
+                  <div class="data-row ip-proxy-column-row" id="row-ip-proxy-region" style="display:none;">
+                    <span class="data-label">地区参数</span>
+                    <input type="text" id="input-ip-proxy-region" class="data-input" placeholder="可选，例如 US / DE / HK" />
+                  </div>
+                  <div class="data-row ip-proxy-column-row" id="row-ip-proxy-pool-target-count" style="display:none;">
+                    <span class="data-label">任务切换阈值</span>
+                    <div class="data-inline">
+                      <input type="number" id="input-ip-proxy-pool-target-count" class="data-input" min="1" max="500" step="1"
+                        placeholder="20（成功轮次）" title="每成功多少轮任务后自动切换一次代理；仅 1 条节点时会跳过自动切换" />
+                      <span class="data-unit">轮</span>
+                    </div>
+                  </div>
+                </div>
+                <div class="ip-proxy-column ip-proxy-column-api" id="ip-proxy-api-panel">
+                  <div class="ip-proxy-column-header">API 模式</div>
+                  <div class="data-row ip-proxy-column-row" id="row-ip-proxy-api-url" style="display:none;">
+                    <span class="data-label">代理API</span>
+                    <div class="input-with-icon">
+                      <input type="password" id="input-ip-proxy-api-url" class="data-input data-input-with-icon"
+                        placeholder="粘贴完整 API 链接" />
+                      <button id="btn-toggle-ip-proxy-api-url" class="input-icon-btn" type="button" aria-label="显示代理 API"
+                        title="显示代理 API"></button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="data-row" id="row-ip-proxy-actions" style="display:none;">
+              <span class="data-label">切换代理</span>
+              <div class="data-inline ip-proxy-actions-inline">
+                <span id="ip-proxy-action-buttons" class="ip-proxy-action-grid">
+                  <button id="btn-ip-proxy-refresh" class="btn btn-outline btn-sm data-inline-btn" type="button">拉取</button>
+                  <button id="btn-ip-proxy-next" class="btn btn-outline btn-sm data-inline-btn" type="button">下一条</button>
+                  <button id="btn-ip-proxy-change" class="btn btn-outline btn-sm data-inline-btn" type="button" title="保持当前会话并刷新出口（仅 711 + session）">Change</button>
+                  <button id="btn-ip-proxy-probe" class="btn btn-outline btn-sm data-inline-btn" type="button">检测出口</button>
+                </span>
+                <span id="ip-proxy-action-hint" class="ip-proxy-action-hint">
+                  下一条：切到代理池下一条。Change：保持当前 session 重绑链路（仅 711 + session）。
+                </span>
+              </div>
+            </div>
+            <div class="data-row" id="row-ip-proxy-runtime-status" style="display:none;">
+              <span class="data-label">代理状态</span>
+              <div id="ip-proxy-runtime-status" class="ip-proxy-runtime-status" aria-live="polite">
+                <span id="ip-proxy-runtime-dot" class="ip-proxy-runtime-dot" aria-hidden="true"></span>
+                <div class="ip-proxy-runtime-content">
+                  <div class="ip-proxy-runtime-main">
+                    <span id="ip-proxy-runtime-text" class="data-value data-value-fill">未启用，沿用浏览器默认/全局代理。</span>
+                  </div>
+                  <div class="ip-proxy-runtime-meta">
+                    <span id="ip-proxy-current" class="ip-proxy-runtime-current mono truncate">未启用</span>
+                    <button id="btn-ip-proxy-check-ip" class="btn btn-outline btn-xs data-inline-btn ip-proxy-check-ip-btn" type="button">检查IP</button>
+                  </div>
+                  <details id="ip-proxy-runtime-details" class="ip-proxy-runtime-details" hidden>
+                    <summary>查看详细信息</summary>
+                    <div id="ip-proxy-runtime-details-text" class="ip-proxy-runtime-details-text"></div>
+                  </details>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
       <div class="data-row" id="row-codex2api-url" style="display:none;">
         <span class="data-label">Codex2API</span>
         <input type="text" id="input-codex2api-url" class="data-input"
@@ -867,6 +1019,8 @@
   <script src="mail-2925-manager.js"></script>
   <script src="icloud-manager.js"></script>
   <script src="luckmail-manager.js"></script>
+  <script src="ip-proxy-provider-lumiproxy.js"></script>
+  <script src="ip-proxy-panel.js"></script>
   <script src="contribution-mode.js"></script>
   <script src="account-records-manager.js"></script>
   <script src="sidepanel.js"></script>

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -95,6 +95,60 @@ const rowSub2ApiGroup = document.getElementById('row-sub2api-group');
 const inputSub2ApiGroup = document.getElementById('input-sub2api-group');
 const rowSub2ApiDefaultProxy = document.getElementById('row-sub2api-default-proxy');
 const inputSub2ApiDefaultProxy = document.getElementById('input-sub2api-default-proxy');
+const rowIpProxyEnabled = document.getElementById('row-ip-proxy-enabled');
+const inputIpProxyEnabled = document.getElementById('input-ip-proxy-enabled');
+const ipProxyEnabledStatus = document.getElementById('ip-proxy-enabled-status');
+const ipProxyEnabledStatusDot = document.getElementById('ip-proxy-enabled-status-dot');
+const ipProxyEnabledStatusText = document.getElementById('ip-proxy-enabled-status-text');
+const ipProxyEnabledButtons = Array.from(document.querySelectorAll('[data-ip-proxy-enabled]'));
+const rowIpProxyFold = document.getElementById('row-ip-proxy-fold');
+const rowIpProxyService = document.getElementById('row-ip-proxy-service');
+const selectIpProxyService = document.getElementById('select-ip-proxy-service');
+const rowIpProxyMode = document.getElementById('row-ip-proxy-mode');
+const ipProxyModeButtons = Array.from(document.querySelectorAll('[data-ip-proxy-mode]'));
+const rowIpProxyLayout = document.getElementById('row-ip-proxy-layout');
+const ipProxyLayout = document.getElementById('ip-proxy-layout');
+const ipProxyApiPanel = document.getElementById('ip-proxy-api-panel');
+const rowIpProxyApiUrl = document.getElementById('row-ip-proxy-api-url');
+const inputIpProxyApiUrl = document.getElementById('input-ip-proxy-api-url');
+const btnToggleIpProxyApiUrl = document.getElementById('btn-toggle-ip-proxy-api-url');
+const rowIpProxyAccountList = document.getElementById('row-ip-proxy-account-list');
+const inputIpProxyAccountList = document.getElementById('input-ip-proxy-account-list');
+const rowIpProxyAccountSessionPrefix = document.getElementById('row-ip-proxy-account-session-prefix');
+const inputIpProxyAccountSessionPrefix = document.getElementById('input-ip-proxy-account-session-prefix');
+const rowIpProxyAccountLifeMinutes = document.getElementById('row-ip-proxy-account-life-minutes');
+const inputIpProxyAccountLifeMinutes = document.getElementById('input-ip-proxy-account-life-minutes');
+const rowIpProxyPoolTargetCount = document.getElementById('row-ip-proxy-pool-target-count');
+const inputIpProxyPoolTargetCount = document.getElementById('input-ip-proxy-pool-target-count');
+const rowIpProxyHost = document.getElementById('row-ip-proxy-host');
+const inputIpProxyHost = document.getElementById('input-ip-proxy-host');
+const rowIpProxyPort = document.getElementById('row-ip-proxy-port');
+const inputIpProxyPort = document.getElementById('input-ip-proxy-port');
+const rowIpProxyProtocol = document.getElementById('row-ip-proxy-protocol');
+const selectIpProxyProtocol = document.getElementById('select-ip-proxy-protocol');
+const rowIpProxyUsername = document.getElementById('row-ip-proxy-username');
+const inputIpProxyUsername = document.getElementById('input-ip-proxy-username');
+const btnToggleIpProxyUsername = document.getElementById('btn-toggle-ip-proxy-username');
+const rowIpProxyPassword = document.getElementById('row-ip-proxy-password');
+const inputIpProxyPassword = document.getElementById('input-ip-proxy-password');
+const btnToggleIpProxyPassword = document.getElementById('btn-toggle-ip-proxy-password');
+const rowIpProxyRegion = document.getElementById('row-ip-proxy-region');
+const inputIpProxyRegion = document.getElementById('input-ip-proxy-region');
+const rowIpProxyActions = document.getElementById('row-ip-proxy-actions');
+const ipProxyActionButtons = document.getElementById('ip-proxy-action-buttons');
+const ipProxyActionHint = document.getElementById('ip-proxy-action-hint');
+const btnIpProxyRefresh = document.getElementById('btn-ip-proxy-refresh');
+const btnIpProxyNext = document.getElementById('btn-ip-proxy-next');
+const btnIpProxyChange = document.getElementById('btn-ip-proxy-change');
+const btnIpProxyProbe = document.getElementById('btn-ip-proxy-probe');
+const btnIpProxyCheckIp = document.getElementById('btn-ip-proxy-check-ip');
+const ipProxyCurrent = document.getElementById('ip-proxy-current');
+const rowIpProxyRuntimeStatus = document.getElementById('row-ip-proxy-runtime-status');
+const ipProxyRuntimeStatus = document.getElementById('ip-proxy-runtime-status');
+const ipProxyRuntimeDot = document.getElementById('ip-proxy-runtime-dot');
+const ipProxyRuntimeText = document.getElementById('ip-proxy-runtime-text');
+const ipProxyRuntimeDetails = document.getElementById('ip-proxy-runtime-details');
+const ipProxyRuntimeDetailsText = document.getElementById('ip-proxy-runtime-details-text');
 const rowCodex2ApiUrl = document.getElementById('row-codex2api-url');
 const inputCodex2ApiUrl = document.getElementById('input-codex2api-url');
 const rowCodex2ApiAdminKey = document.getElementById('row-codex2api-admin-key');
@@ -322,6 +376,14 @@ const CONTRIBUTION_UPLOAD_URL = 'https://apikey.qzz.io/';
 const DEFAULT_PHONE_VERIFICATION_ENABLED = false;
 const DEFAULT_HERO_SMS_COUNTRY_ID = 52;
 const DEFAULT_HERO_SMS_COUNTRY_LABEL = 'Thailand';
+const DEFAULT_IP_PROXY_SERVICE = '711proxy';
+const SUPPORTED_IP_PROXY_SERVICES = ['711proxy'];
+const DEFAULT_IP_PROXY_MODE = 'account';
+const SUPPORTED_IP_PROXY_MODES = ['api', 'account'];
+const DEFAULT_IP_PROXY_PROTOCOL = 'http';
+const SUPPORTED_IP_PROXY_PROTOCOLS = ['http', 'https', 'socks4', 'socks5'];
+const IP_PROXY_API_MODE_ENABLED = false;
+const IP_PROXY_ACCOUNT_LIST_ENABLED = false;
 
 function getManagedAliasUtils() {
   return window.MultiPageManagedAliasUtils || null;
@@ -1928,6 +1990,201 @@ function collectSettingsPayload() {
     : '';
   const normalizedIcloudTargetMailboxType = normalizeIcloudTargetMailboxType(icloudTargetMailboxTypeValue);
   const normalizedIcloudForwardMailProvider = normalizeIcloudForwardMailProvider(icloudForwardMailProviderValue);
+  const normalizeIpProxyServiceSafe = typeof normalizeIpProxyService === 'function'
+    ? normalizeIpProxyService
+    : ((value = '') => {
+      const normalized = String(value || '').trim().toLowerCase();
+      return ['711proxy'].includes(normalized)
+        ? normalized
+        : '711proxy';
+    });
+  const normalizeIpProxyModeSafe = typeof normalizeIpProxyMode === 'function'
+    ? normalizeIpProxyMode
+    : ((value = '') => {
+      const normalized = String(value || '').trim().toLowerCase();
+      return ['api', 'account'].includes(normalized) ? normalized : 'account';
+    });
+  const normalizeIpProxyProtocolSafe = typeof normalizeIpProxyProtocol === 'function'
+    ? normalizeIpProxyProtocol
+    : ((value = '') => {
+      const normalized = String(value || '').trim().toLowerCase();
+      return ['http', 'https', 'socks4', 'socks5'].includes(normalized) ? normalized : 'http';
+    });
+  const normalizeIpProxyPortSafe = typeof normalizeIpProxyPort === 'function'
+    ? normalizeIpProxyPort
+    : ((value = '') => {
+      const numeric = Number.parseInt(String(value || '').trim(), 10);
+      if (!Number.isInteger(numeric) || numeric <= 0 || numeric > 65535) {
+        return 0;
+      }
+      return numeric;
+    });
+  const normalizeIpProxyPoolTargetCountSafe = typeof normalizeIpProxyPoolTargetCount === 'function'
+    ? normalizeIpProxyPoolTargetCount
+    : ((value = '', fallback = 20) => {
+      const rawValue = String(value ?? '').trim();
+      if (!rawValue) {
+        return String(Math.max(1, Math.min(500, Number(fallback) || 20)));
+      }
+      const numeric = Number.parseInt(rawValue, 10);
+      if (!Number.isInteger(numeric)) {
+        return String(Math.max(1, Math.min(500, Number(fallback) || 20)));
+      }
+      return String(Math.max(1, Math.min(500, numeric)));
+    });
+  const normalizeIpProxyAccountLifeMinutesSafe = typeof normalizeIpProxyAccountLifeMinutes === 'function'
+    ? normalizeIpProxyAccountLifeMinutes
+    : ((value = '', fallback = '') => {
+      const rawValue = String(value ?? '').trim();
+      if (!rawValue) {
+        return String(fallback || '').trim();
+      }
+      const numeric = Number.parseInt(rawValue, 10);
+      if (!Number.isInteger(numeric)) {
+        return String(fallback || '').trim();
+      }
+      return String(Math.max(1, Math.min(1440, numeric)));
+    });
+  const normalizeIpProxyAccountSessionPrefixSafe = typeof normalizeIpProxyAccountSessionPrefix === 'function'
+    ? normalizeIpProxyAccountSessionPrefix
+    : ((value = '') => String(value || '').trim().replace(/[^A-Za-z0-9_-]/g, '').slice(0, 32));
+  const normalizeIpProxyAccountListSafe = typeof normalizeIpProxyAccountList === 'function'
+    ? normalizeIpProxyAccountList
+    : ((value = '') => String(value || '')
+      .replace(/\r/g, '')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .join('\n'));
+  const getSelectedIpProxyEnabledSafe = typeof getSelectedIpProxyEnabled === 'function'
+    ? getSelectedIpProxyEnabled
+    : (() => false);
+  const getSelectedIpProxyModeSafe = typeof getSelectedIpProxyMode === 'function'
+    ? getSelectedIpProxyMode
+    : (() => 'account');
+  const isIpProxyApiModeEnabledSafe = typeof isIpProxyApiModeAvailable === 'function'
+    ? Boolean(isIpProxyApiModeAvailable())
+    : (typeof IP_PROXY_API_MODE_ENABLED !== 'undefined' ? Boolean(IP_PROXY_API_MODE_ENABLED) : false);
+  const normalizeIpProxyServiceProfilesSafe = typeof normalizeIpProxyServiceProfiles === 'function'
+    ? normalizeIpProxyServiceProfiles
+    : ((rawValue = {}, fallbackState = {}) => {
+      const raw = (rawValue && typeof rawValue === 'object' && !Array.isArray(rawValue))
+        ? rawValue
+        : {};
+      const services = ['711proxy'];
+      const fallbackProfile = {
+        mode: normalizeIpProxyModeSafe(fallbackState?.ipProxyMode || 'account'),
+        apiUrl: String(fallbackState?.ipProxyApiUrl || '').trim(),
+        accountList: normalizeIpProxyAccountListSafe(fallbackState?.ipProxyAccountList || ''),
+        accountSessionPrefix: normalizeIpProxyAccountSessionPrefixSafe(fallbackState?.ipProxyAccountSessionPrefix || ''),
+        accountLifeMinutes: normalizeIpProxyAccountLifeMinutesSafe(fallbackState?.ipProxyAccountLifeMinutes || ''),
+        poolTargetCount: normalizeIpProxyPoolTargetCountSafe(fallbackState?.ipProxyPoolTargetCount || '', 20),
+        host: String(fallbackState?.ipProxyHost || '').trim(),
+        port: String(normalizeIpProxyPortSafe(fallbackState?.ipProxyPort || '') || ''),
+        protocol: normalizeIpProxyProtocolSafe(fallbackState?.ipProxyProtocol || ''),
+        username: String(fallbackState?.ipProxyUsername || '').trim(),
+        password: String(fallbackState?.ipProxyPassword || ''),
+        region: String(fallbackState?.ipProxyRegion || '').trim(),
+      };
+      const result = {};
+      services.forEach((service) => {
+        const candidate = raw?.[service];
+        const source = (candidate && typeof candidate === 'object' && !Array.isArray(candidate))
+          ? candidate
+          : fallbackProfile;
+        result[service] = {
+          mode: normalizeIpProxyModeSafe(source.mode || fallbackProfile.mode),
+          apiUrl: String(source.apiUrl || fallbackProfile.apiUrl || '').trim(),
+          accountList: normalizeIpProxyAccountListSafe(source.accountList || fallbackProfile.accountList),
+          accountSessionPrefix: normalizeIpProxyAccountSessionPrefixSafe(source.accountSessionPrefix || fallbackProfile.accountSessionPrefix),
+          accountLifeMinutes: normalizeIpProxyAccountLifeMinutesSafe(source.accountLifeMinutes || fallbackProfile.accountLifeMinutes),
+          poolTargetCount: normalizeIpProxyPoolTargetCountSafe(source.poolTargetCount || fallbackProfile.poolTargetCount, 20),
+          host: String(source.host || fallbackProfile.host || '').trim(),
+          port: String(normalizeIpProxyPortSafe(source.port || fallbackProfile.port || '') || ''),
+          protocol: normalizeIpProxyProtocolSafe(source.protocol || fallbackProfile.protocol),
+          username: String(source.username || fallbackProfile.username || '').trim(),
+          password: String(source.password || fallbackProfile.password || ''),
+          region: String(source.region || fallbackProfile.region || '').trim(),
+        };
+      });
+      return result;
+    });
+  const ipProxyServiceRawValue = typeof selectIpProxyService !== 'undefined'
+    ? selectIpProxyService?.value
+    : '';
+  const ipProxyApiUrlRawValue = typeof inputIpProxyApiUrl !== 'undefined'
+    ? inputIpProxyApiUrl?.value
+    : '';
+  const ipProxyAccountListRawValue = typeof inputIpProxyAccountList !== 'undefined'
+    ? inputIpProxyAccountList?.value
+    : '';
+  const ipProxyAccountSessionPrefixRawValue = typeof inputIpProxyAccountSessionPrefix !== 'undefined'
+    ? inputIpProxyAccountSessionPrefix?.value
+    : '';
+  const ipProxyAccountLifeMinutesRawValue = typeof inputIpProxyAccountLifeMinutes !== 'undefined'
+    ? inputIpProxyAccountLifeMinutes?.value
+    : '';
+  const ipProxyPoolTargetCountRawValue = typeof inputIpProxyPoolTargetCount !== 'undefined'
+    ? inputIpProxyPoolTargetCount?.value
+    : '';
+  const ipProxyHostRawValue = typeof inputIpProxyHost !== 'undefined'
+    ? inputIpProxyHost?.value
+    : '';
+  const ipProxyPortRawValue = typeof inputIpProxyPort !== 'undefined'
+    ? inputIpProxyPort?.value
+    : '';
+  const ipProxyProtocolRawValue = typeof selectIpProxyProtocol !== 'undefined'
+    ? selectIpProxyProtocol?.value
+    : '';
+  const ipProxyUsernameRawValue = typeof inputIpProxyUsername !== 'undefined'
+    ? inputIpProxyUsername?.value
+    : '';
+  const ipProxyPasswordRawValue = typeof inputIpProxyPassword !== 'undefined'
+    ? inputIpProxyPassword?.value
+    : '';
+  const ipProxyRegionRawValue = typeof inputIpProxyRegion !== 'undefined'
+    ? inputIpProxyRegion?.value
+    : '';
+  const selectedIpProxyService = normalizeIpProxyServiceSafe(
+    ipProxyServiceRawValue || latestState?.ipProxyService || '711proxy'
+  );
+  const selectedIpProxyModeRaw = normalizeIpProxyModeSafe(getSelectedIpProxyModeSafe());
+  const selectedIpProxyMode = (!isIpProxyApiModeEnabledSafe && selectedIpProxyModeRaw === 'api')
+    ? 'account'
+    : selectedIpProxyModeRaw;
+  const currentIpProxyServiceProfile = {
+    mode: selectedIpProxyMode,
+    apiUrl: String(ipProxyApiUrlRawValue || '').trim(),
+    accountList: normalizeIpProxyAccountListSafe(ipProxyAccountListRawValue || ''),
+    accountSessionPrefix: normalizeIpProxyAccountSessionPrefixSafe(ipProxyAccountSessionPrefixRawValue || ''),
+    accountLifeMinutes: normalizeIpProxyAccountLifeMinutesSafe(ipProxyAccountLifeMinutesRawValue || ''),
+    poolTargetCount: normalizeIpProxyPoolTargetCountSafe(ipProxyPoolTargetCountRawValue || '', 20),
+    host: String(ipProxyHostRawValue || '').trim(),
+    port: String(normalizeIpProxyPortSafe(ipProxyPortRawValue || '') || ''),
+    protocol: normalizeIpProxyProtocolSafe(ipProxyProtocolRawValue),
+    username: String(ipProxyUsernameRawValue || '').trim(),
+    password: String(ipProxyPasswordRawValue || ''),
+    region: String(ipProxyRegionRawValue || '').trim(),
+  };
+  const ipProxyServiceProfiles = normalizeIpProxyServiceProfilesSafe({
+    ...(latestState?.ipProxyServiceProfiles || {}),
+    [selectedIpProxyService]: currentIpProxyServiceProfile,
+  }, {
+    ...(latestState || {}),
+    ipProxyService: selectedIpProxyService,
+    ipProxyMode: currentIpProxyServiceProfile.mode,
+    ipProxyApiUrl: currentIpProxyServiceProfile.apiUrl,
+    ipProxyAccountList: currentIpProxyServiceProfile.accountList,
+    ipProxyAccountSessionPrefix: currentIpProxyServiceProfile.accountSessionPrefix,
+    ipProxyAccountLifeMinutes: currentIpProxyServiceProfile.accountLifeMinutes,
+    ipProxyPoolTargetCount: currentIpProxyServiceProfile.poolTargetCount,
+    ipProxyHost: currentIpProxyServiceProfile.host,
+    ipProxyPort: currentIpProxyServiceProfile.port,
+    ipProxyProtocol: currentIpProxyServiceProfile.protocol,
+    ipProxyUsername: currentIpProxyServiceProfile.username,
+    ipProxyPassword: currentIpProxyServiceProfile.password,
+    ipProxyRegion: currentIpProxyServiceProfile.region,
+  });
   const mail2925UseAccountPool = typeof inputMail2925UseAccountPool !== 'undefined'
     ? Boolean(inputMail2925UseAccountPool?.checked)
     : Boolean(latestState?.mail2925UseAccountPool);
@@ -1952,6 +2209,21 @@ function collectSettingsPayload() {
     sub2apiPassword: inputSub2ApiPassword.value,
     sub2apiGroupName: inputSub2ApiGroup.value.trim(),
     sub2apiDefaultProxyName: inputSub2ApiDefaultProxy.value.trim(),
+    ipProxyEnabled: getSelectedIpProxyEnabledSafe(),
+    ipProxyService: selectedIpProxyService,
+    ipProxyMode: currentIpProxyServiceProfile.mode,
+    ipProxyApiUrl: currentIpProxyServiceProfile.apiUrl,
+    ipProxyServiceProfiles,
+    ipProxyAccountList: currentIpProxyServiceProfile.accountList,
+    ipProxyAccountSessionPrefix: currentIpProxyServiceProfile.accountSessionPrefix,
+    ipProxyAccountLifeMinutes: currentIpProxyServiceProfile.accountLifeMinutes,
+    ipProxyPoolTargetCount: currentIpProxyServiceProfile.poolTargetCount,
+    ipProxyHost: currentIpProxyServiceProfile.host,
+    ipProxyPort: normalizeIpProxyPortSafe(currentIpProxyServiceProfile.port),
+    ipProxyProtocol: currentIpProxyServiceProfile.protocol,
+    ipProxyUsername: currentIpProxyServiceProfile.username,
+    ipProxyPassword: currentIpProxyServiceProfile.password,
+    ipProxyRegion: currentIpProxyServiceProfile.region,
     codex2apiUrl: inputCodex2ApiUrl.value.trim(),
     codex2apiAdminKey: inputCodex2ApiAdminKey.value.trim(),
     plusModeEnabled: typeof inputPlusModeEnabled !== 'undefined' && inputPlusModeEnabled
@@ -2489,6 +2761,79 @@ function applySettingsState(state) {
   inputSub2ApiPassword.value = state?.sub2apiPassword || '';
   inputSub2ApiGroup.value = state?.sub2apiGroupName || '';
   inputSub2ApiDefaultProxy.value = state?.sub2apiDefaultProxyName || '';
+  const normalizedIpProxyService = normalizeIpProxyService(state?.ipProxyService);
+  const normalizedIpProxyServiceProfiles = typeof normalizeIpProxyServiceProfiles === 'function'
+    ? normalizeIpProxyServiceProfiles(state?.ipProxyServiceProfiles || {}, state || {})
+    : (state?.ipProxyServiceProfiles || {});
+  const activeIpProxyProfile = typeof getIpProxyServiceProfile === 'function'
+    ? getIpProxyServiceProfile(normalizedIpProxyService, {
+      ...(state || {}),
+      ipProxyService: normalizedIpProxyService,
+      ipProxyServiceProfiles: normalizedIpProxyServiceProfiles,
+    })
+    : {
+      mode: typeof normalizeIpProxyModeForCurrentRelease === 'function'
+        ? normalizeIpProxyModeForCurrentRelease(state?.ipProxyMode)
+        : normalizeIpProxyMode(state?.ipProxyMode),
+      apiUrl: String(state?.ipProxyApiUrl || '').trim(),
+      accountList: normalizeIpProxyAccountList(state?.ipProxyAccountList || ''),
+      accountSessionPrefix: normalizeIpProxyAccountSessionPrefix(state?.ipProxyAccountSessionPrefix || ''),
+      accountLifeMinutes: normalizeIpProxyAccountLifeMinutes(state?.ipProxyAccountLifeMinutes || ''),
+      poolTargetCount: normalizeIpProxyPoolTargetCount(state?.ipProxyPoolTargetCount || '', 20),
+      host: String(state?.ipProxyHost || '').trim(),
+      port: String(normalizeIpProxyPort(state?.ipProxyPort || '') || ''),
+      protocol: normalizeIpProxyProtocol(state?.ipProxyProtocol),
+      username: String(state?.ipProxyUsername || '').trim(),
+      password: String(state?.ipProxyPassword || ''),
+      region: String(state?.ipProxyRegion || '').trim(),
+    };
+  if (selectIpProxyService) {
+    selectIpProxyService.value = normalizedIpProxyService;
+  }
+  if (inputIpProxyApiUrl) {
+    inputIpProxyApiUrl.value = String(activeIpProxyProfile.apiUrl || '').trim();
+  }
+  if (inputIpProxyAccountList) {
+    inputIpProxyAccountList.value = activeIpProxyProfile.accountList;
+  }
+  if (inputIpProxyAccountSessionPrefix) {
+    inputIpProxyAccountSessionPrefix.value = activeIpProxyProfile.accountSessionPrefix;
+  }
+  if (inputIpProxyAccountLifeMinutes) {
+    inputIpProxyAccountLifeMinutes.value = activeIpProxyProfile.accountLifeMinutes;
+  }
+  if (inputIpProxyPoolTargetCount) {
+    inputIpProxyPoolTargetCount.value = activeIpProxyProfile.poolTargetCount;
+  }
+  if (inputIpProxyHost) {
+    inputIpProxyHost.value = activeIpProxyProfile.host;
+  }
+  if (inputIpProxyPort) {
+    const normalizedPort = normalizeIpProxyPort(activeIpProxyProfile.port || '');
+    inputIpProxyPort.value = normalizedPort > 0 ? String(normalizedPort) : '';
+  }
+  if (selectIpProxyProtocol) {
+    selectIpProxyProtocol.value = normalizeIpProxyProtocol(activeIpProxyProfile.protocol);
+  }
+  if (inputIpProxyUsername) {
+    inputIpProxyUsername.value = activeIpProxyProfile.username;
+  }
+  if (inputIpProxyPassword) {
+    inputIpProxyPassword.value = activeIpProxyProfile.password;
+  }
+  if (inputIpProxyRegion) {
+    inputIpProxyRegion.value = activeIpProxyProfile.region;
+  }
+  setIpProxyMode(activeIpProxyProfile.mode);
+  setIpProxyEnabled(Boolean(state?.ipProxyEnabled));
+  syncLatestState({
+    ipProxyService: normalizedIpProxyService,
+    ipProxyServiceProfiles: normalizedIpProxyServiceProfiles,
+    ...(typeof buildIpProxyStatePatchFromServiceProfile === 'function'
+      ? buildIpProxyStatePatchFromServiceProfile(normalizedIpProxyService, activeIpProxyProfile)
+      : {}),
+  });
+  updateIpProxyUI(latestState);
   inputCodex2ApiUrl.value = state?.codex2apiUrl || '';
   inputCodex2ApiAdminKey.value = state?.codex2apiAdminKey || '';
   const restoredMailProvider = isCustomMailProvider(state?.mailProvider)
@@ -4498,6 +4843,27 @@ function syncVpsPasswordToggleLabel() {
   });
 }
 
+function syncIpProxyApiUrlToggleLabel() {
+  syncToggleButtonLabel(btnToggleIpProxyApiUrl, inputIpProxyApiUrl, {
+    show: '显示代理 API',
+    hide: '隐藏代理 API',
+  });
+}
+
+function syncIpProxyUsernameToggleLabel() {
+  syncToggleButtonLabel(btnToggleIpProxyUsername, inputIpProxyUsername, {
+    show: '显示代理账号',
+    hide: '隐藏代理账号',
+  });
+}
+
+function syncIpProxyPasswordToggleLabel() {
+  syncToggleButtonLabel(btnToggleIpProxyPassword, inputIpProxyPassword, {
+    show: '显示代理密码',
+    hide: '隐藏代理密码',
+  });
+}
+
 async function maybeTakeoverAutoRun(actionLabel) {
   if (!isAutoRunPausedPhase()) {
     return true;
@@ -4634,6 +5000,21 @@ btnToggleVpsUrl.addEventListener('click', () => {
 btnToggleVpsPassword.addEventListener('click', () => {
   inputVpsPassword.type = inputVpsPassword.type === 'password' ? 'text' : 'password';
   syncVpsPasswordToggleLabel();
+});
+
+btnToggleIpProxyApiUrl?.addEventListener('click', () => {
+  inputIpProxyApiUrl.type = inputIpProxyApiUrl.type === 'password' ? 'text' : 'password';
+  syncIpProxyApiUrlToggleLabel();
+});
+
+btnToggleIpProxyUsername?.addEventListener('click', () => {
+  inputIpProxyUsername.type = inputIpProxyUsername.type === 'password' ? 'text' : 'password';
+  syncIpProxyUsernameToggleLabel();
+});
+
+btnToggleIpProxyPassword?.addEventListener('click', () => {
+  inputIpProxyPassword.type = inputIpProxyPassword.type === 'password' ? 'text' : 'password';
+  syncIpProxyPasswordToggleLabel();
 });
 
 btnMailLogin?.addEventListener('click', async () => {
@@ -5160,6 +5541,240 @@ selectPanelMode.addEventListener('change', () => {
   saveSettings({ silent: true }).catch(() => { });
 });
 
+function syncCurrentIpProxyServiceProfileToLatestState() {
+  const selectedService = normalizeIpProxyService(
+    selectIpProxyService?.value || latestState?.ipProxyService || DEFAULT_IP_PROXY_SERVICE
+  );
+  const normalizedProfiles = typeof buildIpProxyServiceProfilesPatch === 'function'
+    ? buildIpProxyServiceProfilesPatch(selectedService, latestState || {})
+    : { ...(latestState?.ipProxyServiceProfiles || {}) };
+  const currentProfile = typeof getIpProxyServiceProfile === 'function'
+    ? getIpProxyServiceProfile(selectedService, {
+      ...(latestState || {}),
+      ipProxyService: selectedService,
+      ipProxyServiceProfiles: normalizedProfiles,
+    })
+    : {
+      mode: normalizeIpProxyMode(getSelectedIpProxyMode()),
+      apiUrl: String(inputIpProxyApiUrl?.value || '').trim(),
+      accountList: normalizeIpProxyAccountList(inputIpProxyAccountList?.value || ''),
+      accountSessionPrefix: normalizeIpProxyAccountSessionPrefix(inputIpProxyAccountSessionPrefix?.value || ''),
+      accountLifeMinutes: normalizeIpProxyAccountLifeMinutes(inputIpProxyAccountLifeMinutes?.value || ''),
+      poolTargetCount: normalizeIpProxyPoolTargetCount(inputIpProxyPoolTargetCount?.value || '', 20),
+      host: String(inputIpProxyHost?.value || '').trim(),
+      port: String(normalizeIpProxyPort(inputIpProxyPort?.value || '') || ''),
+      protocol: normalizeIpProxyProtocol(selectIpProxyProtocol?.value || ''),
+      username: String(inputIpProxyUsername?.value || '').trim(),
+      password: String(inputIpProxyPassword?.value || ''),
+      region: String(inputIpProxyRegion?.value || '').trim(),
+    };
+  syncLatestState({
+    ipProxyService: selectedService,
+    ipProxyServiceProfiles: normalizedProfiles,
+    ...(typeof buildIpProxyStatePatchFromServiceProfile === 'function'
+      ? buildIpProxyStatePatchFromServiceProfile(selectedService, currentProfile)
+      : {}),
+  });
+}
+
+function handleIpProxyEnabledToggle(nextEnabled) {
+  const enabled = Boolean(nextEnabled);
+  const previousEnabled = Boolean(latestState?.ipProxyEnabled);
+  if (previousEnabled === enabled) {
+    setIpProxyEnabled(enabled);
+    updateIpProxyUI(latestState);
+    return;
+  }
+  setIpProxyEnabled(enabled);
+  syncLatestState({ ipProxyEnabled: enabled });
+  updateIpProxyUI(latestState);
+  markSettingsDirty(true);
+  saveSettings({ silent: true }).catch(() => {});
+}
+
+if (inputIpProxyEnabled) {
+  inputIpProxyEnabled.addEventListener('change', () => {
+    handleIpProxyEnabledToggle(Boolean(inputIpProxyEnabled.checked));
+  });
+} else {
+  ipProxyEnabledButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const nextEnabled = String(button.dataset.ipProxyEnabled) === 'true';
+      handleIpProxyEnabledToggle(nextEnabled);
+    });
+  });
+}
+
+selectIpProxyService?.addEventListener('change', () => {
+  const previousService = normalizeIpProxyService(latestState?.ipProxyService || DEFAULT_IP_PROXY_SERVICE);
+  const nextService = normalizeIpProxyService(selectIpProxyService.value);
+  const normalizedProfiles = typeof normalizeIpProxyServiceProfiles === 'function'
+    ? normalizeIpProxyServiceProfiles(latestState?.ipProxyServiceProfiles || {}, latestState || {})
+    : { ...(latestState?.ipProxyServiceProfiles || {}) };
+
+  if (typeof buildCurrentIpProxyServiceProfileFromInputs === 'function') {
+    normalizedProfiles[previousService] = buildCurrentIpProxyServiceProfileFromInputs();
+  }
+
+  const nextProfile = typeof getIpProxyServiceProfile === 'function'
+    ? getIpProxyServiceProfile(nextService, {
+      ...(latestState || {}),
+      ipProxyService: nextService,
+      ipProxyServiceProfiles: normalizedProfiles,
+    })
+    : {
+      mode: typeof normalizeIpProxyModeForCurrentRelease === 'function'
+        ? normalizeIpProxyModeForCurrentRelease(latestState?.ipProxyMode)
+        : normalizeIpProxyMode(latestState?.ipProxyMode),
+      apiUrl: String(latestState?.ipProxyApiUrl || '').trim(),
+      accountList: normalizeIpProxyAccountList(latestState?.ipProxyAccountList || ''),
+      accountSessionPrefix: normalizeIpProxyAccountSessionPrefix(latestState?.ipProxyAccountSessionPrefix || ''),
+      accountLifeMinutes: normalizeIpProxyAccountLifeMinutes(latestState?.ipProxyAccountLifeMinutes || ''),
+      poolTargetCount: normalizeIpProxyPoolTargetCount(latestState?.ipProxyPoolTargetCount || '', 20),
+      host: String(latestState?.ipProxyHost || '').trim(),
+      port: String(normalizeIpProxyPort(latestState?.ipProxyPort || '') || ''),
+      protocol: normalizeIpProxyProtocol(latestState?.ipProxyProtocol),
+      username: String(latestState?.ipProxyUsername || '').trim(),
+      password: String(latestState?.ipProxyPassword || ''),
+      region: String(latestState?.ipProxyRegion || '').trim(),
+    };
+
+  if (typeof applyIpProxyServiceProfileToInputs === 'function') {
+    applyIpProxyServiceProfileToInputs(nextProfile);
+  } else {
+    setIpProxyMode(nextProfile.mode);
+  }
+
+  syncLatestState({
+    ipProxyService: nextService,
+    ipProxyServiceProfiles: normalizedProfiles,
+    ...(typeof buildIpProxyStatePatchFromServiceProfile === 'function'
+      ? buildIpProxyStatePatchFromServiceProfile(nextService, nextProfile)
+      : {}),
+  });
+  updateIpProxyUI(latestState);
+  markSettingsDirty(true);
+  saveSettings({ silent: true }).catch(() => {});
+});
+
+ipProxyModeButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    const nextMode = normalizeIpProxyMode(button.dataset.ipProxyMode || DEFAULT_IP_PROXY_MODE);
+    const apiModeAvailable = typeof isIpProxyApiModeAvailable === 'function'
+      ? Boolean(isIpProxyApiModeAvailable())
+      : (typeof IP_PROXY_API_MODE_ENABLED !== 'undefined' ? Boolean(IP_PROXY_API_MODE_ENABLED) : false);
+    if (!apiModeAvailable && nextMode === 'api') {
+      setIpProxyMode('account');
+      updateIpProxyUI(latestState);
+      showToast('API 模式暂未开放，请先使用账号密码模式。', 'info', 1800);
+      return;
+    }
+    if (getSelectedIpProxyMode() === nextMode) {
+      return;
+    }
+    setIpProxyMode(nextMode);
+    syncCurrentIpProxyServiceProfileToLatestState();
+    updateIpProxyUI(latestState);
+    markSettingsDirty(true);
+    saveSettings({ silent: true }).catch(() => {});
+  });
+});
+
+selectIpProxyProtocol?.addEventListener('change', () => {
+  syncCurrentIpProxyServiceProfileToLatestState();
+  updateIpProxyUI(latestState);
+  markSettingsDirty(true);
+  saveSettings({ silent: true }).catch(() => {});
+});
+
+btnIpProxyRefresh?.addEventListener('click', async () => {
+  try {
+    const result = typeof runIpProxyActionWithLock === 'function'
+      ? await runIpProxyActionWithLock('refresh', async () => {
+        await saveSettings({ silent: true });
+        await refreshIpProxyPoolByApi();
+      })
+      : await (async () => {
+        await saveSettings({ silent: true });
+        await refreshIpProxyPoolByApi();
+        return { skipped: false };
+      })();
+    if (result?.skipped) {
+      return;
+    }
+  } catch (err) {
+    showToast(err?.message || String(err || '未知错误'), 'error');
+  }
+});
+
+btnIpProxyNext?.addEventListener('click', async () => {
+  try {
+    const result = typeof runIpProxyActionWithLock === 'function'
+      ? await runIpProxyActionWithLock('next', async () => {
+        await saveSettings({ silent: true });
+        await switchIpProxyToNext();
+      })
+      : await (async () => {
+        await saveSettings({ silent: true });
+        await switchIpProxyToNext();
+        return { skipped: false };
+      })();
+    if (result?.skipped) {
+      return;
+    }
+  } catch (err) {
+    showToast(err?.message || String(err || '未知错误'), 'error');
+  }
+});
+
+btnIpProxyChange?.addEventListener('click', async () => {
+  try {
+    const result = typeof runIpProxyActionWithLock === 'function'
+      ? await runIpProxyActionWithLock('change', async () => {
+        await saveSettings({ silent: true });
+        await changeIpProxyExitBySession();
+      })
+      : await (async () => {
+        await saveSettings({ silent: true });
+        await changeIpProxyExitBySession();
+        return { skipped: false };
+      })();
+    if (result?.skipped) {
+      return;
+    }
+  } catch (err) {
+    showToast(err?.message || String(err || '未知错误'), 'error');
+  }
+});
+
+btnIpProxyProbe?.addEventListener('click', async () => {
+  try {
+    const result = typeof runIpProxyActionWithLock === 'function'
+      ? await runIpProxyActionWithLock('probe', async () => {
+        await saveSettings({ silent: true });
+        await probeIpProxyExit();
+      })
+      : await (async () => {
+        await saveSettings({ silent: true });
+        await probeIpProxyExit();
+        return { skipped: false };
+      })();
+    if (result?.skipped) {
+      return;
+    }
+  } catch (err) {
+    showToast(err?.message || String(err || '未知错误'), 'error');
+  }
+});
+
+btnIpProxyCheckIp?.addEventListener('click', async () => {
+  try {
+    await chrome.tabs.create({ url: 'https://ipinfo.io/what-is-my-ip' });
+  } catch (err) {
+    showToast(`打开 IP 检测页失败：${err?.message || String(err || '未知错误')}`, 'error');
+  }
+});
+
 selectCfDomain.addEventListener('change', () => {
   if (selectCfDomain.disabled) {
     return;
@@ -5286,6 +5901,188 @@ inputCodex2ApiAdminKey.addEventListener('input', () => {
 });
 inputCodex2ApiAdminKey.addEventListener('blur', () => {
   saveSettings({ silent: true }).catch(() => { });
+});
+
+[
+  inputIpProxyApiUrl,
+  inputIpProxyAccountList,
+  inputIpProxyHost,
+  inputIpProxyUsername,
+  inputIpProxyPassword,
+].forEach((input) => {
+  input?.addEventListener('input', () => {
+    markSettingsDirty(true);
+    scheduleSettingsAutoSave();
+  });
+  input?.addEventListener('blur', () => {
+    saveSettings({ silent: true }).catch(() => {});
+  });
+});
+
+inputIpProxyUsername?.addEventListener('paste', () => {
+  setTimeout(() => {
+    let profileUpdated = false;
+    if (typeof sync711SessionFieldsFromUsernameForPanel !== 'function') {
+      profileUpdated = false;
+    } else {
+      const result = sync711SessionFieldsFromUsernameForPanel();
+      profileUpdated = profileUpdated || Boolean(result?.updated);
+    }
+    if (typeof sync711RegionFieldFromUsernameForPanel === 'function') {
+      const regionResult = sync711RegionFieldFromUsernameForPanel();
+      profileUpdated = profileUpdated || Boolean(regionResult?.updated);
+    }
+    if (typeof syncIpProxyRegionInputFromCredentials === 'function') {
+      const beforeRegion = String(inputIpProxyRegion?.value || '');
+      syncIpProxyRegionInputFromCredentials({ force: true });
+      const afterRegion = String(inputIpProxyRegion?.value || '');
+      profileUpdated = profileUpdated || (beforeRegion !== afterRegion);
+    }
+    if (!profileUpdated) return;
+    syncCurrentIpProxyServiceProfileToLatestState();
+    updateIpProxyUI(latestState);
+    markSettingsDirty(true);
+    scheduleSettingsAutoSave();
+  }, 0);
+});
+
+inputIpProxyHost?.addEventListener('blur', () => {
+  if (typeof syncIpProxyRegionInputFromCredentials === 'function') {
+    const beforeRegion = String(inputIpProxyRegion?.value || '');
+    syncIpProxyRegionInputFromCredentials({ force: true });
+    const afterRegion = String(inputIpProxyRegion?.value || '');
+    if (afterRegion !== beforeRegion) {
+      markSettingsDirty(true);
+      saveSettings({ silent: true }).catch(() => {});
+    }
+  }
+});
+
+inputIpProxyUsername?.addEventListener('blur', () => {
+  let profileUpdated = false;
+  if (typeof sync711SessionFieldsFromUsernameForPanel === 'function') {
+    const result = sync711SessionFieldsFromUsernameForPanel();
+    profileUpdated = profileUpdated || Boolean(result?.updated);
+  }
+  if (typeof sync711RegionFieldFromUsernameForPanel === 'function') {
+    const regionResult = sync711RegionFieldFromUsernameForPanel();
+    profileUpdated = profileUpdated || Boolean(regionResult?.updated);
+  }
+
+  if (typeof syncIpProxyRegionInputFromCredentials === 'function') {
+    const beforeRegion = String(inputIpProxyRegion?.value || '');
+    syncIpProxyRegionInputFromCredentials({ force: true });
+    const afterRegion = String(inputIpProxyRegion?.value || '');
+    profileUpdated = profileUpdated || (afterRegion !== beforeRegion);
+  }
+
+  if (profileUpdated) {
+    syncCurrentIpProxyServiceProfileToLatestState();
+    updateIpProxyUI(latestState);
+    markSettingsDirty(true);
+    saveSettings({ silent: true }).catch(() => {});
+  }
+});
+
+inputIpProxyAccountSessionPrefix?.addEventListener('input', () => {
+  const syncResult = typeof sync711UsernameFromSessionFieldsForPanel === 'function'
+    ? sync711UsernameFromSessionFieldsForPanel()
+    : null;
+  if (syncResult?.updated) {
+    syncCurrentIpProxyServiceProfileToLatestState();
+    updateIpProxyUI(latestState);
+  }
+  markSettingsDirty(true);
+  scheduleSettingsAutoSave();
+});
+inputIpProxyAccountSessionPrefix?.addEventListener('blur', () => {
+  inputIpProxyAccountSessionPrefix.value = normalizeIpProxyAccountSessionPrefix(inputIpProxyAccountSessionPrefix.value || '');
+  const syncResult = typeof sync711UsernameFromSessionFieldsForPanel === 'function'
+    ? sync711UsernameFromSessionFieldsForPanel({ removeWhenEmpty: true })
+    : null;
+  if (syncResult?.updated) {
+    syncCurrentIpProxyServiceProfileToLatestState();
+    updateIpProxyUI(latestState);
+    markSettingsDirty(true);
+  }
+  saveSettings({ silent: true }).catch(() => {});
+});
+
+inputIpProxyAccountLifeMinutes?.addEventListener('input', () => {
+  const syncResult = typeof sync711UsernameFromSessionFieldsForPanel === 'function'
+    ? sync711UsernameFromSessionFieldsForPanel()
+    : null;
+  if (syncResult?.updated) {
+    syncCurrentIpProxyServiceProfileToLatestState();
+    updateIpProxyUI(latestState);
+  }
+  markSettingsDirty(true);
+  scheduleSettingsAutoSave();
+});
+inputIpProxyAccountLifeMinutes?.addEventListener('blur', () => {
+  inputIpProxyAccountLifeMinutes.value = normalizeIpProxyAccountLifeMinutes(inputIpProxyAccountLifeMinutes.value || '');
+  const syncResult = typeof sync711UsernameFromSessionFieldsForPanel === 'function'
+    ? sync711UsernameFromSessionFieldsForPanel({ removeWhenEmpty: true })
+    : null;
+  if (syncResult?.updated) {
+    syncCurrentIpProxyServiceProfileToLatestState();
+    updateIpProxyUI(latestState);
+    markSettingsDirty(true);
+  }
+  saveSettings({ silent: true }).catch(() => {});
+});
+
+inputIpProxyRegion?.addEventListener('input', () => {
+  const normalizedRegion = typeof normalize711RegionCodeForPanel === 'function'
+    ? normalize711RegionCodeForPanel(inputIpProxyRegion.value || '')
+    : String(inputIpProxyRegion.value || '').trim().toUpperCase();
+  if (normalizedRegion) {
+    inputIpProxyRegion.value = normalizedRegion;
+  }
+
+  const syncResult = typeof sync711UsernameFromRegionForPanel === 'function'
+    ? sync711UsernameFromRegionForPanel()
+    : null;
+  if (syncResult?.updated) {
+    syncCurrentIpProxyServiceProfileToLatestState();
+    updateIpProxyUI(latestState);
+  }
+  markSettingsDirty(true);
+  scheduleSettingsAutoSave();
+});
+inputIpProxyRegion?.addEventListener('blur', () => {
+  const normalizedRegion = typeof normalize711RegionCodeForPanel === 'function'
+    ? normalize711RegionCodeForPanel(inputIpProxyRegion.value || '')
+    : String(inputIpProxyRegion.value || '').trim().toUpperCase();
+  inputIpProxyRegion.value = normalizedRegion;
+  const syncResult = typeof sync711UsernameFromRegionForPanel === 'function'
+    ? sync711UsernameFromRegionForPanel({ removeWhenEmpty: true })
+    : null;
+  if (syncResult?.updated) {
+    syncCurrentIpProxyServiceProfileToLatestState();
+    updateIpProxyUI(latestState);
+    markSettingsDirty(true);
+  }
+  saveSettings({ silent: true }).catch(() => {});
+});
+
+inputIpProxyPoolTargetCount?.addEventListener('input', () => {
+  markSettingsDirty(true);
+  scheduleSettingsAutoSave();
+});
+inputIpProxyPoolTargetCount?.addEventListener('blur', () => {
+  inputIpProxyPoolTargetCount.value = normalizeIpProxyPoolTargetCount(inputIpProxyPoolTargetCount.value || '', 20);
+  saveSettings({ silent: true }).catch(() => {});
+});
+
+inputIpProxyPort?.addEventListener('input', () => {
+  markSettingsDirty(true);
+  scheduleSettingsAutoSave();
+});
+inputIpProxyPort?.addEventListener('blur', () => {
+  const normalizedPort = normalizeIpProxyPort(inputIpProxyPort.value || '');
+  inputIpProxyPort.value = normalizedPort > 0 ? String(normalizedPort) : '';
+  saveSettings({ silent: true }).catch(() => {});
 });
 
 inputEmailPrefix.addEventListener('input', () => {
@@ -5652,6 +6449,142 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         selectPanelMode.value = message.payload.panelMode || 'cpa';
         updatePanelModeUI();
       }
+      if (
+        message.payload.ipProxyEnabled !== undefined
+        || message.payload.ipProxyService !== undefined
+        || message.payload.ipProxyServiceProfiles !== undefined
+        || message.payload.ipProxyMode !== undefined
+        || message.payload.ipProxyApiUrl !== undefined
+        || message.payload.ipProxyAccountList !== undefined
+        || message.payload.ipProxyAccountSessionPrefix !== undefined
+        || message.payload.ipProxyAccountLifeMinutes !== undefined
+        || message.payload.ipProxyPoolTargetCount !== undefined
+        || message.payload.ipProxyHost !== undefined
+        || message.payload.ipProxyPort !== undefined
+        || message.payload.ipProxyProtocol !== undefined
+        || message.payload.ipProxyUsername !== undefined
+        || message.payload.ipProxyPassword !== undefined
+        || message.payload.ipProxyRegion !== undefined
+        || message.payload.ipProxyApiPool !== undefined
+        || message.payload.ipProxyApiCurrentIndex !== undefined
+        || message.payload.ipProxyApiCurrent !== undefined
+        || message.payload.ipProxyAccountPool !== undefined
+        || message.payload.ipProxyAccountCurrentIndex !== undefined
+        || message.payload.ipProxyAccountCurrent !== undefined
+        || message.payload.ipProxyCurrent !== undefined
+        || message.payload.ipProxyCurrentIndex !== undefined
+        || message.payload.ipProxyPool !== undefined
+        || message.payload.ipProxyApplied !== undefined
+        || message.payload.ipProxyAppliedReason !== undefined
+        || message.payload.ipProxyAppliedHost !== undefined
+        || message.payload.ipProxyAppliedPort !== undefined
+        || message.payload.ipProxyAppliedRegion !== undefined
+        || message.payload.ipProxyAppliedHasAuth !== undefined
+        || message.payload.ipProxyAppliedWarning !== undefined
+        || message.payload.ipProxyAppliedExitIp !== undefined
+        || message.payload.ipProxyAppliedExitRegion !== undefined
+        || message.payload.ipProxyAppliedExitDetecting !== undefined
+        || message.payload.ipProxyAppliedExitError !== undefined
+        || message.payload.ipProxyAppliedExitSource !== undefined
+      ) {
+        const hasIpProxyConfigPayload = (
+          message.payload.ipProxyService !== undefined
+          || message.payload.ipProxyServiceProfiles !== undefined
+          || message.payload.ipProxyMode !== undefined
+          || message.payload.ipProxyApiUrl !== undefined
+          || message.payload.ipProxyAccountList !== undefined
+          || message.payload.ipProxyAccountSessionPrefix !== undefined
+          || message.payload.ipProxyAccountLifeMinutes !== undefined
+          || message.payload.ipProxyPoolTargetCount !== undefined
+          || message.payload.ipProxyHost !== undefined
+          || message.payload.ipProxyPort !== undefined
+          || message.payload.ipProxyProtocol !== undefined
+          || message.payload.ipProxyUsername !== undefined
+          || message.payload.ipProxyPassword !== undefined
+          || message.payload.ipProxyRegion !== undefined
+        );
+        const selectedProxyService = normalizeIpProxyService(
+          message.payload.ipProxyService !== undefined
+            ? message.payload.ipProxyService
+            : latestState?.ipProxyService
+        );
+        const mergedProxyState = {
+          ...(latestState || {}),
+          ...message.payload,
+          ipProxyService: selectedProxyService,
+        };
+        let normalizedProxyProfiles = (mergedProxyState?.ipProxyServiceProfiles || {});
+        if (typeof normalizeIpProxyServiceProfiles === 'function') {
+          normalizedProxyProfiles = normalizeIpProxyServiceProfiles(
+            mergedProxyState?.ipProxyServiceProfiles || {},
+            mergedProxyState
+          );
+        }
+        if (typeof buildIpProxyServiceProfileFromFlatState === 'function') {
+          normalizedProxyProfiles[selectedProxyService] = buildIpProxyServiceProfileFromFlatState(mergedProxyState);
+        }
+        if (selectIpProxyService) {
+          selectIpProxyService.value = selectedProxyService;
+        }
+        if (message.payload.ipProxyEnabled !== undefined) {
+          setIpProxyEnabled(Boolean(message.payload.ipProxyEnabled));
+        }
+        if (message.payload.ipProxyApiUrl !== undefined && inputIpProxyApiUrl) {
+          inputIpProxyApiUrl.value = String(message.payload.ipProxyApiUrl || '').trim();
+        }
+        if (hasIpProxyConfigPayload) {
+          const activeProxyProfile = typeof getIpProxyServiceProfile === 'function'
+            ? getIpProxyServiceProfile(selectedProxyService, {
+              ...mergedProxyState,
+              ipProxyServiceProfiles: normalizedProxyProfiles,
+            })
+            : {
+              mode: typeof normalizeIpProxyModeForCurrentRelease === 'function'
+                ? normalizeIpProxyModeForCurrentRelease(mergedProxyState?.ipProxyMode)
+                : normalizeIpProxyMode(mergedProxyState?.ipProxyMode),
+              apiUrl: String(mergedProxyState?.ipProxyApiUrl || '').trim(),
+              accountList: normalizeIpProxyAccountList(mergedProxyState?.ipProxyAccountList || ''),
+              accountSessionPrefix: normalizeIpProxyAccountSessionPrefix(mergedProxyState?.ipProxyAccountSessionPrefix || ''),
+              accountLifeMinutes: normalizeIpProxyAccountLifeMinutes(mergedProxyState?.ipProxyAccountLifeMinutes || ''),
+              poolTargetCount: normalizeIpProxyPoolTargetCount(mergedProxyState?.ipProxyPoolTargetCount || '', 20),
+              host: String(mergedProxyState?.ipProxyHost || '').trim(),
+              port: String(normalizeIpProxyPort(mergedProxyState?.ipProxyPort || '') || ''),
+              protocol: normalizeIpProxyProtocol(mergedProxyState?.ipProxyProtocol),
+              username: String(mergedProxyState?.ipProxyUsername || '').trim(),
+              password: String(mergedProxyState?.ipProxyPassword || ''),
+              region: String(mergedProxyState?.ipProxyRegion || '').trim(),
+            };
+          if (typeof applyIpProxyServiceProfileToInputs === 'function') {
+            applyIpProxyServiceProfileToInputs(activeProxyProfile);
+          } else {
+            setIpProxyMode(activeProxyProfile.mode);
+            if (inputIpProxyApiUrl) inputIpProxyApiUrl.value = String(activeProxyProfile.apiUrl || '').trim();
+            if (inputIpProxyAccountList) inputIpProxyAccountList.value = activeProxyProfile.accountList;
+            if (inputIpProxyAccountSessionPrefix) inputIpProxyAccountSessionPrefix.value = activeProxyProfile.accountSessionPrefix;
+            if (inputIpProxyAccountLifeMinutes) inputIpProxyAccountLifeMinutes.value = activeProxyProfile.accountLifeMinutes;
+            if (inputIpProxyPoolTargetCount) inputIpProxyPoolTargetCount.value = activeProxyProfile.poolTargetCount;
+            if (inputIpProxyHost) inputIpProxyHost.value = activeProxyProfile.host;
+            if (inputIpProxyPort) inputIpProxyPort.value = activeProxyProfile.port;
+            if (selectIpProxyProtocol) selectIpProxyProtocol.value = normalizeIpProxyProtocol(activeProxyProfile.protocol);
+            if (inputIpProxyUsername) inputIpProxyUsername.value = activeProxyProfile.username;
+            if (inputIpProxyPassword) inputIpProxyPassword.value = activeProxyProfile.password;
+            if (inputIpProxyRegion) inputIpProxyRegion.value = activeProxyProfile.region;
+          }
+          syncLatestState({
+            ipProxyService: selectedProxyService,
+            ipProxyServiceProfiles: normalizedProxyProfiles,
+            ...(typeof buildIpProxyStatePatchFromServiceProfile === 'function'
+              ? buildIpProxyStatePatchFromServiceProfile(selectedProxyService, activeProxyProfile)
+              : {}),
+          });
+        } else {
+          syncLatestState({
+            ipProxyService: selectedProxyService,
+            ipProxyServiceProfiles: normalizedProxyProfiles,
+          });
+        }
+        updateIpProxyUI(latestState);
+      }
       if (message.payload.oauthUrl !== undefined) {
         displayOauthUrl.textContent = message.payload.oauthUrl || '等待中...';
         displayOauthUrl.classList.toggle('has-value', Boolean(message.payload.oauthUrl));
@@ -5913,6 +6846,9 @@ loadHeroSmsCountries().catch((err) => {
     syncPasswordToggleLabel();
     syncVpsUrlToggleLabel();
     syncVpsPasswordToggleLabel();
+    syncIpProxyApiUrlToggleLabel();
+    syncIpProxyUsernameToggleLabel();
+    syncIpProxyPasswordToggleLabel();
     updatePanelModeUI();
     updateButtonStates();
     updateStatusDisplay(latestState);


### PR DESCRIPTION
## 说明\n这是基于 Ultra1 的独立分支改动，只包含 IP 模块相关文件与说明文档。\n\n## 包含内容\n1. 后台模块：路由应用、切换、出口检测、诊断状态\n2. 侧边栏模块：开关、同步/下一条/Change/检测出口、状态卡\n3. 711 参数联动：session / sessTime / region 双向同步\n4. 文档：模块定位、功能、使用方式\n\n## 文件范围\n- background.js\n- background/message-router.js\n- background/ip-proxy-core.js\n- background/ip-proxy-provider-lumiproxy.js\n- sidepanel/sidepanel.html\n- sidepanel/sidepanel.css\n- sidepanel/sidepanel.js\n- sidepanel/ip-proxy-panel.js\n- sidepanel/ip-proxy-provider-lumiproxy.js\n- docs/ip-proxy-module.md\n\n> 本 PR 仅用于提交这部分独立模块改动，合并策略可由维护者按主线节奏处理。