### PR TITLE
fix(auth): 修复第8/9步重试链路与接码异常处理

### DIFF
--- a/background.js
+++ b/background.js
@@ -5729,7 +5729,7 @@ function isAddPhoneAuthFailure(error) {
   if (/\u624b\u673a\u53f7\u8f93\u5165\u6a21\u5f0f|phone\s+entry/i.test(message)) {
     return false;
   }
-  return /https:\/\/auth\.openai\.com\/add-phone(?:[/?#]|$)|\badd-phone\b|\u6dfb\u52a0\u624b\u673a\u53f7|\u624b\u673a\u53f7\u7801|\u8fdb\u5165\u624b\u673a\u53f7\u9875\u9762|\u624b\u673a\u53f7\u9875|\u624b\u673a\u53f7\u9875\u9762|phone\s+number|telephone/i.test(message);
+  return /https:\/\/auth\.openai\.com\/add-phone(?:[/?#]|$)|\badd-phone\b|phone\s+verification(?:\s+page)?|\u6dfb\u52a0\u624b\u673a\u53f7|\u624b\u673a\u53f7\u7801|\u8fdb\u5165\u624b\u673a\u53f7\u9875\u9762|\u624b\u673a\u53f7\u9875|\u624b\u673a\u53f7\u9875\u9762|phone\s+number|telephone/i.test(message);
 }
 
 function getLoginAuthStateLabel(state) {
@@ -9196,7 +9196,6 @@ async function getPostStep6AutoRestartDecision(step, error) {
 
   const normalizedStep = Number(step);
   const errorMessage = getErrorMessage(error);
-  const shouldForceRestartFromStep7 = /restart step 7 with a new number/i.test(errorMessage);
   const latestState = await getState();
   const authChainStartStep = typeof getAuthChainStartStepId === 'function'
     ? getAuthChainStartStepId(latestState)
@@ -9223,11 +9222,23 @@ async function getPostStep6AutoRestartDecision(step, error) {
     };
   }
 
-  if (shouldForceRestartFromStep7) {
+  const isPhoneVerificationFlowFatal = (
+    Boolean(error && typeof error === 'object' && (
+      error.addPhoneFlowFatal
+      || error.phoneVerificationFlowFatal
+    ))
+    || (
+      currentStepKey === 'confirm-oauth'
+      && Boolean(latestState?.phoneVerificationEnabled)
+      && /(?:^|\b)(?:step\s*9|步骤\s*9)\b[\s\S]*?(?:hero\s*sms|phone\s+verification|add-phone|手机号|手机验证码)|hero\s*sms|timed out waiting for phone verification page|phone verification could not receive an sms/i.test(errorMessage)
+    )
+  );
+
+  if (isPhoneVerificationFlowFatal) {
     return {
-      shouldRestart: true,
-      blockedByAddPhone: false,
-      forcedByPhoneVerificationTimeout: true,
+      shouldRestart: false,
+      blockedByAddPhone: true,
+      forcedByPhoneVerificationTimeout: false,
       restartStep: authChainStartStep,
       errorMessage,
       authState: null,

--- a/background/logging-status.js
+++ b/background/logging-status.js
@@ -66,7 +66,7 @@
       if (/\u624b\u673a\u53f7\u8f93\u5165\u6a21\u5f0f|phone\s+entry/i.test(message)) {
         return false;
       }
-      return /https:\/\/auth\.openai\.com\/(?:add-phone|phone-verification)(?:[/?#]|$)|\badd-phone\b|phone-verification|\u6dfb\u52a0\u624b\u673a\u53f7|\u624b\u673a\u53f7\u7801|\u624b\u673a\u9a8c\u8bc1\u7801\u9875|\u624b\u673a\u9a8c\u8bc1\u9875|\u8fdb\u5165\u624b\u673a\u53f7\u9875\u9762|\u624b\u673a\u53f7\u9875|\u624b\u673a\u53f7\u9875\u9762|phone\s+number|telephone/i.test(message);
+      return /https:\/\/auth\.openai\.com\/(?:add-phone|phone-verification)(?:[/?#]|$)|\badd-phone\b|phone-verification|phone\s+verification(?:\s+page)?|\u6dfb\u52a0\u624b\u673a\u53f7|\u624b\u673a\u53f7\u7801|\u624b\u673a\u9a8c\u8bc1\u7801\u9875|\u624b\u673a\u9a8c\u8bc1\u9875|\u8fdb\u5165\u624b\u673a\u53f7\u9875\u9762|\u624b\u673a\u53f7\u9875|\u624b\u673a\u53f7\u9875\u9762|phone\s+number|telephone/i.test(message);
     }
 
     function getLoginAuthStateLabel(state) {

--- a/background/phone-verification-flow.js
+++ b/background/phone-verification-flow.js
@@ -28,8 +28,8 @@
     const DEFAULT_PHONE_CODE_WAIT_WINDOW_MS = 60000;
     const DEFAULT_PHONE_NUMBER_MAX_USES = 3;
     const DEFAULT_PHONE_PRICE_LOOKUP_ATTEMPTS = 3;
+    const DEFAULT_PHONE_NUMBER_REPLACEMENT_LIMIT = 5;
     const PHONE_CODE_TIMEOUT_ERROR_PREFIX = 'PHONE_CODE_TIMEOUT::';
-    const PHONE_RESTART_STEP7_ERROR_PREFIX = 'PHONE_RESTART_STEP7::';
 
     function normalizeUrl(value, fallback = DEFAULT_HERO_SMS_BASE_URL) {
       const trimmed = String(value || '').trim();
@@ -174,11 +174,13 @@
       return String(error?.message || '').startsWith(PHONE_CODE_TIMEOUT_ERROR_PREFIX);
     }
 
-    function buildPhoneRestartStep7Error(phoneNumber = '') {
-      const suffix = phoneNumber ? ` Current number: ${phoneNumber}.` : '';
-      return new Error(
-        `${PHONE_RESTART_STEP7_ERROR_PREFIX}Phone verification could not receive an SMS after resend. Restart step 7 with a new number.${suffix}`
-      );
+    function buildPhoneAddPhoneTerminalError(message = '') {
+      const detail = String(message || '').trim();
+      const suffix = detail ? ` ${detail}` : '';
+      const terminalError = new Error(`Step 9: add-phone flow cannot continue.${suffix} URL: https://auth.openai.com/add-phone`);
+      terminalError.addPhoneFlowFatal = true;
+      terminalError.phoneVerificationFlowFatal = true;
+      return terminalError;
     }
 
     function sanitizePhoneCodeTimeoutError(error) {
@@ -187,17 +189,6 @@
         return error;
       }
       return new Error(message.slice(PHONE_CODE_TIMEOUT_ERROR_PREFIX.length).trim() || 'Timed out waiting for the phone verification code.');
-    }
-
-    function sanitizePhoneRestartStep7Error(error) {
-      const message = String(error?.message || '');
-      if (!message.startsWith(PHONE_RESTART_STEP7_ERROR_PREFIX)) {
-        return error;
-      }
-      return new Error(
-        message.slice(PHONE_RESTART_STEP7_ERROR_PREFIX.length).trim()
-        || 'Phone verification could not receive an SMS after resend. Restart step 7 with a new number.'
-      );
     }
 
     async function fetchHeroSmsPayload(config, query, actionLabel) {
@@ -333,6 +324,51 @@
       return /\bNO_NUMBERS\b/i.test(describeHeroSmsPayload(payload));
     }
 
+    function isHeroSmsNoNumbersError(error) {
+      return isHeroSmsNoNumbersPayload(error?.payload || error?.message || error);
+    }
+
+    function extractHeroSmsErrorToken(payload) {
+      const text = describeHeroSmsPayload(payload).toUpperCase();
+      if (!text) {
+        return '';
+      }
+      const tokenMatch = text.match(/\b([A-Z][A-Z0-9_]{2,})\b/);
+      return String(tokenMatch?.[1] || '').trim();
+    }
+
+    function getHeroSmsTerminalAcquireReason(payload) {
+      const text = describeHeroSmsPayload(payload);
+      const token = extractHeroSmsErrorToken(payload);
+      const terminalTokenSet = new Set([
+        'NO_BALANCE',
+        'NOT_ENOUGH_BALANCE',
+        'BAD_KEY',
+        'WRONG_KEY',
+        'BAD_ACTION',
+        'BAD_SERVICE',
+        'BAD_STATUS',
+        'BAD_COUNTRY',
+        'ERROR_SQL',
+        'BANNED',
+      ]);
+      if (terminalTokenSet.has(token)) {
+        return text || token;
+      }
+      return '';
+    }
+
+    function isHeroSmsActivationReplaceableError(error) {
+      const text = describeHeroSmsPayload(error?.payload || error?.message || error).toUpperCase();
+      if (!text) {
+        return false;
+      }
+      return (
+        /\b(?:STATUS_CANCEL|NO_ACTIVATION|BAD_STATUS|STATUS_EXPIRED|STATUS_FINISHED|STATUS_DONE)\b/.test(text)
+        || /ACTIVATION WAS CANCELLED/.test(text)
+      );
+    }
+
     function extractHeroSmsWrongMaxPrice(payload) {
       if (payload && typeof payload === 'object') {
         const title = String(payload.title || '').trim();
@@ -355,7 +391,15 @@
       return /failed to fetch|networkerror|load failed/i.test(message);
     }
 
-    async function resolveCheapestPhoneActivationPrice(config, countryConfig) {
+    function findHeroSmsPriceLadder(payload) {
+      const candidates = collectHeroSmsPriceCandidates(payload, []);
+      if (!candidates.length) {
+        return [];
+      }
+      return Array.from(new Set(candidates.map((price) => Number(price)))).sort((left, right) => left - right);
+    }
+
+    async function resolvePhoneActivationPriceLadder(config, countryConfig) {
       for (let attempt = 1; attempt <= DEFAULT_PHONE_PRICE_LOOKUP_ATTEMPTS; attempt += 1) {
         try {
           const payload = await fetchHeroSmsPayload(config, {
@@ -363,15 +407,15 @@
             service: HERO_SMS_SERVICE_CODE,
             country: countryConfig.id,
           }, 'HeroSMS getPrices');
-          const price = findLowestHeroSmsPrice(payload);
-          if (price !== null) {
-            return price;
+          const priceLadder = findHeroSmsPriceLadder(payload);
+          if (priceLadder.length) {
+            return priceLadder;
           }
         } catch (_) {
           // Best-effort lookup only.
         }
       }
-      return null;
+      return [];
     }
 
     async function fetchPhoneActivationPayload(config, countryConfig, action, options = {}) {
@@ -429,37 +473,79 @@
     async function requestPhoneActivation(state = {}) {
       const config = resolvePhoneConfig(state);
       const countryConfig = resolveCountryConfig(state);
-      const maxPrice = await resolveCheapestPhoneActivationPrice(config, countryConfig);
+      const priceLadder = await resolvePhoneActivationPriceLadder(config, countryConfig);
+      const priceCandidates = priceLadder.length ? priceLadder : [null];
       const buildFallbackActivation = (requestAction) => ({
         countryId: countryConfig.id,
         ...(requestAction === 'getNumberV2' ? { statusAction: 'getStatusV2' } : {}),
       });
-      let requestAction = 'getNumber';
-      let payload;
 
-      try {
-        payload = await requestPhoneActivationWithPrice(config, countryConfig, requestAction, maxPrice);
-      } catch (error) {
-        if (!isHeroSmsNoNumbersPayload(error?.payload || error?.message)) {
-          throw error;
+      let lastNoNumbersMessage = '';
+
+      for (let priceIndex = 0; priceIndex < priceCandidates.length; priceIndex += 1) {
+        const maxPrice = priceCandidates[priceIndex];
+        const hasNextPrice = priceIndex < priceCandidates.length - 1;
+        const actions = ['getNumber', 'getNumberV2'];
+        let priceExhaustedByNoNumbers = false;
+
+        for (const requestAction of actions) {
+          let payload;
+          try {
+            payload = await requestPhoneActivationWithPrice(config, countryConfig, requestAction, maxPrice);
+          } catch (error) {
+            if (isHeroSmsNoNumbersError(error)) {
+              lastNoNumbersMessage = describeHeroSmsPayload(error?.payload || error?.message || '');
+              priceExhaustedByNoNumbers = true;
+              continue;
+            }
+            const terminalReason = getHeroSmsTerminalAcquireReason(error?.payload || error?.message || error);
+            if (terminalReason) {
+              throw buildPhoneAddPhoneTerminalError(
+                `HeroSMS number acquisition failed (${terminalReason}).`
+              );
+            }
+            throw error;
+          }
+
+          const activation = parseActivationPayload(payload, buildFallbackActivation(requestAction));
+          if (activation) {
+            return activation;
+          }
+
+          if (isHeroSmsNoNumbersPayload(payload)) {
+            lastNoNumbersMessage = describeHeroSmsPayload(payload);
+            priceExhaustedByNoNumbers = true;
+            continue;
+          }
+
+          const terminalReason = getHeroSmsTerminalAcquireReason(payload);
+          if (terminalReason) {
+            throw buildPhoneAddPhoneTerminalError(
+              `HeroSMS number acquisition failed (${terminalReason}).`
+            );
+          }
+
+          const text = describeHeroSmsPayload(payload);
+          throw new Error(`HeroSMS ${requestAction} failed: ${text || 'empty response'}`);
         }
-        requestAction = 'getNumberV2';
-        payload = await requestPhoneActivationWithPrice(config, countryConfig, requestAction, maxPrice);
+
+        if (priceExhaustedByNoNumbers && hasNextPrice) {
+          const nextPrice = priceCandidates[priceIndex + 1];
+          const currentPriceLabel = maxPrice === null ? '不限价' : String(maxPrice);
+          const nextPriceLabel = nextPrice === null ? '不限价' : String(nextPrice);
+          await addLog(
+            `Step 9: HeroSMS returned NO_NUMBERS at maxPrice=${currentPriceLabel}, retrying with maxPrice=${nextPriceLabel}.`,
+            'warn'
+          );
+        }
       }
 
-      let activation = parseActivationPayload(payload, buildFallbackActivation(requestAction));
-      if (!activation && requestAction === 'getNumber' && isHeroSmsNoNumbersPayload(payload)) {
-        requestAction = 'getNumberV2';
-        payload = await requestPhoneActivationWithPrice(config, countryConfig, requestAction, maxPrice);
-        activation = parseActivationPayload(payload, buildFallbackActivation(requestAction));
-      }
-
-      if (!activation) {
-        const text = describeHeroSmsPayload(payload);
-        throw new Error(`HeroSMS ${requestAction} failed: ${text || 'empty response'}`);
-      }
-
-      return activation;
+      const details = lastNoNumbersMessage
+        ? ` HeroSMS response: ${lastNoNumbersMessage}.`
+        : '';
+      throw buildPhoneAddPhoneTerminalError(
+        `HeroSMS has no available numbers for ${countryConfig.label}.${details}`
+      );
     }
 
     async function reactivatePhoneActivation(state = {}, activation) {
@@ -830,6 +916,17 @@
             replaceNumber: false,
           };
         } catch (error) {
+          if (isHeroSmsActivationReplaceableError(error)) {
+            await addLog(
+              `Step 9: HeroSMS reported activation issue for ${normalizedActivation.phoneNumber} (${error.message || 'unknown status'}), replacing this number in current step 9.`,
+              'warn'
+            );
+            return {
+              code: '',
+              replaceNumber: true,
+            };
+          }
+
           if (!isPhoneCodeTimeoutError(error)) {
             throw error;
           }
@@ -850,10 +947,13 @@
           }
 
           await addLog(
-            `Step 9: still no SMS for ${normalizedActivation.phoneNumber} 60 seconds after resend, restarting from step 7 with a new number.`,
+            `Step 9: still no SMS for ${normalizedActivation.phoneNumber} 60 seconds after resend, replacing the number in current step 9.`,
             'warn'
           );
-          throw buildPhoneRestartStep7Error(normalizedActivation.phoneNumber);
+          return {
+            code: '',
+            replaceNumber: true,
+          };
         }
       }
 
@@ -866,6 +966,16 @@
       let pageState = initialPageState || await readPhonePageState(tabId);
       let shouldCancelActivation = false;
       let remainingResendRequests = Math.max(0, Number(state.verificationResendCount) || 0);
+      let replacedNumberCount = 0;
+
+      const ensureReplacementWithinLimit = (reason = '') => {
+        replacedNumberCount += 1;
+        if (replacedNumberCount > DEFAULT_PHONE_NUMBER_REPLACEMENT_LIMIT) {
+          throw buildPhoneAddPhoneTerminalError(
+            `Reached number replacement limit (${DEFAULT_PHONE_NUMBER_REPLACEMENT_LIMIT}).${reason ? ` ${reason}` : ''}`
+          );
+        }
+      };
 
       try {
         while (true) {
@@ -885,13 +995,38 @@
             activation = await acquirePhoneActivation(state);
             shouldCancelActivation = true;
             await persistCurrentActivation(activation);
-            const submitResult = await submitPhoneNumber(tabId, activation.phoneNumber);
+            let submitResult;
+            try {
+              submitResult = await submitPhoneNumber(tabId, activation.phoneNumber);
+            } catch (submitError) {
+              const submitErrorMessage = String(submitError?.message || submitError || '');
+              const likelyNumberRejected = /Timed out waiting for phone verification page|already\s+(?:in use|used|associated|linked)|phone\s+number.*(?:invalid|not valid|unsupported|not supported|cannot|can't)|号码.*(?:已被|无效|不支持)/i
+                .test(submitErrorMessage);
+              if (likelyNumberRejected) {
+                const observedState = await readPhonePageState(tabId, 10000).catch(() => null);
+                if (observedState?.addPhonePage) {
+                  ensureReplacementWithinLimit(`Last reason: ${submitErrorMessage}`);
+                  await addLog(
+                    `Step 9: phone number ${activation.phoneNumber} was rejected on add-phone, replacing with a new number (${replacedNumberCount}/${DEFAULT_PHONE_NUMBER_REPLACEMENT_LIMIT}).`,
+                    'warn'
+                  );
+                  pageState = {
+                    ...pageState,
+                    ...observedState,
+                    addPhonePage: true,
+                    phoneVerificationPage: false,
+                  };
+                  continue;
+                }
+              }
+              throw submitError;
+            }
             await addLog('Step 9: submitted the phone number on add-phone page.', 'info');
             pageState = {
               ...pageState,
               ...submitResult,
-              addPhonePage: false,
-              phoneVerificationPage: true,
+              addPhonePage: Boolean(submitResult?.addPhonePage),
+              phoneVerificationPage: Boolean(submitResult?.phoneVerificationPage),
             };
           }
 
@@ -914,6 +1049,18 @@
 
             const codeResult = await waitForPhoneCodeOrRotateNumber(tabId, state, activation);
             if (codeResult.replaceNumber) {
+              ensureReplacementWithinLimit(`No SMS for ${activation.phoneNumber} after resend.`);
+              const backToAddPhone = await returnToAddPhone(tabId);
+              pageState = {
+                ...pageState,
+                ...backToAddPhone,
+                addPhonePage: true,
+                phoneVerificationPage: false,
+              };
+              await addLog(
+                `Step 9: switching to another number in current flow (${replacedNumberCount}/${DEFAULT_PHONE_NUMBER_REPLACEMENT_LIMIT}).`,
+                'warn'
+              );
               shouldReplaceNumber = true;
               break;
             }
@@ -922,6 +1069,7 @@
             const submitResult = await submitPhoneVerificationCode(tabId, codeResult.code);
 
             if (submitResult.returnedToAddPhone) {
+              ensureReplacementWithinLimit('Verification page returned to add-phone after code submission.');
               await addLog(
                 'Step 9: phone verification returned to add-phone after code submission, replacing the current number.',
                 'warn'
@@ -982,7 +1130,7 @@
           await cancelPhoneActivation(state, activation);
         }
         await clearCurrentActivation();
-        throw sanitizePhoneRestartStep7Error(sanitizePhoneCodeTimeoutError(error));
+        throw sanitizePhoneCodeTimeoutError(error);
       }
     }
 

--- a/background/steps/fetch-login-code.js
+++ b/background/steps/fetch-login-code.js
@@ -267,6 +267,7 @@
         disableTimeBudgetCap: mail.provider === '2925',
         getRemainingTimeMs: getStep8RemainingTimeResolver(state?.oauthUrl || '', visibleStep),
         requestFreshCodeFirst: false,
+        lastResendAt: Number(state?.loginVerificationRequestedAt) || 0,
         targetEmail: fixedTargetEmail,
         resendIntervalMs: mail.provider === LUCKMAIL_PROVIDER
           ? 15000

--- a/background/steps/fetch-signup-code.js
+++ b/background/steps/fetch-signup-code.js
@@ -158,6 +158,7 @@
         sessionKey: verificationSessionKey,
         disableTimeBudgetCap: mail.provider === '2925',
         requestFreshCodeFirst: shouldRequestFreshCodeFirst,
+        lastResendAt: Number(state?.signupVerificationRequestedAt) || 0,
         resendIntervalMs: mail.provider === LUCKMAIL_PROVIDER
           ? 15000
           : ((mail.provider === HOTMAIL_PROVIDER || mail.provider === '2925')

--- a/background/steps/oauth-login.js
+++ b/background/steps/oauth-login.js
@@ -14,7 +14,7 @@
         if (/\u624b\u673a\u53f7\u8f93\u5165\u6a21\u5f0f|phone\s+entry/i.test(message)) {
           return false;
         }
-        return /https:\/\/auth\.openai\.com\/add-phone(?:[/?#]|$)|\badd-phone\b|\u6dfb\u52a0\u624b\u673a\u53f7|\u624b\u673a\u53f7\u7801|\u8fdb\u5165\u624b\u673a\u53f7\u9875\u9762|\u624b\u673a\u53f7\u9875|\u624b\u673a\u53f7\u9875\u9762|phone\s+number|telephone/i.test(message);
+        return /https:\/\/auth\.openai\.com\/add-phone(?:[/?#]|$)|\badd-phone\b|phone\s+verification(?:\s+page)?|\u6dfb\u52a0\u624b\u673a\u53f7|\u624b\u673a\u53f7\u7801|\u8fdb\u5165\u624b\u673a\u53f7\u9875\u9762|\u624b\u673a\u53f7\u9875|\u624b\u673a\u53f7\u9875\u9762|phone\s+number|telephone/i.test(message);
       },
       isStep6RecoverableResult,
       isStep6SuccessResult,

--- a/background/verification-flow.js
+++ b/background/verification-flow.js
@@ -373,6 +373,24 @@
       };
     }
 
+    function getMailPollingTransportTimeouts(mail, timedPoll = {}) {
+      const responseTimeoutMs = Math.max(1000, Number(timedPoll?.responseTimeoutMs) || 1000);
+      const timeoutMs = Math.max(responseTimeoutMs, Number(timedPoll?.timeoutMs) || responseTimeoutMs);
+      if (mail?.source !== 'icloud-mail') {
+        return {
+          responseTimeoutMs,
+          timeoutMs,
+        };
+      }
+
+      const icloudResponseTimeoutMs = Math.max(12000, responseTimeoutMs);
+      const icloudTimeoutMs = Math.max(icloudResponseTimeoutMs + 4000, timeoutMs);
+      return {
+        responseTimeoutMs: icloudResponseTimeoutMs,
+        timeoutMs: icloudTimeoutMs,
+      };
+    }
+
     async function requestVerificationCodeResend(step, options = {}) {
       throwIfStopped();
       const signupTabId = await getTabId('signup-page');
@@ -597,6 +615,7 @@
               pollOverrides,
               `轮询${getVerificationCodeLabel(step)}验证码邮箱`
             );
+            const mailTransportTimeouts = getMailPollingTransportTimeouts(mail, timedPoll);
             const result = await sendToMailContentScriptResilient(
               mail,
               {
@@ -606,9 +625,9 @@
                 payload: timedPoll.payload,
               },
               {
-                timeoutMs: timedPoll.timeoutMs,
+                timeoutMs: mailTransportTimeouts.timeoutMs,
                 maxRecoveryAttempts: 2,
-                responseTimeoutMs: timedPoll.responseTimeoutMs,
+                responseTimeoutMs: mailTransportTimeouts.responseTimeoutMs,
               }
             );
 
@@ -752,6 +771,7 @@
             pollOverrides,
             `轮询${getVerificationCodeLabel(step)}验证码邮箱`
           );
+          const mailTransportTimeouts = getMailPollingTransportTimeouts(mail, timedPoll);
           const result = await sendToMailContentScriptResilient(
             mail,
             {
@@ -761,9 +781,9 @@
               payload: timedPoll.payload,
             },
             {
-              timeoutMs: timedPoll.timeoutMs,
+              timeoutMs: mailTransportTimeouts.timeoutMs,
               maxRecoveryAttempts: 2,
-              responseTimeoutMs: timedPoll.responseTimeoutMs,
+              responseTimeoutMs: mailTransportTimeouts.responseTimeoutMs,
             }
           );
 

--- a/tests/auto-run-step6-restart.test.js
+++ b/tests/auto-run-step6-restart.test.js
@@ -67,6 +67,7 @@ function createHarness(options = {}) {
     failureBudget = 1,
     failureMessage = '认证失败: Request failed with status code 502',
     authState = { state: 'password_page', url: 'https://auth.openai.com/log-in' },
+    phoneVerificationEnabled = false,
   } = options;
 
   return new Function(`
@@ -97,6 +98,7 @@ async function getState() {
   return {
     stepStatuses: { 3: 'completed' },
     mailProvider: '163',
+    phoneVerificationEnabled: ${JSON.stringify(phoneVerificationEnabled)},
   };
 }
 function isStopError(error) {
@@ -215,7 +217,24 @@ test('auto-run stops restarting on generic phone-page failure messages even with
   assert.ok(!result.events.logs.some(({ message }) => /回到步骤 7 重新开始授权流程/.test(message)));
 });
 
-test('auto-run restarts from step 7 when phone verification cannot receive SMS after resend', async () => {
+test('auto-run stops restarting when step 9 times out waiting for phone verification page', async () => {
+  const harness = createHarness({
+    failureStep: 9,
+    failureBudget: 1,
+    failureMessage: 'Timed out waiting for phone verification page.',
+    authState: { state: 'password_page', url: 'https://auth.openai.com/log-in' },
+    phoneVerificationEnabled: true,
+  });
+
+  const result = await harness.runAndCaptureError();
+
+  assert.ok(result?.error);
+  assert.equal(result.events.invalidations.length, 0);
+  assert.deepStrictEqual(result.events.steps, [7, 8, 9]);
+  assert.ok(!result.events.logs.some(({ message }) => /回到步骤 7 重新开始授权流程/.test(message)));
+});
+
+test('auto-run does not restart from step 7 when phone verification cannot receive SMS after resend', async () => {
   const harness = createHarness({
     failureStep: 9,
     failureBudget: 1,
@@ -223,10 +242,12 @@ test('auto-run restarts from step 7 when phone verification cannot receive SMS a
     authState: { state: 'add_phone_page', url: 'https://auth.openai.com/add-phone' },
   });
 
-  const events = await harness.run();
+  const result = await harness.runAndCaptureError();
 
-  assert.equal(events.invalidations.length, 1);
-  assert.deepStrictEqual(events.steps, [7, 8, 9, 7, 8, 9, 10]);
+  assert.ok(result?.error);
+  assert.equal(result.events.invalidations.length, 0);
+  assert.deepStrictEqual(result.events.steps, [7, 8, 9]);
+  assert.ok(!result.events.logs.some(({ message }) => /回到步骤 7 重新开始授权流程/.test(message)));
 });
 
 test('auto-run stop errors after step 7 are rethrown immediately instead of restarting', async () => {

--- a/tests/background-logging-status-module.test.js
+++ b/tests/background-logging-status-module.test.js
@@ -43,6 +43,10 @@ test('logging/status add-phone detection ignores step 2 phone-entry switch failu
     loggingStatus.isAddPhoneAuthFailure('Step 9: auth page entered phone verification page. URL: https://auth.openai.com/phone-verification'),
     true
   );
+  assert.equal(
+    loggingStatus.isAddPhoneAuthFailure('Timed out waiting for phone verification page.'),
+    true
+  );
   assert.equal(loggingStatus.getLoginAuthStateLabel('phone_verification_page'), '手机验证码页');
   assert.equal(loggingStatus.getLoginAuthStateLabel('oauth_consent_page'), 'OAuth 授权页');
 });

--- a/tests/background-step4-filter-window.test.js
+++ b/tests/background-step4-filter-window.test.js
@@ -110,6 +110,7 @@ test('step 4 does not request a fresh code first for Cloudflare temp mail', asyn
     await executor.executeStep4({
       email: 'user@example.com',
       password: 'secret',
+      signupVerificationRequestedAt: 690000,
     });
   } finally {
     Date.now = realDateNow;
@@ -118,6 +119,7 @@ test('step 4 does not request a fresh code first for Cloudflare temp mail', asyn
   assert.equal(capturedOptions.filterAfterTimestamp, 700000);
   assert.equal(capturedOptions.requestFreshCodeFirst, false);
   assert.equal(capturedOptions.resendIntervalMs, 25000);
+  assert.equal(capturedOptions.lastResendAt, 690000);
 });
 
 test('step 4 checks iCloud session before polling iCloud mailbox', async () => {

--- a/tests/background-step7-recovery.test.js
+++ b/tests/background-step7-recovery.test.js
@@ -68,6 +68,7 @@ test('step 8 submits login verification directly without replaying step 7', asyn
       email: 'user@example.com',
       password: 'secret',
       oauthUrl: 'https://oauth.example/latest',
+      loginVerificationRequestedAt: 120000,
     });
   } finally {
     Date.now = realDateNow;
@@ -80,6 +81,7 @@ test('step 8 submits login verification directly without replaying step 7', asyn
   assert.equal(typeof calls.resolveOptions.getRemainingTimeMs, 'function');
   assert.equal(await calls.resolveOptions.getRemainingTimeMs({ actionLabel: '登录验证码流程' }), 5000);
   assert.equal(calls.resolveOptions.resendIntervalMs, 25000);
+  assert.equal(calls.resolveOptions.lastResendAt, 120000);
   assert.equal(calls.resolveOptions.targetEmail, 'display.user@example.com');
   assert.deepStrictEqual(calls.setStates, [
     { step8VerificationTargetEmail: 'display.user@example.com' },

--- a/tests/phone-verification-flow.test.js
+++ b/tests/phone-verification-flow.test.js
@@ -244,6 +244,159 @@ test('phone verification helper retries with HeroSMS getNumberV2 when getNumber 
   assert.equal(requests[2].searchParams.get('fixedPrice'), 'true');
 });
 
+test('phone verification helper raises terminal add-phone error on HeroSMS account-level acquire failures', async () => {
+  const helpers = api.createPhoneVerificationHelpers({
+    addLog: async () => {},
+    ensureStep8SignupPageReady: async () => {},
+    fetchImpl: async (url) => {
+      const parsedUrl = new URL(url);
+      const action = parsedUrl.searchParams.get('action');
+      if (action === 'getPrices') {
+        return {
+          ok: true,
+          text: async () => buildHeroSmsPricesPayload(),
+        };
+      }
+      if (action === 'getNumber') {
+        return {
+          ok: true,
+          text: async () => 'NO_BALANCE',
+        };
+      }
+      throw new Error(`Unexpected HeroSMS action: ${action}`);
+    },
+    getState: async () => ({ heroSmsApiKey: 'demo-key' }),
+    sendToContentScriptResilient: async () => ({}),
+    setState: async () => {},
+    sleepWithStop: async () => {},
+    throwIfStopped: () => {},
+  });
+
+  await assert.rejects(
+    helpers.requestPhoneActivation({ heroSmsApiKey: 'demo-key' }),
+    /add-phone flow cannot continue[\s\S]*NO_BALANCE/i
+  );
+});
+
+test('phone verification helper replaces number in current step 9 when HeroSMS status returns STATUS_CANCEL', async () => {
+  const requests = [];
+  const messages = [];
+  let currentState = {
+    heroSmsApiKey: 'demo-key',
+    verificationResendCount: 0,
+    currentPhoneActivation: null,
+    reusablePhoneActivation: null,
+  };
+
+  const numbers = [
+    { activationId: '100001', phoneNumber: '66950000011' },
+    { activationId: '100002', phoneNumber: '66950000022' },
+  ];
+  let numberIndex = 0;
+  const statusById = {
+    '100001': 'STATUS_CANCEL',
+    '100002': 'STATUS_OK:987654',
+  };
+
+  const helpers = api.createPhoneVerificationHelpers({
+    addLog: async () => {},
+    ensureStep8SignupPageReady: async () => {},
+    fetchImpl: async (url) => {
+      const parsedUrl = new URL(url);
+      requests.push(parsedUrl);
+      const action = parsedUrl.searchParams.get('action');
+      const id = parsedUrl.searchParams.get('id');
+      if (action === 'getPrices') {
+        return {
+          ok: true,
+          text: async () => buildHeroSmsPricesPayload(),
+        };
+      }
+      if (action === 'getNumber') {
+        const nextNumber = numbers[numberIndex];
+        numberIndex += 1;
+        return {
+          ok: true,
+          text: async () => `ACCESS_NUMBER:${nextNumber.activationId}:${nextNumber.phoneNumber}`,
+        };
+      }
+      if (action === 'getStatus') {
+        return {
+          ok: true,
+          text: async () => statusById[id] || 'STATUS_WAIT_CODE',
+        };
+      }
+      if (action === 'setStatus') {
+        return {
+          ok: true,
+          text: async () => `STATUS_UPDATED:${id}`,
+        };
+      }
+      throw new Error(`Unexpected HeroSMS action: ${action}`);
+    },
+    getOAuthFlowStepTimeoutMs: async (defaultTimeoutMs) => defaultTimeoutMs,
+    getState: async () => ({ ...currentState }),
+    sendToContentScriptResilient: async (_source, message) => {
+      messages.push(message.type);
+      if (message.type === 'SUBMIT_PHONE_NUMBER') {
+        return {
+          phoneVerificationPage: true,
+          url: 'https://auth.openai.com/phone-verification',
+        };
+      }
+      if (message.type === 'RETURN_TO_ADD_PHONE') {
+        return {
+          addPhonePage: true,
+          url: 'https://auth.openai.com/add-phone',
+        };
+      }
+      if (message.type === 'SUBMIT_PHONE_VERIFICATION_CODE') {
+        return {
+          success: true,
+          consentReady: true,
+          url: 'https://auth.openai.com/authorize',
+        };
+      }
+      throw new Error(`Unexpected content-script message: ${message.type}`);
+    },
+    setState: async (updates) => {
+      currentState = { ...currentState, ...updates };
+    },
+    sleepWithStop: async () => {},
+    throwIfStopped: () => {},
+  });
+
+  const result = await helpers.completePhoneVerificationFlow(1, {
+    addPhonePage: true,
+    phoneVerificationPage: false,
+    url: 'https://auth.openai.com/add-phone',
+  });
+
+  assert.deepStrictEqual(result, {
+    success: true,
+    consentReady: true,
+    url: 'https://auth.openai.com/authorize',
+  });
+  assert.deepStrictEqual(messages, [
+    'SUBMIT_PHONE_NUMBER',
+    'RETURN_TO_ADD_PHONE',
+    'SUBMIT_PHONE_NUMBER',
+    'SUBMIT_PHONE_VERIFICATION_CODE',
+  ]);
+  const actions = requests.map((url) => `${url.searchParams.get('action')}:${url.searchParams.get('id') || ''}`);
+  assert.deepStrictEqual(actions, [
+    'getPrices:',
+    'getNumber:',
+    'getStatus:100001',
+    'setStatus:100001',
+    'getPrices:',
+    'getNumber:',
+    'getStatus:100002',
+    'setStatus:100002',
+  ]);
+  assert.deepStrictEqual(currentState.currentPhoneActivation, null);
+});
+
 test('phone verification helper uses HeroSMS getStatusV2 after acquiring a number via getNumberV2', async () => {
   const requests = [];
   const stateUpdates = [];
@@ -701,7 +854,7 @@ test('phone verification helper uses the configured HeroSMS country for both num
   }]);
 });
 
-test('phone verification helper throws a step-7 restart error after 60 seconds plus one resend window without SMS', async () => {
+test('phone verification helper replaces number in step 9 when no SMS arrives after resend', async () => {
   const requests = [];
   const messages = [];
   let currentState = {
@@ -711,6 +864,11 @@ test('phone verification helper throws a step-7 restart error after 60 seconds p
     reusablePhoneActivation: null,
   };
   const statusCallsById = {};
+  const numbers = [
+    { activationId: '123456', phoneNumber: '66959916439' },
+    { activationId: '654321', phoneNumber: '66959916440' },
+  ];
+  let numberIndex = 0;
   const realDateNow = Date.now;
   let fakeNow = 0;
   Date.now = () => fakeNow;
@@ -733,14 +891,22 @@ test('phone verification helper throws a step-7 restart error after 60 seconds p
         }
 
         if (action === 'getNumber') {
+          const nextNumber = numbers[numberIndex];
+          numberIndex += 1;
           return {
             ok: true,
-            text: async () => 'ACCESS_NUMBER:123456:66959916439',
+            text: async () => `ACCESS_NUMBER:${nextNumber.activationId}:${nextNumber.phoneNumber}`,
           };
         }
 
         if (action === 'getStatus') {
           statusCallsById[id] = (statusCallsById[id] || 0) + 1;
+          if (id === '654321') {
+            return {
+              ok: true,
+              text: async () => 'STATUS_OK:112233',
+            };
+          }
           return {
             ok: true,
             text: async () => 'STATUS_WAIT_CODE',
@@ -766,10 +932,23 @@ test('phone verification helper throws a step-7 restart error after 60 seconds p
             url: 'https://auth.openai.com/phone-verification',
           };
         }
+        if (message.type === 'SUBMIT_PHONE_VERIFICATION_CODE') {
+          return {
+            success: true,
+            consentReady: true,
+            url: 'https://auth.openai.com/authorize',
+          };
+        }
         if (message.type === 'RESEND_PHONE_VERIFICATION_CODE') {
           return {
             resent: true,
             url: 'https://auth.openai.com/phone-verification',
+          };
+        }
+        if (message.type === 'RETURN_TO_ADD_PHONE') {
+          return {
+            addPhonePage: true,
+            url: 'https://auth.openai.com/add-phone',
           };
         }
         throw new Error(`Unexpected content-script message: ${message.type}`);
@@ -783,18 +962,25 @@ test('phone verification helper throws a step-7 restart error after 60 seconds p
       throwIfStopped: () => {},
     });
 
-    await assert.rejects(
-      helpers.completePhoneVerificationFlow(1, {
-        addPhonePage: true,
-        phoneVerificationPage: false,
-        url: 'https://auth.openai.com/add-phone',
-      }),
-      /Restart step 7 with a new number/i
-    );
+    const result = await helpers.completePhoneVerificationFlow(1, {
+      addPhonePage: true,
+      phoneVerificationPage: false,
+      url: 'https://auth.openai.com/add-phone',
+    });
+
+    assert.deepStrictEqual(result, {
+      success: true,
+      consentReady: true,
+      url: 'https://auth.openai.com/authorize',
+    });
     assert.ok(statusCallsById['123456'] >= 2, 'first number should be polled twice before being replaced');
+    assert.ok(statusCallsById['654321'] >= 1, 'second number should be polled and succeed');
     assert.deepStrictEqual(messages, [
       'SUBMIT_PHONE_NUMBER',
       'RESEND_PHONE_VERIFICATION_CODE',
+      'RETURN_TO_ADD_PHONE',
+      'SUBMIT_PHONE_NUMBER',
+      'SUBMIT_PHONE_VERIFICATION_CODE',
     ]);
 
     const actions = requests.map((url) => `${url.searchParams.get('action')}:${url.searchParams.get('id') || ''}`);
@@ -805,11 +991,87 @@ test('phone verification helper throws a step-7 restart error after 60 seconds p
       'setStatus:123456',
       'getStatus:123456',
       'setStatus:123456',
+      'getPrices:',
+      'getNumber:',
+      'getStatus:654321',
+      'setStatus:654321',
     ]);
     assert.equal(currentState.currentPhoneActivation, null);
   } finally {
     Date.now = realDateNow;
   }
+});
+
+test('phone verification helper retries a higher HeroSMS maxPrice when lower price pool has NO_NUMBERS', async () => {
+  const requests = [];
+  const helpers = api.createPhoneVerificationHelpers({
+    addLog: async () => {},
+    ensureStep8SignupPageReady: async () => {},
+    fetchImpl: async (url) => {
+      const parsedUrl = new URL(url);
+      requests.push(parsedUrl);
+      const action = parsedUrl.searchParams.get('action');
+      const maxPrice = parsedUrl.searchParams.get('maxPrice');
+      if (action === 'getPrices') {
+        return {
+          ok: true,
+          text: async () => JSON.stringify({
+            '52': {
+              dr: {
+                cost: 0.08,
+                count: 10,
+                physicalCount: 10,
+              },
+            },
+            '52-premium': {
+              dr: {
+                cost: 0.12,
+                count: 6,
+                physicalCount: 6,
+              },
+            },
+          }),
+        };
+      }
+      if (action === 'getNumber' || action === 'getNumberV2') {
+        if (maxPrice === '0.08') {
+          return {
+            ok: true,
+            text: async () => 'NO_NUMBERS',
+          };
+        }
+        return {
+          ok: true,
+          text: async () => 'ACCESS_NUMBER:888888:66958889999',
+        };
+      }
+      throw new Error(`Unexpected HeroSMS action: ${action}`);
+    },
+    getState: async () => ({ heroSmsApiKey: 'demo-key' }),
+    sendToContentScriptResilient: async () => ({}),
+    setState: async () => {},
+    sleepWithStop: async () => {},
+    throwIfStopped: () => {},
+  });
+
+  const activation = await helpers.requestPhoneActivation({ heroSmsApiKey: 'demo-key' });
+
+  assert.deepStrictEqual(activation, {
+    activationId: '888888',
+    phoneNumber: '66958889999',
+    provider: 'hero-sms',
+    serviceCode: 'dr',
+    countryId: 52,
+    successfulUses: 0,
+    maxUses: 3,
+  });
+  assert.equal(requests[0].searchParams.get('action'), 'getPrices');
+  assert.equal(requests[1].searchParams.get('action'), 'getNumber');
+  assert.equal(requests[1].searchParams.get('maxPrice'), '0.08');
+  assert.equal(requests[2].searchParams.get('action'), 'getNumberV2');
+  assert.equal(requests[2].searchParams.get('maxPrice'), '0.08');
+  assert.equal(requests[3].searchParams.get('action'), 'getNumber');
+  assert.equal(requests[3].searchParams.get('maxPrice'), '0.12');
 });
 
 test('phone verification helper replaces the number when code submission returns to add-phone', async () => {

--- a/tests/verification-flow-polling.test.js
+++ b/tests/verification-flow-polling.test.js
@@ -1030,6 +1030,56 @@ test('verification flow waits during resend cooldown instead of tight-looping', 
   assert.ok(sleepCalls[0] >= 1000);
 });
 
+test('verification flow keeps a stable iCloud mail transport timeout even when OAuth budget is low', async () => {
+  const mailCallOptions = [];
+
+  const helpers = api.createVerificationFlowHelpers({
+    addLog: async () => {},
+    chrome: { tabs: { update: async () => {} } },
+    CLOUDFLARE_TEMP_EMAIL_PROVIDER: 'cloudflare-temp-email',
+    completeStepFromBackground: async () => {},
+    confirmCustomVerificationStepBypassRequest: async () => ({ confirmed: true }),
+    getHotmailVerificationPollConfig: () => ({}),
+    getHotmailVerificationRequestTimestamp: () => 0,
+    getState: async () => ({}),
+    getTabId: async () => 1,
+    HOTMAIL_PROVIDER: 'hotmail-api',
+    isStopError: () => false,
+    LUCKMAIL_PROVIDER: 'luckmail-api',
+    MAIL_2925_VERIFICATION_INTERVAL_MS: 15000,
+    MAIL_2925_VERIFICATION_MAX_ATTEMPTS: 15,
+    pollCloudflareTempEmailVerificationCode: async () => ({}),
+    pollHotmailVerificationCode: async () => ({}),
+    pollLuckmailVerificationCode: async () => ({}),
+    sendToContentScript: async () => ({}),
+    sendToMailContentScriptResilient: async (_mail, _message, options = {}) => {
+      mailCallOptions.push(options);
+      return { code: '654321', emailTimestamp: 123 };
+    },
+    setState: async () => {},
+    setStepStatus: async () => {},
+    sleepWithStop: async () => {},
+    throwIfStopped: () => {},
+    VERIFICATION_POLL_MAX_ROUNDS: 5,
+  });
+
+  const result = await helpers.pollFreshVerificationCode(
+    8,
+    { email: 'user@example.com', lastLoginCode: null },
+    { provider: 'qq', label: 'iCloud 邮箱', source: 'icloud-mail' },
+    {
+      maxResendRequests: 0,
+      resendIntervalMs: 0,
+      getRemainingTimeMs: async () => 1000,
+    }
+  );
+
+  assert.equal(result.code, '654321');
+  assert.equal(mailCallOptions.length, 1);
+  assert.ok(mailCallOptions[0].responseTimeoutMs >= 12000);
+  assert.ok(mailCallOptions[0].timeoutMs >= 16000);
+});
+
 test('verification flow uses resilient signup-page transport when submitting verification code', async () => {
   const resilientCalls = [];
 


### PR DESCRIPTION
## 功能说明
- 修复第 8/9 步在验证码与手机号链路中的异常回退，避免误触发整链路重开。
- 当流程进入 add-phone / 手机验证码页时，自动运行按“当前轮终止”处理，不再错误回到前置步骤。
- 增强 HeroSMS 取号与轮询异常处理：
  - `NO_NUMBERS` 按价格梯度重试。
  - 无短信/号码被拒/状态取消时，在第 9 步内换号继续。
  - 账户级错误（如余额/鉴权类）按终止当前轮处理。

## 合并建议
- 建议直接合并到 `dev`，该提交仅影响认证与接码链路，不改动支付/贡献模式主路径。
- 如需进一步降低接码成本，可在后续 PR 增加“价格上限、地区回退、换号上限、物理号策略”配置。

## 如何使用
- 开启接码后按原流程运行即可。
- 若第 9 步遇到手机号链路异常，系统会优先在当前第 9 步内自愈（换号/重试），不再误回第 1 步。

## 验证
- `node --test tests/phone-verification-flow.test.js`
- `node --test tests/auto-run-step6-restart.test.js`
- `node --test tests/background-step7-recovery.test.js`
- `node --test tests/background-step4-filter-window.test.js`
- `node --test tests/verification-flow-polling.test.js`
- `node --test tests/auto-run-add-phone-stop.test.js`
- `node --test tests/background-logging-status-module.test.js`
