### PR TITLE
fix: 处理第 9 步手机号验证后的可选资料页

### DIFF
--- a/background.js
+++ b/background.js
@@ -9494,6 +9494,8 @@ const phoneVerificationHelpers = self.MultiPageBackgroundPhoneVerification?.crea
   DEFAULT_PHONE_CODE_POLL_INTERVAL_SECONDS,
   DEFAULT_PHONE_CODE_POLL_ROUNDS,
   ensureStep8SignupPageReady,
+  generateRandomBirthday,
+  generateRandomName,
   getOAuthFlowRemainingMs,
   getOAuthFlowStepTimeoutMs,
   getState,

--- a/background/phone-verification-flow.js
+++ b/background/phone-verification-flow.js
@@ -6,6 +6,8 @@
       addLog,
       ensureStep8SignupPageReady,
       fetchImpl = (...args) => fetch(...args),
+      generateRandomBirthday,
+      generateRandomName,
       getOAuthFlowStepTimeoutMs,
       getState,
       sendToContentScript,
@@ -3295,13 +3297,35 @@
     }
 
     async function submitPhoneVerificationCode(tabId, code) {
+      const signupProfile = (
+        typeof generateRandomName === 'function'
+        && typeof generateRandomBirthday === 'function'
+      )
+        ? (() => {
+          const name = generateRandomName();
+          const birthday = generateRandomBirthday();
+          if (!name?.firstName || !name?.lastName || !birthday) {
+            return null;
+          }
+          return {
+            firstName: name.firstName,
+            lastName: name.lastName,
+            year: birthday.year,
+            month: birthday.month,
+            day: birthday.day,
+          };
+        })()
+        : null;
       const timeoutMs = typeof getOAuthFlowStepTimeoutMs === 'function'
         ? await getOAuthFlowStepTimeoutMs(45000, { step: 9, actionLabel: 'submit phone verification code' })
         : 45000;
       const result = await sendToContentScriptResilient('signup-page', {
         type: 'SUBMIT_PHONE_VERIFICATION_CODE',
         source: 'background',
-        payload: { code },
+        payload: {
+          code,
+          ...(signupProfile ? { signupProfile } : {}),
+        },
       }, {
         timeoutMs,
         responseTimeoutMs: timeoutMs,

--- a/content/signup-page.js
+++ b/content/signup-page.js
@@ -84,7 +84,7 @@ async function handleCommand(message) {
     case 'SUBMIT_PHONE_NUMBER':
       return await phoneAuthHelpers.submitPhoneNumber(message.payload);
     case 'SUBMIT_PHONE_VERIFICATION_CODE':
-      return await phoneAuthHelpers.submitPhoneVerificationCode(message.payload);
+      return await submitPhoneVerificationCodeWithProfileFallback(message.payload);
     case 'RESEND_PHONE_VERIFICATION_CODE':
       return await phoneAuthHelpers.resendPhoneVerificationCode();
     case 'RETURN_TO_ADD_PHONE':
@@ -1337,6 +1337,69 @@ const phoneAuthHelpers = self.MultiPagePhoneAuth?.createPhoneAuthHelpers?.({
     throw new Error('Phone auth helpers are unavailable.');
   },
 };
+
+async function waitForPhoneVerificationProfileCompletion(timeout = 30000) {
+  const start = Date.now();
+
+  while (Date.now() - start < timeout) {
+    throwIfStopped();
+
+    if (isStep8Ready()) {
+      return {
+        success: true,
+        consentReady: true,
+        url: location.href,
+      };
+    }
+
+    if (isAddPhonePageReady()) {
+      return {
+        returnedToAddPhone: true,
+        url: location.href,
+      };
+    }
+
+    await sleep(150);
+  }
+
+  if (isStep8Ready()) {
+    return {
+      success: true,
+      consentReady: true,
+      url: location.href,
+    };
+  }
+
+  return {
+    success: true,
+    assumed: true,
+    url: location.href,
+  };
+}
+
+async function submitPhoneVerificationCodeWithProfileFallback(payload = {}) {
+  const result = await phoneAuthHelpers.submitPhoneVerificationCode(payload);
+  if (!(isStep5Ready() || isSignupProfilePageUrl(result?.url || location.href))) {
+    return result;
+  }
+
+  const signupProfile = payload?.signupProfile || {};
+  if (!signupProfile.firstName || !signupProfile.lastName) {
+    throw new Error('手机号验证后进入资料页，但未提供步骤 5 所需的姓名数据。');
+  }
+
+  await step5_fillNameBirthday(signupProfile);
+  const nextState = await waitForPhoneVerificationProfileCompletion();
+  const mergedResult = {
+    ...result,
+    ...nextState,
+    profileCompleted: true,
+  };
+  if (nextState.consentReady || nextState.returnedToAddPhone) {
+    delete mergedResult.assumed;
+  }
+  return mergedResult;
+}
 
 function normalizeInlineText(text) {
   return (text || '').replace(/\s+/g, ' ').trim();

--- a/tests/phone-verification-flow.test.js
+++ b/tests/phone-verification-flow.test.js
@@ -1603,6 +1603,98 @@ test('phone verification helper completes add-phone flow, clears current activat
   assert.deepStrictEqual(actions, ['getPrices', 'getNumber', 'getStatus', 'setStatus']);
 });
 
+test('phone verification helper forwards signup profile payload when submitting the phone verification code', async () => {
+  let currentState = {
+    heroSmsApiKey: 'demo-key',
+    verificationResendCount: 0,
+    currentPhoneActivation: null,
+    reusablePhoneActivation: null,
+  };
+  const submittedPayloads = [];
+
+  const helpers = api.createPhoneVerificationHelpers({
+    addLog: async () => {},
+    ensureStep8SignupPageReady: async () => {},
+    fetchImpl: async (url) => {
+      const parsedUrl = new URL(url);
+      const action = parsedUrl.searchParams.get('action');
+      if (action === 'getPrices') {
+        return {
+          ok: true,
+          text: async () => buildHeroSmsPricesPayload(),
+        };
+      }
+      if (action === 'getNumber') {
+        return {
+          ok: true,
+          text: async () => 'ACCESS_NUMBER:123456:66959916439',
+        };
+      }
+      if (action === 'getStatus') {
+        return {
+          ok: true,
+          text: async () => 'STATUS_OK:654321',
+        };
+      }
+      if (action === 'setStatus') {
+        return {
+          ok: true,
+          text: async () => 'ACCESS_ACTIVATION',
+        };
+      }
+      throw new Error(`Unexpected HeroSMS action: ${action}`);
+    },
+    generateRandomBirthday: () => ({ year: 2003, month: 6, day: 19 }),
+    generateRandomName: () => ({ firstName: 'Ada', lastName: 'Lovelace' }),
+    getOAuthFlowStepTimeoutMs: async (defaultTimeoutMs) => defaultTimeoutMs,
+    getState: async () => ({ ...currentState }),
+    sendToContentScriptResilient: async (_source, message) => {
+      if (message.type === 'SUBMIT_PHONE_NUMBER') {
+        return {
+          phoneVerificationPage: true,
+          url: 'https://auth.openai.com/phone-verification',
+        };
+      }
+      if (message.type === 'SUBMIT_PHONE_VERIFICATION_CODE') {
+        submittedPayloads.push(message.payload);
+        return {
+          success: true,
+          consentReady: true,
+          url: 'https://auth.openai.com/authorize',
+        };
+      }
+      throw new Error(`Unexpected content-script message: ${message.type}`);
+    },
+    setState: async (updates) => {
+      currentState = { ...currentState, ...updates };
+    },
+    sleepWithStop: async () => {},
+    throwIfStopped: () => {},
+  });
+
+  const result = await helpers.completePhoneVerificationFlow(1, {
+    addPhonePage: true,
+    phoneVerificationPage: false,
+    url: 'https://auth.openai.com/add-phone',
+  });
+
+  assert.deepStrictEqual(result, {
+    success: true,
+    consentReady: true,
+    url: 'https://auth.openai.com/authorize',
+  });
+  assert.deepStrictEqual(submittedPayloads, [{
+    code: '654321',
+    signupProfile: {
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      year: 2003,
+      month: 6,
+      day: 19,
+    },
+  }]);
+});
+
 test('phone verification helper uses the configured HeroSMS country for both number acquisition and add-phone submission', async () => {
   const requests = [];
   const submittedPayloads = [];

--- a/tests/step9-profile-after-phone-verification.test.js
+++ b/tests/step9-profile-after-phone-verification.test.js
@@ -1,0 +1,222 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const source = fs.readFileSync('content/signup-page.js', 'utf8');
+
+function extractFunction(name) {
+  const markers = [`async function ${name}(`, `function ${name}(`];
+  const start = markers
+    .map((marker) => source.indexOf(marker))
+    .find((index) => index >= 0);
+  if (start < 0) {
+    throw new Error(`missing function ${name}`);
+  }
+
+  let parenDepth = 0;
+  let signatureEnded = false;
+  let braceStart = -1;
+  for (let i = start; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === '(') {
+      parenDepth += 1;
+    } else if (ch === ')') {
+      parenDepth -= 1;
+      if (parenDepth === 0) {
+        signatureEnded = true;
+      }
+    } else if (ch === '{' && signatureEnded) {
+      braceStart = i;
+      break;
+    }
+  }
+
+  if (braceStart < 0) {
+    throw new Error(`missing body for function ${name}`);
+  }
+
+  let depth = 0;
+  let end = braceStart;
+  for (; end < source.length; end += 1) {
+    const ch = source[end];
+    if (ch === '{') depth += 1;
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        end += 1;
+        break;
+      }
+    }
+  }
+
+  return source.slice(start, end);
+}
+
+test('step 9 auto-fills profile when phone verification lands on signup profile page', async () => {
+  const api = new Function(`
+const profilePayloads = [];
+const logs = [];
+let consentReady = false;
+
+const location = {
+  href: 'https://auth.openai.com/create-account/profile',
+};
+
+function log(message, level = 'info') {
+  logs.push({ message, level });
+}
+
+function isStep5Ready() {
+  return !consentReady;
+}
+
+function isSignupProfilePageUrl(url = location.href) {
+  return /\\/create-account\\/profile(?:[/?#]|$)/i.test(String(url || ''));
+}
+
+function isStep8Ready() {
+  return consentReady;
+}
+
+function isAddPhonePageReady() {
+  return false;
+}
+
+async function sleep() {}
+function throwIfStopped() {}
+
+const phoneAuthHelpers = {
+  async submitPhoneVerificationCode() {
+    return {
+      success: true,
+      assumed: true,
+      url: location.href,
+    };
+  },
+};
+
+async function step5_fillNameBirthday(payload) {
+  profilePayloads.push(payload);
+  consentReady = true;
+  location.href = 'https://auth.openai.com/authorize';
+  return {
+    skippedPostSubmitCheck: true,
+    directProceedToStep6: true,
+  };
+}
+
+${extractFunction('waitForPhoneVerificationProfileCompletion')}
+${extractFunction('submitPhoneVerificationCodeWithProfileFallback')}
+
+return {
+  run(payload) {
+    return submitPhoneVerificationCodeWithProfileFallback(payload);
+  },
+  snapshot() {
+    return {
+      profilePayloads,
+      logs,
+    };
+  },
+};
+`)();
+
+  const result = await api.run({
+    code: '123456',
+    signupProfile: {
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      year: 2003,
+      month: 6,
+      day: 19,
+    },
+  });
+
+  assert.deepStrictEqual(result, {
+    success: true,
+    consentReady: true,
+    profileCompleted: true,
+    url: 'https://auth.openai.com/authorize',
+  });
+  assert.deepStrictEqual(api.snapshot().profilePayloads, [{
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+    year: 2003,
+    month: 6,
+    day: 19,
+  }]);
+});
+
+test('step 9 leaves the existing consent flow untouched when no profile page appears', async () => {
+  const api = new Function(`
+const profilePayloads = [];
+const location = {
+  href: 'https://auth.openai.com/authorize',
+};
+
+function isStep5Ready() {
+  return false;
+}
+
+function isSignupProfilePageUrl(url = location.href) {
+  return /\\/create-account\\/profile(?:[/?#]|$)/i.test(String(url || ''));
+}
+
+function isStep8Ready() {
+  return true;
+}
+
+function isAddPhonePageReady() {
+  return false;
+}
+
+function throwIfStopped() {}
+async function sleep() {}
+
+const phoneAuthHelpers = {
+  async submitPhoneVerificationCode() {
+    return {
+      success: true,
+      consentReady: true,
+      url: location.href,
+    };
+  },
+};
+
+async function step5_fillNameBirthday(payload) {
+  profilePayloads.push(payload);
+}
+
+${extractFunction('waitForPhoneVerificationProfileCompletion')}
+${extractFunction('submitPhoneVerificationCodeWithProfileFallback')}
+
+return {
+  run(payload) {
+    return submitPhoneVerificationCodeWithProfileFallback(payload);
+  },
+  snapshot() {
+    return {
+      profilePayloads,
+    };
+  },
+};
+`)();
+
+  const result = await api.run({
+    code: '123456',
+    signupProfile: {
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      year: 2003,
+      month: 6,
+      day: 19,
+    },
+  });
+
+  assert.deepStrictEqual(result, {
+    success: true,
+    consentReady: true,
+    url: 'https://auth.openai.com/authorize',
+  });
+  assert.deepStrictEqual(api.snapshot().profilePayloads, []);
+});


### PR DESCRIPTION
## 本次改动
- 处理第 9 步手机号验证完成后，偶发再次进入资料页的分支，复用第 5 步已有的姓名和生日填写逻辑自动补齐资料
- 保持原有正常路径不变；如果资料页没有出现，仍然直接进入 OAuth 授权确认页继续后续流程
- 在第 9 步提交手机号验证码时一并透传资料 payload，并补充对应回归测试覆盖“出现资料页”和“不出现资料页”两条路径

## 风险与影响
- 影响范围集中在第 9 步手机号验证后的认证页跳转处理，以及对应的 background/content 消息透传
- 这次改动复用了现有第 5 步资料填写逻辑，没有新加独立资料页实现，后续如果第 5 步字段结构调整，这里会同步受影响

## 测试情况
- 已运行：`node --test tests/step9-profile-after-phone-verification.test.js tests/phone-verification-flow.test.js`
