### PR TITLE
feat(gpc): add SMS OTP helper support

### DIFF
--- a/background.js
+++ b/background.js
@@ -4,6 +4,7 @@ importScripts(
   'managed-alias-utils.js',
   'mail2925-utils.js',
   'paypal-utils.js',
+  'gopay-utils.js',
   'background/phone-verification-flow.js',
   'background/account-run-history.js',
   'background/contribution-oauth.js',
@@ -57,11 +58,16 @@ const PLUS_GOPAY_STEP_DEFINITIONS = self.MultiPageStepDefinitions?.getSteps?.({
   plusModeEnabled: true,
   plusPaymentMethod: 'gopay',
 }) || PLUS_PAYPAL_STEP_DEFINITIONS;
+const PLUS_GPC_STEP_DEFINITIONS = self.MultiPageStepDefinitions?.getSteps?.({
+  plusModeEnabled: true,
+  plusPaymentMethod: 'gpc-helper',
+}) || PLUS_GOPAY_STEP_DEFINITIONS;
 const PLUS_STEP_DEFINITIONS = PLUS_PAYPAL_STEP_DEFINITIONS;
 const ALL_STEP_DEFINITIONS = self.MultiPageStepDefinitions?.getAllSteps?.() || [
   ...NORMAL_STEP_DEFINITIONS,
   ...PLUS_PAYPAL_STEP_DEFINITIONS,
   ...PLUS_GOPAY_STEP_DEFINITIONS,
+  ...PLUS_GPC_STEP_DEFINITIONS,
 ];
 const STEP_IDS = Array.from(new Set(ALL_STEP_DEFINITIONS
   .map((definition) => Number(definition?.id))
@@ -79,10 +85,15 @@ const PLUS_GOPAY_STEP_IDS = PLUS_GOPAY_STEP_DEFINITIONS
   .map((definition) => Number(definition?.id))
   .filter(Number.isFinite)
   .sort((left, right) => left - right);
+const PLUS_GPC_STEP_IDS = PLUS_GPC_STEP_DEFINITIONS
+  .map((definition) => Number(definition?.id))
+  .filter(Number.isFinite)
+  .sort((left, right) => left - right);
 const LAST_STEP_ID = Math.max(
   NORMAL_STEP_IDS[NORMAL_STEP_IDS.length - 1] || 10,
   PLUS_PAYPAL_STEP_IDS[PLUS_PAYPAL_STEP_IDS.length - 1] || 10,
-  PLUS_GOPAY_STEP_IDS[PLUS_GOPAY_STEP_IDS.length - 1] || 10
+  PLUS_GOPAY_STEP_IDS[PLUS_GOPAY_STEP_IDS.length - 1] || 10,
+  PLUS_GPC_STEP_IDS[PLUS_GPC_STEP_IDS.length - 1] || 10
 );
 const FINAL_OAUTH_CHAIN_START_STEP = 7;
 
@@ -374,7 +385,11 @@ function isPlusModeState(state = {}) {
 }
 
 function normalizePlusPaymentMethod(value = '') {
-  return String(value || '').trim().toLowerCase() === 'gopay' ? 'gopay' : 'paypal';
+  const normalized = String(value || '').trim().toLowerCase();
+  if (normalized === 'gpc-helper') {
+    return 'gpc-helper';
+  }
+  return normalized === 'gopay' ? 'gopay' : 'paypal';
 }
 
 function normalizeContributionModeSource(value = '') {
@@ -415,18 +430,22 @@ function getStepDefinitionsForState(state = {}) {
   if (!isPlusModeState(state)) {
     return NORMAL_STEP_DEFINITIONS;
   }
-  return normalizePlusPaymentMethod(state?.plusPaymentMethod) === 'gopay'
-    ? PLUS_GOPAY_STEP_DEFINITIONS
-    : PLUS_PAYPAL_STEP_DEFINITIONS;
+  const paymentMethod = normalizePlusPaymentMethod(state?.plusPaymentMethod);
+  if (paymentMethod === 'gpc-helper') {
+    return PLUS_GPC_STEP_DEFINITIONS;
+  }
+  return paymentMethod === 'gopay' ? PLUS_GOPAY_STEP_DEFINITIONS : PLUS_PAYPAL_STEP_DEFINITIONS;
 }
 
 function getStepIdsForState(state = {}) {
   if (!isPlusModeState(state)) {
     return NORMAL_STEP_IDS;
   }
-  return normalizePlusPaymentMethod(state?.plusPaymentMethod) === 'gopay'
-    ? PLUS_GOPAY_STEP_IDS
-    : PLUS_PAYPAL_STEP_IDS;
+  const paymentMethod = normalizePlusPaymentMethod(state?.plusPaymentMethod);
+  if (paymentMethod === 'gpc-helper') {
+    return PLUS_GPC_STEP_IDS;
+  }
+  return paymentMethod === 'gopay' ? PLUS_GOPAY_STEP_IDS : PLUS_PAYPAL_STEP_IDS;
 }
 
 function getLastStepIdForState(state = {}) {
@@ -520,6 +539,22 @@ const PERSISTED_SETTING_DEFAULTS = {
   customPassword: '',
   plusModeEnabled: false,
   plusPaymentMethod: 'paypal',
+  gopayHelperApiUrl: '',
+  gopayHelperCardKey: '',
+  gopayHelperPhoneNumber: '',
+  gopayHelperCountryCode: '+86',
+  gopayHelperPin: '',
+  gopayHelperReferenceId: '',
+  gopayHelperGoPayGuid: '',
+  gopayHelperRedirectUrl: '',
+  gopayHelperNextAction: '',
+  gopayHelperFlowId: '',
+  gopayHelperChallengeId: '',
+  gopayHelperStartPayload: null,
+  gopayHelperBalance: '',
+  gopayHelperBalancePayload: null,
+  gopayHelperBalanceUpdatedAt: 0,
+  gopayHelperBalanceError: '',
   paypalEmail: '',
   paypalPassword: '',
   currentPayPalAccountId: '',
@@ -649,6 +684,7 @@ const DEFAULT_STATE = {
   plusCheckoutCurrency: 'EUR',
   plusBillingCountryText: '',
   plusBillingAddress: null,
+  plusCheckoutSource: '',
   plusPaypalApprovedAt: null,
   plusReturnUrl: '',
   plusManualConfirmationPending: false,
@@ -657,6 +693,17 @@ const DEFAULT_STATE = {
   plusManualConfirmationMethod: '',
   plusManualConfirmationTitle: '',
   plusManualConfirmationMessage: '',
+  gopayHelperReferenceId: '',
+  gopayHelperGoPayGuid: '',
+  gopayHelperRedirectUrl: '',
+  gopayHelperNextAction: '',
+  gopayHelperFlowId: '',
+  gopayHelperChallengeId: '',
+  gopayHelperStartPayload: null,
+  gopayHelperPinPayload: null,
+  gopayHelperResolvedOtp: '',
+  gopayHelperOtpRequestId: '',
+  gopayHelperOtpReferenceId: '',
   flowStartTime: null, // 当前流程开始时间。
   tabRegistry: {}, // 程序维护的标签页注册表。
   sourceLastUrls: {}, // 各来源页面最近一次打开的地址记录。
@@ -1786,7 +1833,41 @@ function normalizePersistentSettingValue(key, value) {
     case 'currentPayPalAccountId':
       return String(value || '').trim();
     case 'plusPaymentMethod':
-      return String(value || '').trim().toLowerCase() === 'gopay' ? 'gopay' : 'paypal';
+      {
+        const normalized = String(value || '').trim().toLowerCase();
+        if (normalized === 'gpc-helper') {
+          return 'gpc-helper';
+        }
+        return normalized === 'gopay' ? 'gopay' : 'paypal';
+      }
+    case 'gopayHelperPhoneNumber':
+      return self.GoPayUtils?.normalizeGoPayPhone
+        ? self.GoPayUtils.normalizeGoPayPhone(value)
+        : String(value || '').trim();
+    case 'gopayHelperPin':
+      return self.GoPayUtils?.normalizeGoPayPin
+        ? self.GoPayUtils.normalizeGoPayPin(value)
+        : String(value || '');
+    case 'gopayHelperCountryCode':
+      return self.GoPayUtils?.normalizeGoPayCountryCode
+        ? self.GoPayUtils.normalizeGoPayCountryCode(value)
+        : String(value || '+86').trim();
+    case 'gopayHelperApiUrl':
+    case 'gopayHelperCardKey':
+    case 'gopayHelperReferenceId':
+    case 'gopayHelperGoPayGuid':
+    case 'gopayHelperRedirectUrl':
+    case 'gopayHelperNextAction':
+    case 'gopayHelperFlowId':
+    case 'gopayHelperChallengeId':
+    case 'gopayHelperBalance':
+    case 'gopayHelperBalanceError':
+      return String(value || '').trim();
+    case 'gopayHelperBalancePayload':
+    case 'gopayHelperStartPayload':
+      return value && typeof value === 'object' && !Array.isArray(value) ? value : null;
+    case 'gopayHelperBalanceUpdatedAt':
+      return Math.max(0, Number(value) || 0);
     case 'autoRunSkipFailures':
     case 'oauthFlowTimeoutEnabled':
     case 'autoRunDelayEnabled':
@@ -5978,6 +6059,60 @@ async function finalizeIcloudAliasAfterSuccessfulFlow(state) {
   }
 }
 
+async function markCurrentRegistrationAccountUsed(state = {}, options = {}) {
+  const providedState = state && typeof state === 'object' ? state : {};
+  const currentState = await getState();
+  const latestState = {
+    ...providedState,
+    ...(currentState && typeof currentState === 'object' ? currentState : {}),
+  };
+  const reasonPrefix = String(options.logPrefix || '').trim() || '当前账号';
+  const level = options.level || 'warn';
+  let updated = false;
+
+  if (latestState.currentHotmailAccountId && isHotmailProvider(latestState)) {
+    await patchHotmailAccount(latestState.currentHotmailAccountId, {
+      used: true,
+      lastUsedAt: Date.now(),
+    });
+    await addLog(`${reasonPrefix}：Hotmail 账号已标记为已用。`, level);
+    updated = true;
+  }
+
+  if (String(latestState.mailProvider || '').trim().toLowerCase() === '2925' && latestState.currentMail2925AccountId) {
+    await patchMail2925Account(latestState.currentMail2925AccountId, {
+      lastUsedAt: Date.now(),
+      lastError: '',
+    });
+    await addLog(`${reasonPrefix}：2925 账号已记录最近使用时间。`, level);
+    updated = true;
+  }
+
+  if (isLuckmailProvider(latestState)) {
+    const currentPurchase = getCurrentLuckmailPurchase(latestState);
+    if (currentPurchase?.id) {
+      await setLuckmailPurchaseUsedState(currentPurchase.id, true);
+      await clearLuckmailRuntimeState({ clearEmail: true });
+      await addLog(`${reasonPrefix}：LuckMail 邮箱 ${currentPurchase.email_address} 已标记为已用。`, level);
+      updated = true;
+    }
+  }
+
+  const email = String(latestState?.email || '').trim().toLowerCase();
+  const knownIcloudAlias = email && (
+    normalizeEmailGenerator(latestState?.emailGenerator) === 'icloud'
+    || Object.prototype.hasOwnProperty.call(getManualAliasUsageMap(latestState), email)
+    || Object.prototype.hasOwnProperty.call(getPreservedAliasMap(latestState), email)
+  );
+  if (knownIcloudAlias) {
+    await setIcloudAliasUsedState({ email, used: true }, { silentLog: true });
+    await addLog(`${reasonPrefix}：iCloud 隐私邮箱 ${email} 已标记为已用。`, level);
+    updated = true;
+  }
+
+  return { updated };
+}
+
 async function finalizePhoneActivationAfterSuccessfulFlow(state) {
   if (typeof phoneVerificationHelpers?.finalizePendingPhoneActivationConfirmation !== 'function') {
     return null;
@@ -6725,6 +6860,7 @@ function getDownstreamStateResets(step, state = {}) {
     plusCheckoutUrl: null,
     plusCheckoutCountry: 'DE',
     plusCheckoutCurrency: 'EUR',
+    plusCheckoutSource: '',
     plusBillingCountryText: '',
     plusBillingAddress: null,
     plusPaypalApprovedAt: null,
@@ -6735,6 +6871,17 @@ function getDownstreamStateResets(step, state = {}) {
     plusManualConfirmationMethod: '',
     plusManualConfirmationTitle: '',
     plusManualConfirmationMessage: '',
+    gopayHelperReferenceId: '',
+    gopayHelperGoPayGuid: '',
+    gopayHelperRedirectUrl: '',
+    gopayHelperNextAction: '',
+    gopayHelperFlowId: '',
+    gopayHelperChallengeId: '',
+    gopayHelperStartPayload: null,
+    gopayHelperPinPayload: null,
+    gopayHelperResolvedOtp: '',
+    gopayHelperOtpRequestId: '',
+    gopayHelperOtpReferenceId: '',
   };
 
   if (step <= 1) {
@@ -6817,6 +6964,9 @@ function getDownstreamStateResets(step, state = {}) {
         plusManualConfirmationMethod: '',
         plusManualConfirmationTitle: '',
         plusManualConfirmationMessage: '',
+        gopayHelperResolvedOtp: '',
+        gopayHelperOtpRequestId: '',
+        gopayHelperOtpReferenceId: '',
       } : {}),
       ...(step === 8 ? {
         plusPaypalApprovedAt: null,
@@ -8775,6 +8925,101 @@ async function maybeSwitchIpProxyAfterAutoRunRoundSuccess(payload = {}) {
   return switchResult;
 }
 
+
+function resolveGpcHelperBaseUrl(apiUrl = '') {
+  if (self.GoPayUtils?.normalizeGpcHelperBaseUrl) {
+    return self.GoPayUtils.normalizeGpcHelperBaseUrl(apiUrl);
+  }
+  let normalized = String(apiUrl || '').trim().replace(/\/+$/g, '');
+  normalized = normalized.replace(/\/api\/checkout\/start$/i, '');
+  normalized = normalized.replace(/\/api\/gopay\/(?:otp|pin)$/i, '');
+  normalized = normalized.replace(/\/api\/card\/balance(?:\?.*)?$/i, '');
+  return normalized;
+}
+
+function buildGpcCardBalanceRequestUrl(apiUrl = '', cardKey = '') {
+  if (self.GoPayUtils?.buildGpcCardBalanceUrl) {
+    return self.GoPayUtils.buildGpcCardBalanceUrl(apiUrl, cardKey);
+  }
+  const baseUrl = resolveGpcHelperBaseUrl(apiUrl);
+  if (!baseUrl) {
+    return '';
+  }
+  return `${baseUrl}/api/card/balance?card_key=${encodeURIComponent(String(cardKey || '').trim())}`;
+}
+
+function formatGpcCardBalancePayload(payload = {}) {
+  if (self.GoPayUtils?.formatGpcBalancePayload) {
+    return self.GoPayUtils.formatGpcBalancePayload(payload);
+  }
+  if (!payload || typeof payload !== 'object') {
+    return '';
+  }
+  const remaining = payload.remaining_uses ?? payload.remainingUses ?? payload.balance ?? payload.remaining;
+  const status = String(payload.card_status || payload.cardStatus || payload.status || '').trim();
+  return [
+    remaining !== undefined && remaining !== null && String(remaining).trim() !== '' ? `余额 ${remaining}` : '',
+    status ? `状态 ${status}` : '',
+  ].filter(Boolean).join('，');
+}
+
+async function refreshGpcCardBalance(state = {}, options = {}) {
+  const apiUrl = String(state?.gopayHelperApiUrl || '').trim();
+  const cardKey = String(state?.gopayHelperCardKey || state?.gpcCardKey || state?.cardKey || '').trim();
+  if (!apiUrl) {
+    throw new Error('缺少 GPC API 地址。');
+  }
+  if (!cardKey) {
+    throw new Error('缺少 GPC 卡密。');
+  }
+  const requestUrl = buildGpcCardBalanceRequestUrl(apiUrl, cardKey);
+  if (!requestUrl) {
+    throw new Error('缺少 GPC API 地址。');
+  }
+
+  const response = await fetch(requestUrl, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+  });
+  const rawText = await response.text();
+  let payload = {};
+  try {
+    payload = rawText ? JSON.parse(rawText) : {};
+  } catch {
+    payload = { raw: rawText };
+  }
+  const balanceText = formatGpcCardBalancePayload(payload) || rawText || '未知';
+  const updates = {
+    gopayHelperBalance: balanceText,
+    gopayHelperBalancePayload: payload && typeof payload === 'object' && !Array.isArray(payload) ? payload : { raw: String(payload || '') },
+    gopayHelperBalanceUpdatedAt: Date.now(),
+    gopayHelperBalanceError: '',
+  };
+  const flowId = String(payload?.flow_id || payload?.flowId || '').trim();
+  if (flowId) {
+    updates.gopayHelperFlowId = flowId;
+  }
+
+  if (!response.ok || payload?.ok === false) {
+    const detail = payload?.error || payload?.message || payload?.detail || `HTTP ${response.status}`;
+    const errorUpdates = { ...updates, gopayHelperBalanceError: String(detail || '余额查询失败') };
+    await setPersistentSettings(errorUpdates);
+    broadcastDataUpdate(errorUpdates);
+    throw new Error(String(detail || '余额查询失败'));
+  }
+
+  await setPersistentSettings(updates);
+  broadcastDataUpdate(updates);
+  const reason = String(options?.reason || '').trim();
+  await addLog(
+    reason === 'round_success'
+      ? `GPC 余额已更新：${balanceText}`
+      : `GPC 余额查询成功：${balanceText}`,
+    'info'
+  );
+  return { balance: balanceText, payload, updatedAt: updates.gopayHelperBalanceUpdatedAt };
+}
+
 const autoRunController = self.MultiPageBackgroundAutoRunController?.createAutoRunController({
   addLog,
   appendAccountRunRecord: (...args) => appendAndBroadcastAccountRunRecord(...args),
@@ -9654,6 +9899,8 @@ const plusCheckoutCreateExecutor = self.MultiPageBackgroundPlusCheckoutCreate?.c
   chrome,
   completeStepFromBackground,
   ensureContentScriptReadyOnTabUntilStopped,
+  fetch: typeof fetch === 'function' ? fetch.bind(globalThis) : null,
+  markCurrentRegistrationAccountUsed,
   registerTab,
   sendTabMessageUntilStopped,
   setState,
@@ -9662,19 +9909,23 @@ const plusCheckoutCreateExecutor = self.MultiPageBackgroundPlusCheckoutCreate?.c
 });
 const plusCheckoutBillingExecutor = self.MultiPageBackgroundPlusCheckoutBilling?.createPlusCheckoutBillingExecutor({
   addLog,
+  broadcastDataUpdate,
   chrome,
   completeStepFromBackground,
   ensureContentScriptReadyOnTabUntilStopped,
   fetch: typeof fetch === 'function' ? fetch.bind(globalThis) : null,
   generateRandomName,
   getAddressSeedForCountry: self.MultiPageAddressSources?.getAddressSeedForCountry,
+  getState,
   getTabId,
   isTabAlive,
+  markCurrentRegistrationAccountUsed,
   sendTabMessageUntilStopped,
   setState,
   sleepWithStop,
   waitForTabCompleteUntilStopped,
   waitForTabUrlMatchUntilStopped,
+  throwIfStopped,
 });
 const goPayManualConfirmExecutor = self.MultiPageBackgroundGoPayManualConfirm?.createGoPayManualConfirmExecutor({
   addLog,
@@ -9775,6 +10026,7 @@ const messageRouter = self.MultiPageBackgroundMessageRouter?.createMessageRouter
   executeStepViaCompletionSignal,
   exportSettingsBundle,
   fetchGeneratedEmail,
+  refreshGpcCardBalance,
   finalizePhoneActivationAfterSuccessfulFlow,
   finalizeStep3Completion: async () => {
     const currentState = await getState();
@@ -9814,6 +10066,7 @@ const messageRouter = self.MultiPageBackgroundMessageRouter?.createMessageRouter
   runIpProxyAutoSync,
   listIcloudAliases,
   listLuckmailPurchasesForManagement,
+  markCurrentRegistrationAccountUsed,
   refreshIpProxyPool,
   getCurrentPayPalAccount,
   getCurrentMail2925Account,
@@ -9877,14 +10130,17 @@ function buildStepRegistry(definitions = []) {
 const normalStepRegistry = buildStepRegistry(NORMAL_STEP_DEFINITIONS);
 const plusPayPalStepRegistry = buildStepRegistry(PLUS_PAYPAL_STEP_DEFINITIONS);
 const plusGoPayStepRegistry = buildStepRegistry(PLUS_GOPAY_STEP_DEFINITIONS);
+const plusGpcStepRegistry = buildStepRegistry(PLUS_GPC_STEP_DEFINITIONS);
 
 function getStepRegistryForState(state = {}) {
   if (!isPlusModeState(state)) {
     return normalStepRegistry;
   }
-  return normalizePlusPaymentMethod(state?.plusPaymentMethod) === 'gopay'
-    ? plusGoPayStepRegistry
-    : plusPayPalStepRegistry;
+  const paymentMethod = normalizePlusPaymentMethod(state?.plusPaymentMethod);
+  if (paymentMethod === 'gpc-helper') {
+    return plusGpcStepRegistry;
+  }
+  return paymentMethod === 'gopay' ? plusGoPayStepRegistry : plusPayPalStepRegistry;
 }
 
 async function requestOAuthUrlFromPanel(state, options = {}) {

--- a/background.js
+++ b/background.js
@@ -544,6 +544,11 @@ const PERSISTED_SETTING_DEFAULTS = {
   gopayHelperPhoneNumber: '',
   gopayHelperCountryCode: '+86',
   gopayHelperPin: '',
+  gopayHelperOtpChannel: 'whatsapp',
+  gopayHelperLocalSmsHelperEnabled: false,
+  gopayHelperLocalSmsHelperUrl: 'http://127.0.0.1:18767',
+  gopayHelperLocalSmsTimeoutSeconds: 90,
+  gopayHelperLocalSmsPollIntervalSeconds: 2,
   gopayHelperReferenceId: '',
   gopayHelperGoPayGuid: '',
   gopayHelperRedirectUrl: '',
@@ -1675,6 +1680,49 @@ function normalizeHotmailLocalBaseUrl(rawValue = '') {
   }
 }
 
+function normalizeGpcOtpChannel(value = '') {
+  if (self.GoPayUtils?.normalizeGpcOtpChannel) {
+    return self.GoPayUtils.normalizeGpcOtpChannel(value);
+  }
+  const normalized = String(value || '').trim().toLowerCase();
+  return normalized === 'sms' ? 'sms' : 'whatsapp';
+}
+
+function normalizeGpcLocalSmsHelperBaseUrl(rawValue = '') {
+  const value = String(rawValue || '').trim();
+  const fallback = String(PERSISTED_SETTING_DEFAULTS?.gopayHelperLocalSmsHelperUrl || 'http://127.0.0.1:18767').trim();
+  if (!value) return fallback;
+
+  try {
+    const parsed = new URL(value);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      return fallback;
+    }
+    const endpointPath = parsed.pathname.replace(/\/+$/g, '') || '/';
+    if (['/otp', '/latest-otp', '/health'].includes(endpointPath)) {
+      parsed.pathname = '';
+      parsed.search = '';
+      parsed.hash = '';
+    }
+    return parsed.toString().replace(/\/$/, '');
+  } catch {
+    return fallback;
+  }
+}
+
+function normalizePositiveIntegerSetting(value, fallback, min, max) {
+  const rawValue = String(value ?? '').trim();
+  const fallbackNumber = Math.floor(Number(fallback) || min);
+  if (!rawValue) {
+    return Math.min(max, Math.max(min, fallbackNumber));
+  }
+  const numeric = Number(rawValue);
+  if (!Number.isFinite(numeric)) {
+    return Math.min(max, Math.max(min, fallbackNumber));
+  }
+  return Math.min(max, Math.max(min, Math.floor(numeric)));
+}
+
 function normalizeAccountRunHistoryHelperBaseUrl(rawValue = '') {
   const value = String(rawValue || '').trim();
   if (!value) return DEFAULT_ACCOUNT_RUN_HISTORY_HELPER_BASE_URL;
@@ -1852,6 +1900,14 @@ function normalizePersistentSettingValue(key, value) {
       return self.GoPayUtils?.normalizeGoPayCountryCode
         ? self.GoPayUtils.normalizeGoPayCountryCode(value)
         : String(value || '+86').trim();
+    case 'gopayHelperOtpChannel':
+      return normalizeGpcOtpChannel(value);
+    case 'gopayHelperLocalSmsHelperUrl':
+      return normalizeGpcLocalSmsHelperBaseUrl(value);
+    case 'gopayHelperLocalSmsTimeoutSeconds':
+      return normalizePositiveIntegerSetting(value, PERSISTED_SETTING_DEFAULTS.gopayHelperLocalSmsTimeoutSeconds, 10, 300);
+    case 'gopayHelperLocalSmsPollIntervalSeconds':
+      return normalizePositiveIntegerSetting(value, PERSISTED_SETTING_DEFAULTS.gopayHelperLocalSmsPollIntervalSeconds, 1, 30);
     case 'gopayHelperApiUrl':
     case 'gopayHelperCardKey':
     case 'gopayHelperReferenceId':
@@ -1873,6 +1929,7 @@ function normalizePersistentSettingValue(key, value) {
     case 'autoRunDelayEnabled':
     case 'phoneVerificationEnabled':
     case 'plusModeEnabled':
+    case 'gopayHelperLocalSmsHelperEnabled':
       return Boolean(value);
     case 'phoneSmsProvider':
       return normalizePhoneSmsProvider(value);

--- a/background/auto-run-controller.js
+++ b/background/auto-run-controller.js
@@ -117,6 +117,15 @@
       return true;
     }
 
+    function isPlusNonFreeTrialFailure(errorLike) {
+      const message = String(
+        typeof errorLike === 'string'
+          ? errorLike
+          : (errorLike?.message || errorLike || '')
+      ).trim();
+      return /PLUS_CHECKOUT_NON_FREE_TRIAL::/i.test(message);
+    }
+
     function shouldKeepCustomMailProviderPoolEmail(state = {}) {
       return String(state?.mailProvider || '').trim().toLowerCase() === 'custom'
         && Array.isArray(state?.customMailProviderPool)
@@ -506,9 +515,11 @@
             const blockedBySignupUserAlreadyExists = typeof isSignupUserAlreadyExistsFailure === 'function'
               && !keepSameEmailUntilAddPhone
               && isSignupUserAlreadyExistsFailure(err);
+            const blockedByPlusNonFreeTrial = isPlusNonFreeTrialFailure(err);
             const canRetry = !blockedByAddPhone
               && !blockedByPhoneSupplyExhausted
               && !blockedBySignupUserAlreadyExists
+              && !blockedByPlusNonFreeTrial
               && autoRunSkipFailures
               && attemptRun < maxAttemptsForRound;
 
@@ -615,6 +626,41 @@
                 targetRun < totalRuns
                   ? `第 ${targetRun}/${totalRuns} 轮因接码号池不可用提前结束，自动流程将继续下一轮。`
                   : `第 ${targetRun}/${totalRuns} 轮因接码号池不可用提前结束，已无后续轮次，本次自动运行结束。`,
+                'warn'
+              );
+              forceFreshTabsNextRun = true;
+              break;
+            }
+
+            if (blockedByPlusNonFreeTrial) {
+              roundSummary.status = 'failed';
+              roundSummary.finalFailureReason = reason;
+              await setState({
+                autoRunRoundSummaries: serializeAutoRunRoundSummaries(totalRuns, roundSummaries),
+              });
+              await appendRoundRecordIfNeeded('failed', reason);
+              cancelPendingCommands('当前轮因 Plus 非免费试用资格已终止。');
+              await broadcastStopToContentScripts();
+              if (!autoRunSkipFailures) {
+                await addLog(
+                  `第 ${targetRun}/${totalRuns} 轮检测到当前账号没有 Plus 免费试用资格，自动重试未开启，当前自动运行将停止。`,
+                  'warn'
+                );
+                stoppedEarly = true;
+                await broadcastAutoRunStatus('stopped', {
+                  currentRun: targetRun,
+                  totalRuns,
+                  attemptRun,
+                  sessionId: 0,
+                });
+                break;
+              }
+
+              await addLog(`第 ${targetRun}/${totalRuns} 轮检测到当前账号没有 Plus 免费试用资格，本轮将直接失败并跳过剩余重试。`, 'warn');
+              await addLog(
+                targetRun < totalRuns
+                  ? `第 ${targetRun}/${totalRuns} 轮因没有 Plus 免费试用资格提前结束，自动流程将继续下一轮。`
+                  : `第 ${targetRun}/${totalRuns} 轮因没有 Plus 免费试用资格提前结束，已无后续轮次，本次自动运行结束。`,
                 'warn'
               );
               forceFreshTabsNextRun = true;

--- a/background/message-router.js
+++ b/background/message-router.js
@@ -130,6 +130,31 @@
         || String(state?.plusCheckoutSource || '').trim().toLowerCase() === 'gpc-helper';
     }
 
+    function normalizeIncomingGpcSmsOtp(payload = {}) {
+      const directCandidates = [
+        payload?.otp,
+        payload?.code,
+        payload?.sms_code,
+        payload?.smsCode,
+        payload?.verification_code,
+        payload?.verificationCode,
+      ];
+      for (const candidate of directCandidates) {
+        const normalized = String(candidate || '').trim().replace(/[^\d]/g, '');
+        if (/^\d{4,8}$/.test(normalized)) {
+          return normalized;
+        }
+      }
+      const messageText = String(payload?.message_text || payload?.messageText || payload?.text || '').trim();
+      if (messageText) {
+        const match = messageText.match(/(?:OTP\s*[:：]?\s*|#)(\d{4,8})\b|\b(\d{6})\b/i);
+        if (match) {
+          return String(match[1] || match[2] || '').trim();
+        }
+      }
+      return '';
+    }
+
     async function refreshGpcCardBalanceIfNeeded(state = {}, options = {}) {
       if (!isGpcHelperState(state) || typeof refreshGpcCardBalance !== 'function') {
         return null;
@@ -486,6 +511,23 @@
             notifyStepError(message.step, message.error);
           }
           return { ok: true };
+        }
+
+        case 'SUBMIT_GPC_SMS_OTP': {
+          const currentState = await getState();
+          const otp = normalizeIncomingGpcSmsOtp(message.payload || {});
+          if (!otp) {
+            throw new Error('未收到有效 OTP。');
+          }
+          await setState({
+            gopayHelperResolvedOtp: otp,
+            gopayHelperSmsOtpPayload: message.payload || {},
+          });
+          if (typeof broadcastDataUpdate === 'function') {
+            broadcastDataUpdate({ gopayHelperResolvedOtp: otp });
+          }
+          await addLog(`步骤 ${Number(currentState?.plusManualConfirmationStep) || 7}：本地 SMS Helper 已回传 OTP，准备验证。`, 'ok');
+          return { ok: true, otp };
         }
 
         case 'RESOLVE_PLUS_MANUAL_CONFIRMATION': {

--- a/background/message-router.js
+++ b/background/message-router.js
@@ -33,6 +33,7 @@
       executeStepViaCompletionSignal,
       exportSettingsBundle,
       fetchGeneratedEmail,
+      refreshGpcCardBalance,
       finalizePhoneActivationAfterSuccessfulFlow,
       finalizeStep3Completion,
       finalizeIcloudAliasAfterSuccessfulFlow,
@@ -66,6 +67,7 @@
       runIpProxyAutoSync,
       listIcloudAliases,
       listLuckmailPurchasesForManagement,
+      markCurrentRegistrationAccountUsed,
       refreshIpProxyPool,
       normalizeHotmailAccounts,
       normalizeMail2925Accounts,
@@ -115,6 +117,30 @@
       upsertHotmailAccount,
       verifyHotmailAccount,
     } = deps;
+
+    function normalizeGpcPaymentMethod(value = '') {
+      if (typeof self !== 'undefined' && self.GoPayUtils?.normalizePlusPaymentMethod) {
+        return self.GoPayUtils.normalizePlusPaymentMethod(value);
+      }
+      return String(value || '').trim().toLowerCase() === 'gpc-helper' ? 'gpc-helper' : String(value || '').trim().toLowerCase();
+    }
+
+    function isGpcHelperState(state = {}) {
+      return normalizeGpcPaymentMethod(state?.plusPaymentMethod) === 'gpc-helper'
+        || String(state?.plusCheckoutSource || '').trim().toLowerCase() === 'gpc-helper';
+    }
+
+    async function refreshGpcCardBalanceIfNeeded(state = {}, options = {}) {
+      if (!isGpcHelperState(state) || typeof refreshGpcCardBalance !== 'function') {
+        return null;
+      }
+      try {
+        return await refreshGpcCardBalance(state, options);
+      } catch (error) {
+        await addLog(`GPC 余额查询失败：${error?.message || String(error || '未知错误')}`, 'warn');
+        return null;
+      }
+    }
 
     async function appendManualAccountRunRecordIfNeeded(status, stateOverride = null, reason = '') {
       if (typeof appendAccountRunRecord !== 'function') {
@@ -183,21 +209,27 @@
         await closeLocalhostCallbackTabs(payload.localhostUrl);
       }
       const latestState = await getState();
-      if (latestState.currentHotmailAccountId && isHotmailProvider(latestState)) {
+      if (typeof markCurrentRegistrationAccountUsed === 'function') {
+        await markCurrentRegistrationAccountUsed(latestState, {
+          logPrefix: '流程完成',
+          level: 'ok',
+        });
+      }
+      if (typeof markCurrentRegistrationAccountUsed !== 'function' && latestState.currentHotmailAccountId && isHotmailProvider(latestState)) {
         await patchHotmailAccount(latestState.currentHotmailAccountId, {
           used: true,
           lastUsedAt: Date.now(),
         });
         await addLog('当前 Hotmail 账号已自动标记为已用。', 'ok');
       }
-      if (String(latestState.mailProvider || '').trim().toLowerCase() === '2925' && latestState.currentMail2925AccountId) {
+      if (typeof markCurrentRegistrationAccountUsed !== 'function' && String(latestState.mailProvider || '').trim().toLowerCase() === '2925' && latestState.currentMail2925AccountId) {
         await patchMail2925Account(latestState.currentMail2925AccountId, {
           lastUsedAt: Date.now(),
           lastError: '',
         });
         await addLog('当前 2925 账号已记录最近使用时间。', 'ok');
       }
-      if (isLuckmailProvider(latestState)) {
+      if (typeof markCurrentRegistrationAccountUsed !== 'function' && isLuckmailProvider(latestState)) {
         const currentPurchase = getCurrentLuckmailPurchase(latestState);
         if (currentPurchase?.id) {
           await setLuckmailPurchaseUsedState(currentPurchase.id, true);
@@ -213,10 +245,13 @@
           excludeLocalhostCallbacks: true,
         });
       }
-      await finalizeIcloudAliasAfterSuccessfulFlow(latestState);
+      if (typeof markCurrentRegistrationAccountUsed !== 'function') {
+        await finalizeIcloudAliasAfterSuccessfulFlow(latestState);
+      }
       if (typeof finalizePhoneActivationAfterSuccessfulFlow === 'function') {
         await finalizePhoneActivationAfterSuccessfulFlow(latestState);
       }
+      await refreshGpcCardBalanceIfNeeded(latestState, { reason: 'round_success' });
     }
 
     async function handleStepData(step, payload) {
@@ -373,6 +408,22 @@
           return { ok: true };
         }
 
+        case 'REFRESH_GPC_CARD_BALANCE': {
+          const currentState = await getState();
+          const payload = message.payload || {};
+          const state = {
+            ...currentState,
+            ...(payload.gopayHelperApiUrl !== undefined ? { gopayHelperApiUrl: payload.gopayHelperApiUrl } : {}),
+            ...(payload.gopayHelperCardKey !== undefined ? { gopayHelperCardKey: payload.gopayHelperCardKey } : {}),
+            plusPaymentMethod: payload.plusPaymentMethod || currentState.plusPaymentMethod || 'gpc-helper',
+          };
+          const result = await refreshGpcCardBalanceIfNeeded(state, { reason: payload.reason || 'manual' });
+          if (!result) {
+            throw new Error('GPC 余额查询能力未接入或当前不是 GPC 模式。');
+          }
+          return { ok: true, ...result };
+        }
+
         case 'STEP_COMPLETE': {
           if (getStopRequested()) {
             await setStepStatus(message.step, 'stopped');
@@ -443,6 +494,7 @@
           const confirmed = Boolean(message.payload?.confirmed);
           const requestId = String(message.payload?.requestId || '').trim();
           const currentRequestId = String(currentState?.plusManualConfirmationRequestId || '').trim();
+          const confirmationMethod = String(currentState?.plusManualConfirmationMethod || '').trim().toLowerCase();
           if (!currentState?.plusManualConfirmationPending) {
             return { ok: true, ignored: true };
           }
@@ -458,15 +510,34 @@
             plusManualConfirmationTitle: '',
             plusManualConfirmationMessage: '',
           };
+
+          if (confirmationMethod === 'gopay-otp') {
+            const resolvedOtp = String(message.payload?.otp || '').trim().replace(/[^\d]/g, '');
+            await setState({
+              ...clearManualConfirmationState,
+              gopayHelperResolvedOtp: confirmed && resolvedOtp ? resolvedOtp : '',
+              gopayHelperOtpRequestId: '',
+              gopayHelperOtpReferenceId: '',
+            });
+            if (typeof broadcastDataUpdate === 'function') {
+              broadcastDataUpdate({ plusManualConfirmationPending: false, plusManualConfirmationRequestId: '' });
+            }
+            await addLog(
+              confirmed && resolvedOtp
+                ? `步骤 ${step}：已收到 OTP 输入，准备验证。`
+                : `步骤 ${step}：OTP 输入已取消。`,
+              confirmed && resolvedOtp ? 'ok' : 'warn'
+            );
+            return { ok: true };
+          }
+
           await setState(clearManualConfirmationState);
           if (typeof broadcastDataUpdate === 'function') {
             broadcastDataUpdate(clearManualConfirmationState);
           }
 
           if (confirmed) {
-            const methodLabel = String(currentState?.plusManualConfirmationMethod || '').trim().toLowerCase() === 'gopay'
-              ? 'GoPay'
-              : '手动';
+            const methodLabel = confirmationMethod === 'gopay' ? 'GoPay' : '手动';
             await addLog(`步骤 ${step}：已确认${methodLabel}订阅完成，准备继续下一步。`, 'ok');
             await completeStepFromBackground(step, {
               plusManualConfirmationMethod: currentState?.plusManualConfirmationMethod || '',
@@ -475,7 +546,7 @@
             return { ok: true };
           }
 
-          const cancelMessage = String(currentState?.plusManualConfirmationMethod || '').trim().toLowerCase() === 'gopay'
+          const cancelMessage = confirmationMethod === 'gopay'
             ? '已取消 GoPay 订阅确认'
             : '已取消当前手动确认';
           await setStepStatus(step, 'failed');
@@ -793,11 +864,12 @@
             await setContributionMode(true);
           }
           if (modeChanged) {
-            const selectedPlusPaymentMethod = String(
-              (stateUpdates.plusPaymentMethod ?? currentState?.plusPaymentMethod ?? 'paypal')
-            ).trim().toLowerCase() === 'gopay'
-              ? 'GoPay'
-              : 'PayPal';
+            const normalizedPlusPaymentMethod = String(
+              stateUpdates.plusPaymentMethod ?? currentState?.plusPaymentMethod ?? 'paypal'
+            ).trim().toLowerCase();
+            const selectedPlusPaymentMethod = normalizedPlusPaymentMethod === 'gpc-helper'
+              ? 'GPC'
+              : (normalizedPlusPaymentMethod === 'gopay' ? 'GoPay' : 'PayPal');
             await addLog(
               Boolean(updates.plusModeEnabled)
                 ? `Plus 模式已开启，已切换为 Plus Checkout 步骤，当前支付方式：${selectedPlusPaymentMethod}。`
@@ -805,11 +877,12 @@
               'info'
             );
           } else if (plusPaymentChanged && nextPlusModeEnabled) {
-            const selectedPlusPaymentMethod = String(
+            const normalizedPlusPaymentMethod = String(
               stateUpdates.plusPaymentMethod ?? currentState?.plusPaymentMethod ?? 'paypal'
-            ).trim().toLowerCase() === 'gopay'
-              ? 'GoPay'
-              : 'PayPal';
+            ).trim().toLowerCase();
+            const selectedPlusPaymentMethod = normalizedPlusPaymentMethod === 'gpc-helper'
+              ? 'GPC'
+              : (normalizedPlusPaymentMethod === 'gopay' ? 'GoPay' : 'PayPal');
             await addLog(`Plus 支付方式已切换为 ${selectedPlusPaymentMethod}，已更新对应的 Plus 步骤。`, 'info');
           }
           return { ok: true, state: await getState(), proxyRouting };

--- a/background/steps/create-plus-checkout.js
+++ b/background/steps/create-plus-checkout.js
@@ -4,6 +4,7 @@
   const PLUS_CHECKOUT_SOURCE = 'plus-checkout';
   const PLUS_CHECKOUT_ENTRY_URL = 'https://chatgpt.com/';
   const PLUS_CHECKOUT_INJECT_FILES = ['content/utils.js', 'content/plus-checkout.js'];
+  const GOPAY_HELPER_CHECKOUT_SOURCE = 'gpc-helper';
 
   function createPlusCheckoutCreateExecutor(deps = {}) {
     const {
@@ -11,21 +12,30 @@
       chrome,
       completeStepFromBackground,
       ensureContentScriptReadyOnTabUntilStopped,
+      fetch: fetchImpl = null,
+      markCurrentRegistrationAccountUsed = null,
       registerTab,
       sendTabMessageUntilStopped,
       setState,
       sleepWithStop,
       waitForTabCompleteUntilStopped,
+      throwIfStopped = () => {},
     } = deps;
 
     function normalizePlusPaymentMethod(value = '') {
-      return String(value || '').trim().toLowerCase() === 'gopay' ? 'gopay' : 'paypal';
+      const normalized = String(value || '').trim().toLowerCase();
+      if (normalized === GOPAY_HELPER_CHECKOUT_SOURCE) {
+        return GOPAY_HELPER_CHECKOUT_SOURCE;
+      }
+      return normalized === 'gopay' ? 'gopay' : 'paypal';
     }
 
     function getCheckoutModeLabel(state = {}) {
-      return normalizePlusPaymentMethod(state?.plusPaymentMethod) === 'gopay'
-        ? 'GoPay 订阅页'
-        : 'Plus Checkout';
+      const paymentMethod = normalizePlusPaymentMethod(state?.plusPaymentMethod);
+      if (paymentMethod === GOPAY_HELPER_CHECKOUT_SOURCE) {
+        return 'GPC 订阅页';
+      }
+      return paymentMethod === 'gopay' ? 'GoPay 订阅页' : 'Plus Checkout';
     }
 
     async function openFreshChatGptTabForCheckoutCreate() {
@@ -40,8 +50,333 @@
       return tabId;
     }
 
+
+    function normalizeHelperPhoneNumber(phone = '', countryCode = '86') {
+      const cleaned = String(phone || '').replace(/\D/g, '');
+      const countryDigits = String(countryCode || '').replace(/\D/g, '');
+      if (countryDigits && cleaned.startsWith(countryDigits) && cleaned.length > countryDigits.length) {
+        return cleaned.slice(countryDigits.length);
+      }
+      return cleaned;
+    }
+
+    function normalizeHelperCountryCode(countryCode = '86') {
+      const digits = String(countryCode || '').replace(/\D/g, '');
+      return digits || '86';
+    }
+
+    function resolveGoPayHelperCardKey(state = {}) {
+      const cardKey = String(state?.gopayHelperCardKey || state?.gpcCardKey || state?.cardKey || '').trim();
+      if (!cardKey) {
+        throw new Error('创建 GPC 订单失败：缺少卡密。');
+      }
+      return cardKey;
+    }
+
+    function resolveGoPayHelperCustomerEmail(state = {}) {
+      const email = String(
+        state?.email
+        || state?.currentEmail
+        || state?.registrationEmail
+        || state?.accountEmail
+        || state?.mailboxEmail
+        || ''
+      ).trim().toLowerCase();
+      if (!email) {
+        throw new Error('创建 GPC 订单失败：缺少当前轮邮箱。');
+      }
+      return email;
+    }
+
+    function parseGopayHelperAmount(value) {
+      if (typeof value === 'number') {
+        return Number.isFinite(value) ? { amount: value, raw: String(value) } : null;
+      }
+      if (typeof value !== 'string') {
+        return null;
+      }
+      const raw = String(value || '').trim();
+      if (!raw || !/\d/.test(raw)) {
+        return null;
+      }
+      const match = raw.match(/([+-]?\d{1,3}(?:[.,]\d{3})*(?:[.,]\d{1,2})|[+-]?\d+(?:[.,]\d{1,2})?)/);
+      if (!match) {
+        return null;
+      }
+      let numericText = String(match[1] || '').trim();
+      const lastComma = numericText.lastIndexOf(',');
+      const lastDot = numericText.lastIndexOf('.');
+      if (lastComma > -1 && lastDot > -1) {
+        const decimalSeparator = lastComma > lastDot ? ',' : '.';
+        const thousandsSeparator = decimalSeparator === ',' ? '.' : ',';
+        numericText = numericText
+          .replace(new RegExp(`\\${thousandsSeparator}`, 'g'), '')
+          .replace(decimalSeparator, '.');
+      } else if (lastComma > -1) {
+        numericText = numericText.replace(',', '.');
+      }
+      const amount = Number(numericText.replace(/[^\d.+-]/g, ''));
+      return Number.isFinite(amount) ? { amount, raw } : null;
+    }
+
+    function isGopayHelperAmountKey(key = '') {
+      const normalized = String(key || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '_');
+      if (!normalized) {
+        return false;
+      }
+      if (/(?:^|_)(?:id|guid|uuid|phone|country|postal|zip|code|count|status|time|timestamp|created|updated|expires|challenge|client|reference|currency|state)(?:_|$)/i.test(normalized)) {
+        return false;
+      }
+      return /(?:amount|balance|total|due|payable|gross|subtotal|price|charge)/i.test(normalized);
+    }
+
+    function findGopayHelperNonZeroAmount(payload = {}) {
+      const seen = new Set();
+      function visit(value, path = [], depth = 0) {
+        if (value == null || depth > 10) {
+          return null;
+        }
+        const key = path[path.length - 1] || '';
+        if (isGopayHelperAmountKey(key)) {
+          const parsed = parseGopayHelperAmount(value);
+          if (parsed && Math.abs(parsed.amount) >= 0.005) {
+            return { ...parsed, path: path.join('.') };
+          }
+        }
+        if (typeof value !== 'object') {
+          return null;
+        }
+        if (seen.has(value)) {
+          return null;
+        }
+        seen.add(value);
+        if (Array.isArray(value)) {
+          for (let index = 0; index < value.length; index += 1) {
+            const found = visit(value[index], [...path, String(index)], depth + 1);
+            if (found) return found;
+          }
+          return null;
+        }
+        for (const [childKey, childValue] of Object.entries(value)) {
+          const found = visit(childValue, [...path, childKey], depth + 1);
+          if (found) return found;
+        }
+        return null;
+      }
+      return visit(payload);
+    }
+
+    async function abortGopayHelperNonFreeTrialIfNeeded(data = {}, state = {}) {
+      const nonZeroAmount = findGopayHelperNonZeroAmount(data);
+      if (!nonZeroAmount) {
+        return;
+      }
+      const amountLabel = nonZeroAmount.raw || String(nonZeroAmount.amount);
+      await addLog(`步骤 6：GPC 接口返回余额非 0（${amountLabel}），当前账号没有免费试用资格，将跳过当前账号。`, 'warn');
+      if (typeof markCurrentRegistrationAccountUsed === 'function') {
+        await markCurrentRegistrationAccountUsed(state, {
+          reason: 'plus-checkout-non-free-trial',
+          logPrefix: 'GPC：当前账号没有免费试用资格',
+        });
+      }
+      throw new Error(`PLUS_CHECKOUT_NON_FREE_TRIAL::步骤 6：GPC 接口返回余额非 0（${amountLabel}），当前账号没有免费试用资格，已跳过支付提交。`);
+    }
+
+    function normalizeGoPayHelperBaseUrl(apiUrl = '') {
+      const globalRoot = typeof self !== 'undefined' ? self : globalThis;
+      if (globalRoot.GoPayUtils?.normalizeGpcHelperBaseUrl) {
+        return globalRoot.GoPayUtils.normalizeGpcHelperBaseUrl(apiUrl);
+      }
+      let normalized = String(apiUrl || '').trim().replace(/\/+$/g, '');
+      normalized = normalized.replace(/\/api\/checkout\/start$/i, '');
+      normalized = normalized.replace(/\/api\/gopay\/(?:otp|pin)$/i, '');
+      normalized = normalized.replace(/\/api\/card\/balance(?:\?.*)?$/i, '');
+      return normalized;
+    }
+
+    function buildGoPayHelperApiUrl(apiUrl = '', path = '') {
+      const baseUrl = normalizeGoPayHelperBaseUrl(apiUrl);
+      if (!baseUrl) {
+        return '';
+      }
+      const normalizedPath = String(path || '').startsWith('/')
+        ? String(path || '')
+        : `/${String(path || '')}`;
+      return `${baseUrl}${normalizedPath}`;
+    }
+
+    async function fetchJsonWithTimeout(url, options = {}, timeoutMs = 30000) {
+      const fetcher = typeof fetchImpl === 'function'
+        ? fetchImpl
+        : (typeof fetch === 'function' ? fetch.bind(globalThis) : null);
+      if (typeof fetcher !== 'function') {
+        throw new Error('当前运行环境不支持 fetch，无法调用 GPC API。');
+      }
+      const controller = typeof AbortController === 'function' ? new AbortController() : null;
+      const timer = controller ? setTimeout(() => controller.abort(), Math.max(1000, Number(timeoutMs) || 30000)) : null;
+      try {
+        const response = await fetcher(url, { ...options, ...(controller ? { signal: controller.signal } : {}) });
+        const data = await response.json().catch(() => ({}));
+        return { response, data };
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    }
+
+    async function readAccessTokenFromChatGptSessionTab(tabId) {
+      await waitForTabCompleteUntilStopped(tabId);
+      await sleepWithStop(1000);
+      await ensureContentScriptReadyOnTabUntilStopped(PLUS_CHECKOUT_SOURCE, tabId, {
+        inject: PLUS_CHECKOUT_INJECT_FILES,
+        injectSource: PLUS_CHECKOUT_SOURCE,
+        logMessage: '步骤 6：正在等待 ChatGPT 页面完成加载，再继续获取 accessToken...',
+      });
+
+      const sessionResult = await sendTabMessageUntilStopped(tabId, PLUS_CHECKOUT_SOURCE, {
+        type: 'PLUS_CHECKOUT_GET_STATE',
+        source: 'background',
+        payload: {
+          includeSession: true,
+          includeAccessToken: true,
+        },
+      });
+      if (sessionResult?.error) {
+        throw new Error(sessionResult.error);
+      }
+      return String(sessionResult?.accessToken || sessionResult?.session?.accessToken || '').trim();
+    }
+
+    async function generateGpcCheckoutFromApi(accessToken = '', state = {}) {
+      const token = String(accessToken || '').trim();
+      if (!token) {
+        throw new Error('创建 GPC 订单失败：缺少 accessToken。');
+      }
+      const apiUrl = buildGoPayHelperApiUrl(state?.gopayHelperApiUrl, '/api/checkout/start');
+      if (!apiUrl) {
+        throw new Error('创建 GPC 订单失败：缺少 API 地址。');
+      }
+      const phoneNumber = String(state?.gopayHelperPhoneNumber || '').trim();
+      const countryCode = normalizeHelperCountryCode(state?.gopayHelperCountryCode || '86');
+      const pin = String(state?.gopayHelperPin || '').trim();
+      const cardKey = resolveGoPayHelperCardKey(state);
+      if (!phoneNumber) {
+        throw new Error('创建 GPC 订单失败：缺少手机号。');
+      }
+      if (!pin) {
+        throw new Error('创建 GPC 订单失败：缺少 PIN。');
+      }
+
+      throwIfStopped();
+      const payload = {
+        token,
+        entry_point: 'all_plans_pricing_modal',
+        plan_name: 'chatgptplusplan',
+        billing_details: { country: 'ID', currency: 'IDR' },
+        promo_campaign: {
+          promo_campaign_id: 'plus-1-month-free',
+          is_coupon_from_query_param: false,
+        },
+        checkout_ui_mode: 'custom',
+        proxy: { type: 'direct', url: '' },
+        tax_region: { country: 'US', line1: '1208 Oakdale Street', city: 'Jonesboro', postal_code: '72401', state: 'AR' },
+        customer_email: resolveGoPayHelperCustomerEmail(state),
+        card_key: cardKey,
+        gopay_link: {
+          type: 'gopay',
+          country_code: countryCode,
+          phone_number: normalizeHelperPhoneNumber(phoneNumber, countryCode),
+        },
+      };
+
+      const { response, data } = await fetchJsonWithTimeout(apiUrl, {
+        method: 'POST',
+        headers: {
+          Accept: '*/*',
+          'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      }, 30000);
+
+      const referenceId = String(data?.reference_id || data?.referenceId || '');
+      const gopayGuid = String(data?.gopay_guid || data?.gopayGuid || '');
+      const redirectUrl = String(data?.redirect_url || data?.redirectUrl || '');
+      const nextAction = String(data?.next_action || data?.nextAction || '');
+      const flowId = String(data?.flow_id || data?.flowId || '');
+      const challengeId = String(data?.challenge_id || data?.challengeId || '');
+
+      if (response?.ok) {
+        await abortGopayHelperNonFreeTrialIfNeeded(data, state);
+      }
+
+      if (!response?.ok || !referenceId) {
+        const globalRoot = typeof self !== 'undefined' ? self : globalThis;
+        const detail = globalRoot.GoPayUtils?.extractGpcResponseErrorDetail
+          ? globalRoot.GoPayUtils.extractGpcResponseErrorDetail(data, response?.status || 0)
+          : (data?.detail || data?.message || data?.error || `HTTP ${response?.status || 0}`);
+        throw new Error(`创建 GPC 订单失败：${detail}`);
+      }
+
+      return {
+        referenceId,
+        gopayGuid,
+        redirectUrl,
+        nextAction,
+        flowId,
+        challengeId,
+        responsePayload: data && typeof data === 'object' && !Array.isArray(data) ? data : null,
+        country: 'ID',
+        currency: 'IDR',
+        checkoutSource: GOPAY_HELPER_CHECKOUT_SOURCE,
+      };
+    }
+
     async function executePlusCheckoutCreate(state = {}) {
+      const paymentMethod = normalizePlusPaymentMethod(state?.plusPaymentMethod);
       const checkoutModeLabel = getCheckoutModeLabel(state);
+
+      if (paymentMethod === GOPAY_HELPER_CHECKOUT_SOURCE) {
+        let accessToken = String(state?.contributionAccessToken || state?.accessToken || state?.chatgptAccessToken || '').trim();
+        if (!accessToken) {
+          await addLog('步骤 6：正在获取 accessToken...', 'info');
+          const tokenTabId = await openFreshChatGptTabForCheckoutCreate();
+          try {
+            accessToken = await readAccessTokenFromChatGptSessionTab(tokenTabId);
+          } finally {
+            if (chrome?.tabs?.remove && Number.isInteger(tokenTabId)) {
+              await chrome.tabs.remove(tokenTabId).catch(() => {});
+            }
+          }
+        }
+        if (!accessToken) {
+          throw new Error('步骤 6：GPC 模式获取 accessToken 失败。');
+        }
+
+        await addLog('步骤 6：正在调用 GPC 接口创建订单...', 'info');
+        const result = await generateGpcCheckoutFromApi(accessToken, state);
+        await setState({
+          plusCheckoutTabId: null,
+          plusCheckoutUrl: '',
+          plusCheckoutCountry: result.country || 'ID',
+          plusCheckoutCurrency: result.currency || 'IDR',
+          plusCheckoutSource: result.checkoutSource,
+          gopayHelperReferenceId: result.referenceId,
+          gopayHelperGoPayGuid: result.gopayGuid,
+          gopayHelperRedirectUrl: result.redirectUrl,
+          gopayHelperNextAction: result.nextAction,
+          gopayHelperFlowId: result.flowId,
+          gopayHelperChallengeId: result.challengeId,
+          gopayHelperStartPayload: result.responsePayload,
+        });
+        await addLog('步骤 6：GPC 订单已创建，准备继续下一步。', 'info');
+        await completeStepFromBackground(6, {
+          plusCheckoutCountry: result.country || 'ID',
+          plusCheckoutCurrency: result.currency || 'IDR',
+          plusCheckoutSource: result.checkoutSource,
+        });
+        return;
+      }
+
       await addLog(`步骤 6：正在打开新的 ChatGPT 会话，准备创建${checkoutModeLabel}...`, 'info');
       const tabId = await openFreshChatGptTabForCheckoutCreate();
 
@@ -57,7 +392,7 @@
         type: 'CREATE_PLUS_CHECKOUT',
         source: 'background',
         payload: {
-          paymentMethod: normalizePlusPaymentMethod(state?.plusPaymentMethod),
+          paymentMethod,
         },
       });
 

--- a/background/steps/create-plus-checkout.js
+++ b/background/steps/create-plus-checkout.js
@@ -65,6 +65,17 @@
       return digits || '86';
     }
 
+    function normalizeGpcOtpChannel(value = '') {
+      const normalized = String(value || '').trim().toLowerCase();
+      if (normalized === 'sms') {
+        return 'sms';
+      }
+      if (normalized === 'wa' || normalized === 'ws' || normalized === 'whatsapp' || !normalized) {
+        return 'whatsapp';
+      }
+      return 'whatsapp';
+    }
+
     function resolveGoPayHelperCardKey(state = {}) {
       const cardKey = String(state?.gopayHelperCardKey || state?.gpcCardKey || state?.cardKey || '').trim();
       if (!cardKey) {
@@ -267,6 +278,7 @@
       }
 
       throwIfStopped();
+      const otpChannel = normalizeGpcOtpChannel(state?.gopayHelperOtpChannel);
       const payload = {
         token,
         entry_point: 'all_plans_pricing_modal',
@@ -283,6 +295,8 @@
         card_key: cardKey,
         gopay_link: {
           type: 'gopay',
+          phone_mode: 'manual',
+          otp_channel: otpChannel,
           country_code: countryCode,
           phone_number: normalizeHelperPhoneNumber(phoneNumber, countryCode),
         },

--- a/background/steps/fill-plus-checkout.js
+++ b/background/steps/fill-plus-checkout.js
@@ -194,6 +194,149 @@
       return Promise.resolve({});
     }
 
+    function normalizeGpcOtpChannel(value = '') {
+      const normalized = String(value || '').trim().toLowerCase();
+      if (normalized === 'sms') {
+        return 'sms';
+      }
+      if (normalized === 'wa' || normalized === 'ws' || normalized === 'whatsapp' || !normalized) {
+        return 'whatsapp';
+      }
+      return 'whatsapp';
+    }
+
+    function normalizeGpcLocalSmsHelperBaseUrl(value = '') {
+      const trimmed = String(value || '').trim();
+      if (!trimmed) {
+        return '';
+      }
+      try {
+        const parsed = new URL(trimmed);
+        if (!['http:', 'https:'].includes(parsed.protocol)) {
+          return '';
+        }
+        const endpointPaths = new Set(['/otp', '/latest-otp', '/health']);
+        if (endpointPaths.has(parsed.pathname.replace(/\/+$/g, '') || '/')) {
+          parsed.pathname = '';
+          parsed.search = '';
+          parsed.hash = '';
+        }
+        return parsed.toString().replace(/\/$/, '');
+      } catch {
+        return '';
+      }
+    }
+
+    function buildGpcLocalSmsHelperUrl(baseUrl = '', path = '/otp') {
+      const base = normalizeGpcLocalSmsHelperBaseUrl(baseUrl);
+      if (!base) {
+        return '';
+      }
+      const normalizedPath = String(path || '').startsWith('/') ? String(path || '') : `/${String(path || '')}`;
+      return `${base}${normalizedPath}`;
+    }
+
+    function extractGpcOtpFromPayload(payload = {}) {
+      if (!payload || typeof payload !== 'object') {
+        return '';
+      }
+      const directCandidates = [
+        payload.otp,
+        payload.code,
+        payload.sms_code,
+        payload.smsCode,
+        payload.verification_code,
+        payload.verificationCode,
+        payload?.data?.otp,
+        payload?.data?.code,
+        payload?.data?.sms_code,
+        payload?.data?.smsCode,
+        payload?.result?.otp,
+        payload?.result?.code,
+      ];
+      for (const candidate of directCandidates) {
+        const normalized = String(candidate || '').trim().replace(/[^\d]/g, '');
+        if (/^\d{4,8}$/.test(normalized)) {
+          return normalized;
+        }
+      }
+      const messageCandidates = [
+        payload.message_text,
+        payload.messageText,
+        payload.text,
+        payload.body,
+        payload?.data?.message_text,
+        payload?.data?.messageText,
+        payload?.data?.text,
+      ];
+      for (const messageText of messageCandidates) {
+        const match = String(messageText || '').match(/(?:OTP\s*[:：]?\s*|#)(\d{4,8})\b|\b(\d{6})\b/i);
+        if (match) {
+          return String(match[1] || match[2] || '').trim();
+        }
+      }
+      return '';
+    }
+
+    async function fetchGpcOtpFromLocalSmsHelper({ baseUrl = '', referenceId = '', phoneNumber = '', timeoutMs = 15000 }) {
+      const requestUrl = buildGpcLocalSmsHelperUrl(baseUrl, '/otp');
+      if (!requestUrl) {
+        throw new Error('本地 SMS Helper 地址无效。');
+      }
+      const queryUrl = new URL(requestUrl);
+      if (referenceId) queryUrl.searchParams.set('reference_id', referenceId);
+      if (phoneNumber) queryUrl.searchParams.set('phone_number', phoneNumber);
+      const result = await fetchJsonWithTimeout(queryUrl.toString(), {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+      }, timeoutMs);
+      if (!result?.response?.ok || result?.data?.ok === false) {
+        const detail = getGpcResponseErrorDetail(result?.data, result?.response?.status || 0);
+        throw new Error(detail || '本地 SMS Helper 查询失败');
+      }
+      return extractGpcOtpFromPayload(result?.data);
+    }
+
+    async function waitForGpcOtpFromLocalSmsHelper(state = {}, options = {}) {
+      const baseUrl = normalizeGpcLocalSmsHelperBaseUrl(state?.gopayHelperLocalSmsHelperUrl || '');
+      if (!baseUrl) {
+        throw new Error('步骤 7：已开启本地 SMS Helper，但未填写有效地址。');
+      }
+      const timeoutSeconds = Math.max(10, Math.min(300, Number(state?.gopayHelperLocalSmsTimeoutSeconds) || 90));
+      const pollIntervalSeconds = Math.max(1, Math.min(30, Number(state?.gopayHelperLocalSmsPollIntervalSeconds) || 2));
+      const deadline = Date.now() + timeoutSeconds * 1000;
+      let lastError = '';
+      while (Date.now() <= deadline) {
+        throwIfStopped();
+        try {
+          const otp = await fetchGpcOtpFromLocalSmsHelper({
+            baseUrl,
+            referenceId: options.referenceId || '',
+            phoneNumber: options.phoneNumber || '',
+            timeoutMs: Math.min(15000, Math.max(3000, pollIntervalSeconds * 1000)),
+          });
+          if (otp) {
+            await setState({
+              gopayHelperResolvedOtp: otp,
+              gopayHelperSmsOtpPayload: {
+                source: 'local-sms-helper',
+                reference_id: options.referenceId || '',
+              },
+            });
+            if (typeof broadcastDataUpdate === 'function') {
+              broadcastDataUpdate({ gopayHelperResolvedOtp: otp });
+            }
+            return otp;
+          }
+          lastError = '未查询到验证码';
+        } catch (error) {
+          lastError = error?.message || String(error || '查询失败');
+        }
+        await sleepWithStop(Math.max(500, pollIntervalSeconds * 1000));
+      }
+      throw new Error(`步骤 7：本地 SMS Helper 查询 OTP 超时${lastError ? `：${lastError}` : ''}`);
+    }
+
     async function requestGpcOtpInput({ title = '', message = '', referenceId = '' }) {
       const requestId = `otp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
       const payload = {
@@ -240,13 +383,25 @@
       if (!cardKey) {
         throw new Error('步骤 7：GPC 模式缺少卡密。');
       }
-      await addLog(`步骤 7：GPC 模式开始 OTP 验证（reference_id: ${referenceId}）...`, 'info');
-      await addLog('步骤 7：等待用户输入 OTP...', 'info');
-      const otp = await requestGpcOtpInput({
-        title: 'GPC OTP 验证',
-        message: `请输入收到的 OTP 验证码（reference_id: ${referenceId}）`,
-        referenceId,
-      });
+      const otpChannel = normalizeGpcOtpChannel(state?.gopayHelperOtpChannel);
+      const localSmsHelperEnabled = Boolean(state?.gopayHelperLocalSmsHelperEnabled) && otpChannel === 'sms';
+      await addLog(`步骤 7：GPC 模式开始 OTP 验证（reference_id: ${referenceId}，通道：${otpChannel}）...`, 'info');
+      let otp = '';
+      if (localSmsHelperEnabled) {
+        await addLog('步骤 7：已开启本地 SMS Helper，正在查询短信 OTP...', 'info');
+        otp = await waitForGpcOtpFromLocalSmsHelper(state, {
+          referenceId,
+          phoneNumber: state?.gopayHelperPhoneNumber || '',
+        });
+        await addLog('步骤 7：本地 SMS Helper 已获取 OTP，准备自动提交。', 'ok');
+      } else {
+        await addLog('步骤 7：等待用户输入 OTP...', 'info');
+        otp = await requestGpcOtpInput({
+          title: 'GPC OTP 验证',
+          message: `请输入收到的 OTP 验证码（reference_id: ${referenceId}）`,
+          referenceId,
+        });
+      }
 
       const baseInput = {
         reference_id: referenceId,

--- a/background/steps/fill-plus-checkout.js
+++ b/background/steps/fill-plus-checkout.js
@@ -4,6 +4,7 @@
   const PLUS_CHECKOUT_SOURCE = 'plus-checkout';
   const PLUS_CHECKOUT_INJECT_FILES = ['content/utils.js', 'content/plus-checkout.js'];
   const PLUS_CHECKOUT_URL_PATTERN = /^https:\/\/chatgpt\.com\/checkout(?:\/|$)/i;
+  const GOPAY_HELPER_CHECKOUT_SOURCE = 'gpc-helper';
   const PLUS_CHECKOUT_FRAME_READY_DELAY_MS = 500;
   const MEIGUODIZHI_ADDRESS_ENDPOINT = 'https://www.meiguodizhi.com/api/v1/dz';
   const MEIGUODIZHI_COUNTRY_CONFIG = {
@@ -34,26 +35,300 @@
   function createPlusCheckoutBillingExecutor(deps = {}) {
     const {
       addLog,
+      broadcastDataUpdate,
       chrome,
       completeStepFromBackground,
       ensureContentScriptReadyOnTabUntilStopped,
       fetch: fetchImpl = null,
       generateRandomName,
       getAddressSeedForCountry,
+      getState,
       getTabId,
       isTabAlive,
+      markCurrentRegistrationAccountUsed,
       setState,
       sleepWithStop,
       waitForTabCompleteUntilStopped,
       waitForTabUrlMatchUntilStopped,
+      throwIfStopped = () => {},
     } = deps;
 
     function isPlusCheckoutUrl(url = '') {
       return PLUS_CHECKOUT_URL_PATTERN.test(String(url || ''));
     }
 
+
+    function isGopayHelperCheckout(state = {}) {
+      return normalizeText(state?.plusCheckoutSource) === GOPAY_HELPER_CHECKOUT_SOURCE
+        && Boolean(state?.gopayHelperReferenceId);
+    }
+
+    async function fetchJsonWithTimeout(url, options = {}, timeoutMs = 30000) {
+      const fetcher = typeof fetchImpl === 'function'
+        ? fetchImpl
+        : (typeof fetch === 'function' ? fetch.bind(globalThis) : null);
+      if (typeof fetcher !== 'function') {
+        throw new Error('当前运行环境不支持 fetch，无法调用 GPC API。');
+      }
+      const controller = typeof AbortController === 'function' ? new AbortController() : null;
+      const timer = controller ? setTimeout(() => controller.abort(), Math.max(1000, Number(timeoutMs) || 30000)) : null;
+      try {
+        const response = await fetcher(url, { ...options, ...(controller ? { signal: controller.signal } : {}) });
+        const data = await response.json().catch(() => ({}));
+        return { response, data };
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    }
+
     function normalizeText(value = '') {
       return String(value || '').replace(/\s+/g, ' ').trim();
+    }
+
+
+    function normalizeGpcHelperBaseUrl(apiUrl = '') {
+      const globalRoot = typeof self !== 'undefined' ? self : globalThis;
+      if (globalRoot.GoPayUtils?.normalizeGpcHelperBaseUrl) {
+        return globalRoot.GoPayUtils.normalizeGpcHelperBaseUrl(apiUrl);
+      }
+      let normalized = String(apiUrl || '').trim().replace(/\/+$/g, '');
+      normalized = normalized.replace(/\/api\/checkout\/start$/i, '');
+      normalized = normalized.replace(/\/api\/gopay\/(?:otp|pin)$/i, '');
+      normalized = normalized.replace(/\/api\/card\/balance(?:\?.*)?$/i, '');
+      return normalized;
+    }
+
+    function buildGpcOtpPayload(input = {}) {
+      if (typeof self !== 'undefined' && self.GoPayUtils?.buildGpcOtpPayload) {
+        return self.GoPayUtils.buildGpcOtpPayload(input);
+      }
+      const payload = {
+        reference_id: String(input.reference_id ?? input.referenceId ?? '').trim(),
+        otp: String(input.otp ?? input.code ?? '').trim().replace(/[^\d]/g, ''),
+        card_key: String(input.card_key ?? input.cardKey ?? '').trim(),
+      };
+      const gopayGuid = String(input.gopay_guid ?? input.gopayGuid ?? '').trim();
+      const redirectUrl = String(input.redirect_url ?? input.redirectUrl ?? '').trim();
+      const flowId = String(input.flow_id ?? input.flowId ?? '').trim();
+      if (flowId) payload.flow_id = flowId;
+      if (gopayGuid) payload.gopay_guid = gopayGuid;
+      if (redirectUrl) payload.redirect_url = redirectUrl;
+      return payload;
+    }
+
+    function buildGpcOtpRetryPayload(input = {}) {
+      if (typeof self !== 'undefined' && self.GoPayUtils?.buildGpcOtpRetryPayload) {
+        return self.GoPayUtils.buildGpcOtpRetryPayload(input);
+      }
+      const basePayload = buildGpcOtpPayload(input);
+      return { ...basePayload, code: basePayload.otp };
+    }
+
+    function buildGpcPinPayload(input = {}) {
+      if (typeof self !== 'undefined' && self.GoPayUtils?.buildGpcPinPayload) {
+        return self.GoPayUtils.buildGpcPinPayload(input);
+      }
+      const payload = {
+        reference_id: String(input.reference_id ?? input.referenceId ?? '').trim(),
+        challenge_id: String(input.challenge_id ?? input.challengeId ?? '').trim(),
+        gopay_guid: String(input.gopay_guid ?? input.gopayGuid ?? '').trim(),
+        pin: String(input.pin ?? '').trim().replace(/[^\d]/g, ''),
+        card_key: String(input.card_key ?? input.cardKey ?? '').trim(),
+      };
+      const redirectUrl = String(input.redirect_url ?? input.redirectUrl ?? '').trim();
+      const flowId = String(input.flow_id ?? input.flowId ?? '').trim();
+      if (flowId) payload.flow_id = flowId;
+      if (redirectUrl) payload.redirect_url = redirectUrl;
+      return payload;
+    }
+
+    function buildGpcPinRetryPayload(input = {}) {
+      if (typeof self !== 'undefined' && self.GoPayUtils?.buildGpcPinRetryPayload) {
+        return self.GoPayUtils.buildGpcPinRetryPayload(input);
+      }
+      const basePayload = buildGpcPinPayload(input);
+      return { ...basePayload, challengeId: basePayload.challenge_id };
+    }
+
+    function getGpcResponseErrorDetail(payload = {}, status = 0) {
+      if (typeof self !== 'undefined' && self.GoPayUtils?.extractGpcResponseErrorDetail) {
+        return self.GoPayUtils.extractGpcResponseErrorDetail(payload, status);
+      }
+      if (payload && typeof payload === 'object') {
+        return payload.detail || payload.message || payload.error || payload.error_description || payload.reason || `HTTP ${status || 0}`;
+      }
+      return `HTTP ${status || 0}`;
+    }
+
+    async function postGpcJsonWithFallback(apiUrl, endpointPath, primaryPayload, fallbackPayload, timeoutMs = 30000) {
+      const requestUrl = `${apiUrl}${endpointPath}`;
+      const send = (payload) => fetchJsonWithTimeout(requestUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      }, timeoutMs);
+      const firstResponse = await send(primaryPayload);
+      if (firstResponse?.response?.ok || !fallbackPayload) {
+        return { ...firstResponse, retried: false, payload: primaryPayload };
+      }
+      const status = Number(firstResponse?.response?.status || 0);
+      if (status !== 400 && status !== 422) {
+        return { ...firstResponse, retried: false, payload: primaryPayload };
+      }
+      const firstDetail = getGpcResponseErrorDetail(firstResponse?.data, status);
+      await addLog(`步骤 7：GPC 接口返回 ${status}（${firstDetail}），使用兼容字段重试。`, 'warn');
+      const secondResponse = await send(fallbackPayload);
+      return {
+        ...secondResponse,
+        retried: true,
+        payload: fallbackPayload,
+        firstError: firstDetail,
+        firstStatus: status,
+      };
+    }
+
+    function getStateInternal() {
+      if (typeof getState === 'function') {
+        return getState();
+      }
+      return Promise.resolve({});
+    }
+
+    async function requestGpcOtpInput({ title = '', message = '', referenceId = '' }) {
+      const requestId = `otp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const payload = {
+        plusManualConfirmationPending: true,
+        plusManualConfirmationRequestId: requestId,
+        plusManualConfirmationStep: 7,
+        plusManualConfirmationMethod: 'gopay-otp',
+        plusManualConfirmationTitle: title || 'GPC OTP 验证',
+        plusManualConfirmationMessage: message || '请输入 OTP 验证码',
+        gopayHelperOtpRequestId: requestId,
+        gopayHelperOtpReferenceId: referenceId,
+        gopayHelperResolvedOtp: '',
+      };
+      await setState(payload);
+      if (typeof broadcastDataUpdate === 'function') {
+        broadcastDataUpdate(payload);
+      }
+      return new Promise((resolve, reject) => {
+        const checkInterval = setInterval(async () => {
+          const currentState = await getStateInternal();
+          if (!currentState?.plusManualConfirmationPending || currentState?.plusManualConfirmationRequestId !== requestId) {
+            clearInterval(checkInterval);
+            const resolvedOtp = String(currentState?.gopayHelperResolvedOtp || '').trim().replace(/[^\d]/g, '');
+            if (resolvedOtp) {
+              resolve(resolvedOtp);
+            } else {
+              reject(new Error('OTP 输入已取消'));
+            }
+          }
+        }, 500);
+      });
+    }
+
+    async function executeGpcHelperBilling(state = {}) {
+      const referenceId = String(state?.gopayHelperReferenceId || '').trim();
+      const apiUrl = normalizeGpcHelperBaseUrl(state?.gopayHelperApiUrl || '');
+      const cardKey = String(state?.gopayHelperCardKey || state?.gpcCardKey || state?.cardKey || '').trim();
+      if (!referenceId) {
+        throw new Error('步骤 7：GPC 模式缺少 reference_id，请先执行步骤 6。');
+      }
+      if (!apiUrl) {
+        throw new Error('步骤 7：GPC 模式缺少 API 地址。');
+      }
+      if (!cardKey) {
+        throw new Error('步骤 7：GPC 模式缺少卡密。');
+      }
+      await addLog(`步骤 7：GPC 模式开始 OTP 验证（reference_id: ${referenceId}）...`, 'info');
+      await addLog('步骤 7：等待用户输入 OTP...', 'info');
+      const otp = await requestGpcOtpInput({
+        title: 'GPC OTP 验证',
+        message: `请输入收到的 OTP 验证码（reference_id: ${referenceId}）`,
+        referenceId,
+      });
+
+      const baseInput = {
+        reference_id: referenceId,
+        otp,
+        card_key: cardKey,
+        gopay_guid: state?.gopayHelperGoPayGuid || '',
+        redirect_url: state?.gopayHelperRedirectUrl || '',
+        flow_id: state?.gopayHelperFlowId
+          || state?.gopayHelperStartPayload?.flow_id
+          || state?.gopayHelperStartPayload?.flowId
+          || state?.gopayHelperBalancePayload?.flow_id
+          || state?.gopayHelperBalancePayload?.flowId
+          || '',
+      };
+      await addLog('步骤 7：正在提交 OTP...', 'info');
+      const otpResponse = await postGpcJsonWithFallback(
+        apiUrl,
+        '/api/gopay/otp',
+        buildGpcOtpPayload(baseInput),
+        buildGpcOtpRetryPayload(baseInput),
+        30000
+      );
+      if (!otpResponse?.response?.ok) {
+        throw new Error(`步骤 7：OTP 验证失败：${getGpcResponseErrorDetail(otpResponse?.data, otpResponse?.response?.status || 0)}`);
+      }
+
+      const otpData = otpResponse?.data || {};
+      const challengeId = String(
+        otpData?.challenge_id
+        || otpData?.challengeId
+        || state?.gopayHelperChallengeId
+        || state?.gopayHelperStartPayload?.challenge_id
+        || state?.gopayHelperStartPayload?.challengeId
+        || ''
+      ).trim();
+      const flowId = String(otpData?.flow_id || otpData?.flowId || baseInput.flow_id || '').trim();
+      const gopayGuid = String(otpData?.gopay_guid || otpData?.gopayGuid || state?.gopayHelperGoPayGuid || '').trim();
+      const redirectUrl = String(otpData?.redirect_url || otpData?.redirectUrl || state?.gopayHelperRedirectUrl || '').trim();
+      if (!challengeId) {
+        throw new Error('步骤 7：GPC OTP 验证后未返回 challenge_id。');
+      }
+      const pin = String(state?.gopayHelperPin || '').trim().replace(/[^\d]/g, '');
+      if (!pin) {
+        throw new Error('步骤 7：GPC 模式缺少 PIN 配置。');
+      }
+
+      await setState({
+        gopayHelperChallengeId: challengeId,
+        gopayHelperFlowId: flowId,
+        gopayHelperGoPayGuid: gopayGuid,
+        gopayHelperRedirectUrl: redirectUrl,
+      });
+
+      await addLog('步骤 7：正在提交 PIN...', 'info');
+      const pinInput = {
+        reference_id: referenceId,
+        challenge_id: challengeId,
+        gopay_guid: gopayGuid,
+        redirect_url: redirectUrl,
+        flow_id: flowId,
+        pin,
+        card_key: cardKey,
+      };
+      const pinResponse = await postGpcJsonWithFallback(
+        apiUrl,
+        '/api/gopay/pin',
+        buildGpcPinPayload(pinInput),
+        buildGpcPinRetryPayload(pinInput),
+        30000
+      );
+      if (!pinResponse?.response?.ok) {
+        throw new Error(`步骤 7：PIN 验证失败：${getGpcResponseErrorDetail(pinResponse?.data, pinResponse?.response?.status || 0)}`);
+      }
+
+      await setState({
+        plusCheckoutSource: GOPAY_HELPER_CHECKOUT_SOURCE,
+        gopayHelperPinPayload: pinResponse?.data || null,
+      });
+      await addLog('步骤 7：GPC 支付完成，准备继续下一步。', 'ok');
+      await completeStepFromBackground(7, {
+        plusCheckoutSource: GOPAY_HELPER_CHECKOUT_SOURCE,
+      });
     }
 
     function compactCountryText(value = '') {
@@ -457,6 +732,10 @@
     }
 
     async function executePlusCheckoutBilling(state = {}) {
+      if (isGopayHelperCheckout(state)) {
+        await executeGpcHelperBilling(state);
+        return;
+      }
       const tabId = await getCheckoutTabId(state);
       await addLog('步骤 7：正在等待 Plus Checkout 页面加载完成...', 'info');
       await waitForTabCompleteUntilStopped(tabId);

--- a/content/plus-checkout.js
+++ b/content/plus-checkout.js
@@ -85,7 +85,7 @@ async function handlePlusCheckoutCommand(message) {
     case 'PLUS_CHECKOUT_CLICK_SUBSCRIBE':
       return clickPlusSubscribe();
     case 'PLUS_CHECKOUT_GET_STATE':
-      return inspectPlusCheckoutState();
+      return inspectPlusCheckoutState(message.payload || {});
     default:
       throw new Error(`plus-checkout.js 不处理消息：${message.type}`);
   }
@@ -1139,9 +1139,20 @@ async function clickPlusSubscribe() {
   };
 }
 
-function inspectPlusCheckoutState() {
-  const structuredAddress = getStructuredAddressFields();
+async function readChatGptSessionAccessToken() {
+  const sessionResponse = await fetch('/api/auth/session', {
+    credentials: 'include',
+  });
+  const session = await sessionResponse.json().catch(() => ({}));
   return {
+    session,
+    accessToken: String(session?.accessToken || '').trim(),
+  };
+}
+
+async function inspectPlusCheckoutState(options = {}) {
+  const structuredAddress = getStructuredAddressFields();
+  const state = {
     url: location.href,
     readyState: document.readyState,
     countryText: readCountryText(),
@@ -1158,5 +1169,11 @@ function inspectPlusCheckoutState() {
       postalCode: structuredAddress.postalCode?.value || '',
     },
   };
+  if (options.includeSession || options.includeAccessToken) {
+    const sessionState = await readChatGptSessionAccessToken();
+    state.session = sessionState.session;
+    state.accessToken = sessionState.accessToken;
+  }
+  return state;
 }
 })();

--- a/data/step-definitions.js
+++ b/data/step-definitions.js
@@ -44,21 +44,41 @@
     { id: 13, order: 130, key: 'platform-verify', title: '平台回调验证' },
   ];
 
+  const PLUS_GPC_STEP_DEFINITIONS = [
+    { id: 1, order: 10, key: 'open-chatgpt', title: '打开 ChatGPT 官网' },
+    { id: 2, order: 20, key: 'submit-signup-email', title: '注册并输入邮箱' },
+    { id: 3, order: 30, key: 'fill-password', title: '填写密码并继续' },
+    { id: 4, order: 40, key: 'fetch-signup-code', title: '获取注册验证码' },
+    { id: 5, order: 50, key: 'fill-profile', title: '填写姓名和生日' },
+    { id: 6, order: 60, key: 'plus-checkout-create', title: '创建 GPC 订单' },
+    { id: 7, order: 70, key: 'plus-checkout-billing', title: 'GPC OTP/PIN 验证' },
+    { id: 10, order: 100, key: 'oauth-login', title: '刷新 OAuth 并登录' },
+    { id: 11, order: 110, key: 'fetch-login-code', title: '获取登录验证码' },
+    { id: 12, order: 120, key: 'confirm-oauth', title: '自动确认 OAuth' },
+    { id: 13, order: 130, key: 'platform-verify', title: '平台回调验证' },
+  ];
+
   function isPlusModeEnabled(options = {}) {
     return Boolean(options?.plusModeEnabled || options?.plusMode);
   }
 
   function normalizePlusPaymentMethod(value = '') {
-    return String(value || '').trim().toLowerCase() === 'gopay' ? 'gopay' : 'paypal';
+    const normalized = String(value || '').trim().toLowerCase();
+    if (normalized === 'gpc-helper') {
+      return 'gpc-helper';
+    }
+    return normalized === 'gopay' ? 'gopay' : 'paypal';
   }
 
   function getModeStepDefinitions(options = {}) {
     if (!isPlusModeEnabled(options)) {
       return NORMAL_STEP_DEFINITIONS;
     }
-    return normalizePlusPaymentMethod(options?.plusPaymentMethod || options?.paymentMethod) === 'gopay'
-      ? PLUS_GOPAY_STEP_DEFINITIONS
-      : PLUS_PAYPAL_STEP_DEFINITIONS;
+    const paymentMethod = normalizePlusPaymentMethod(options?.plusPaymentMethod || options?.paymentMethod);
+    if (paymentMethod === 'gpc-helper') {
+      return PLUS_GPC_STEP_DEFINITIONS;
+    }
+    return paymentMethod === 'gopay' ? PLUS_GOPAY_STEP_DEFINITIONS : PLUS_PAYPAL_STEP_DEFINITIONS;
   }
 
   function cloneSteps(steps = []) {
@@ -75,6 +95,7 @@
       ...NORMAL_STEP_DEFINITIONS,
       ...PLUS_PAYPAL_STEP_DEFINITIONS,
       ...PLUS_GOPAY_STEP_DEFINITIONS,
+      ...PLUS_GPC_STEP_DEFINITIONS,
     ]) {
       keyed.set(`${step.id}:${step.key}`, step);
     }
@@ -110,6 +131,7 @@
     PLUS_STEP_DEFINITIONS: PLUS_PAYPAL_STEP_DEFINITIONS,
     PLUS_PAYPAL_STEP_DEFINITIONS,
     PLUS_GOPAY_STEP_DEFINITIONS,
+    PLUS_GPC_STEP_DEFINITIONS,
     getAllSteps,
     getLastStepId,
     getStepById,

--- a/gopay-utils.js
+++ b/gopay-utils.js
@@ -43,6 +43,17 @@
     return String(value || '').trim().replace(/[^\d]/g, '');
   }
 
+  function normalizeGpcOtpChannel(value = '') {
+    const normalized = String(value || '').trim().toLowerCase();
+    if (normalized === 'sms') {
+      return 'sms';
+    }
+    if (normalized === 'wa' || normalized === 'ws' || normalized === 'whatsapp' || !normalized) {
+      return 'whatsapp';
+    }
+    return 'whatsapp';
+  }
+
   function normalizeGpcHelperBaseUrl(apiUrl = '') {
     let normalized = String(apiUrl || '').trim();
     if (!normalized) {
@@ -203,6 +214,7 @@
     normalizeGoPayPhoneForCountry,
     normalizeGoPayOtp,
     normalizeGoPayPin,
+    normalizeGpcOtpChannel,
     normalizeGpcHelperBaseUrl,
     buildGpcHelperApiUrl,
     buildGpcCardBalanceUrl,

--- a/gopay-utils.js
+++ b/gopay-utils.js
@@ -1,0 +1,216 @@
+(function attachGoPayUtils(root, factory) {
+  root.GoPayUtils = factory();
+})(typeof self !== 'undefined' ? self : globalThis, function createGoPayUtils() {
+  const PLUS_PAYMENT_METHOD_PAYPAL = 'paypal';
+  const PLUS_PAYMENT_METHOD_GOPAY = 'gopay';
+  const PLUS_PAYMENT_METHOD_GOPAY_HELPER = 'gpc-helper';
+  const DEFAULT_GOPAY_COUNTRY_CODE = '+86';
+
+  function normalizePlusPaymentMethod(value = '') {
+    const normalized = String(value || '').trim().toLowerCase();
+    if (normalized === PLUS_PAYMENT_METHOD_GOPAY_HELPER) {
+      return PLUS_PAYMENT_METHOD_GOPAY_HELPER;
+    }
+    return normalized === PLUS_PAYMENT_METHOD_GOPAY
+      ? PLUS_PAYMENT_METHOD_GOPAY
+      : PLUS_PAYMENT_METHOD_PAYPAL;
+  }
+
+  function normalizeGoPayCountryCode(value = '') {
+    const digits = String(value || '').trim().replace(/[^\d+]/g, '').replace(/\D/g, '');
+    return digits ? `+${digits}` : DEFAULT_GOPAY_COUNTRY_CODE;
+  }
+
+  function normalizeGoPayPhone(value = '') {
+    return String(value || '').trim().replace(/[^\d+]/g, '');
+  }
+
+  function normalizeGoPayPhoneForCountry(value = '', countryCode = DEFAULT_GOPAY_COUNTRY_CODE) {
+    const normalizedPhone = normalizeGoPayPhone(value);
+    const countryDigits = normalizeGoPayCountryCode(countryCode).replace(/\D/g, '');
+    let nationalNumber = normalizedPhone.replace(/\D/g, '');
+    if (countryDigits && nationalNumber.startsWith(countryDigits)) {
+      nationalNumber = nationalNumber.slice(countryDigits.length);
+    }
+    return nationalNumber;
+  }
+
+  function normalizeGoPayPin(value = '') {
+    return String(value || '').trim().replace(/[^\d]/g, '');
+  }
+
+  function normalizeGoPayOtp(value = '') {
+    return String(value || '').trim().replace(/[^\d]/g, '');
+  }
+
+  function normalizeGpcHelperBaseUrl(apiUrl = '') {
+    let normalized = String(apiUrl || '').trim();
+    if (!normalized) {
+      return '';
+    }
+    normalized = normalized.replace(/\/+$/g, '');
+    normalized = normalized.replace(/\/api\/checkout\/start$/i, '');
+    normalized = normalized.replace(/\/api\/gopay\/(?:otp|pin)$/i, '');
+    normalized = normalized.replace(/\/api\/card\/balance(?:\?.*)?$/i, '');
+    return normalized;
+  }
+
+  function buildGpcHelperApiUrl(apiUrl = '', path = '') {
+    const baseUrl = normalizeGpcHelperBaseUrl(apiUrl);
+    if (!baseUrl) {
+      return '';
+    }
+    const normalizedPath = String(path || '').startsWith('/')
+      ? String(path || '')
+      : `/${String(path || '')}`;
+    return `${baseUrl}${normalizedPath}`;
+  }
+
+  function buildGpcCardBalanceUrl(apiUrl = '', cardKey = '') {
+    const endpoint = buildGpcHelperApiUrl(apiUrl, '/api/card/balance');
+    if (!endpoint) {
+      return '';
+    }
+    return `${endpoint}?card_key=${encodeURIComponent(String(cardKey || '').trim())}`;
+  }
+
+  function extractGpcResponseErrorDetail(payload = {}, status = 0) {
+    if (!payload || typeof payload !== 'object') {
+      return status ? `HTTP ${status}` : '未知错误';
+    }
+
+    const payloadText = JSON.stringify(payload).toLowerCase();
+    if (/account\s+already\s+linked/i.test(payloadText)) {
+      return 'GOPAY已经绑了订阅，需要手动解绑';
+    }
+
+    const direct = payload.detail
+      ?? payload.message
+      ?? payload.error
+      ?? payload.error_description
+      ?? payload.reason;
+    if (direct !== undefined && direct !== null && String(direct).trim()) {
+      const directText = String(direct).trim();
+      return /account\s+already\s+linked/i.test(directText)
+        ? 'GOPAY已经绑了订阅，需要手动解绑'
+        : directText;
+    }
+
+    const errorMessages = payload.error_messages ?? payload.errorMessages;
+    if (Array.isArray(errorMessages) && errorMessages.length > 0) {
+      const firstMessage = String(errorMessages[0] || '').trim();
+      if (/account\s+already\s+linked/i.test(firstMessage)) {
+        return 'GOPAY已经绑了订阅，需要手动解绑';
+      }
+      if (firstMessage) {
+        return firstMessage;
+      }
+    }
+
+    const errors = payload.errors;
+    if (Array.isArray(errors) && errors.length > 0) {
+      const first = errors[0];
+      if (typeof first === 'string') {
+        return first.trim() || (status ? `HTTP ${status}` : '未知错误');
+      }
+      if (first && typeof first === 'object') {
+        const field = Array.isArray(first.loc) ? first.loc.join('.') : String(first.field || first.path || '').trim();
+        const message = String(first.msg || first.message || first.error || '').trim();
+        return [field, message].filter(Boolean).join(': ') || JSON.stringify(first);
+      }
+    }
+
+    return status ? `HTTP ${status}` : '未知错误';
+  }
+
+  function buildGpcOtpPayload(input = {}) {
+    const payload = {
+      reference_id: String(input.reference_id ?? input.referenceId ?? '').trim(),
+      otp: normalizeGoPayOtp(input.otp ?? input.code ?? ''),
+      card_key: String(input.card_key ?? input.cardKey ?? '').trim(),
+    };
+    const flowId = String(input.flow_id ?? input.flowId ?? '').trim();
+    const gopayGuid = String(input.gopay_guid ?? input.gopayGuid ?? '').trim();
+    const redirectUrl = String(input.redirect_url ?? input.redirectUrl ?? '').trim();
+    if (flowId) payload.flow_id = flowId;
+    if (gopayGuid) payload.gopay_guid = gopayGuid;
+    if (redirectUrl) payload.redirect_url = redirectUrl;
+    return payload;
+  }
+
+  function buildGpcOtpRetryPayload(input = {}) {
+    const payload = buildGpcOtpPayload(input);
+    return { ...payload, code: payload.otp };
+  }
+
+  function buildGpcPinPayload(input = {}) {
+    const payload = {
+      reference_id: String(input.reference_id ?? input.referenceId ?? '').trim(),
+      challenge_id: String(input.challenge_id ?? input.challengeId ?? '').trim(),
+      gopay_guid: String(input.gopay_guid ?? input.gopayGuid ?? '').trim(),
+      pin: normalizeGoPayPin(input.pin ?? ''),
+      card_key: String(input.card_key ?? input.cardKey ?? '').trim(),
+    };
+    const flowId = String(input.flow_id ?? input.flowId ?? '').trim();
+    const redirectUrl = String(input.redirect_url ?? input.redirectUrl ?? '').trim();
+    if (flowId) payload.flow_id = flowId;
+    if (redirectUrl) payload.redirect_url = redirectUrl;
+    return payload;
+  }
+
+  function buildGpcPinRetryPayload(input = {}) {
+    const payload = buildGpcPinPayload(input);
+    return { ...payload, challengeId: payload.challenge_id };
+  }
+
+  function formatGpcBalancePayload(payload = {}) {
+    if (!payload || typeof payload !== 'object') {
+      return '';
+    }
+    const candidates = [
+      payload.remaining_uses,
+      payload.remainingUses,
+      payload.balance,
+      payload.remaining,
+      payload.uses,
+      payload.available_uses,
+      payload.availableUses,
+    ];
+    const firstValue = candidates.find((value) => value !== undefined && value !== null && String(value).trim() !== '');
+    const status = String(payload.card_status || payload.cardStatus || payload.status || '').trim();
+    const flowId = String(payload.flow_id || payload.flowId || '').trim();
+    const parts = [];
+    if (firstValue !== undefined) {
+      parts.push(`余额 ${firstValue}`);
+    }
+    if (status) {
+      parts.push(`状态 ${status}`);
+    }
+    if (flowId) {
+      parts.push(`flow_id ${flowId}`);
+    }
+    return parts.join('，');
+  }
+
+  return {
+    DEFAULT_GOPAY_COUNTRY_CODE,
+    PLUS_PAYMENT_METHOD_GOPAY_HELPER,
+    PLUS_PAYMENT_METHOD_GOPAY,
+    PLUS_PAYMENT_METHOD_PAYPAL,
+    normalizePlusPaymentMethod,
+    normalizeGoPayCountryCode,
+    normalizeGoPayPhone,
+    normalizeGoPayPhoneForCountry,
+    normalizeGoPayOtp,
+    normalizeGoPayPin,
+    normalizeGpcHelperBaseUrl,
+    buildGpcHelperApiUrl,
+    buildGpcCardBalanceUrl,
+    extractGpcResponseErrorDetail,
+    buildGpcOtpPayload,
+    buildGpcOtpRetryPayload,
+    buildGpcPinPayload,
+    buildGpcPinRetryPayload,
+    formatGpcBalancePayload,
+  };
+});

--- a/scripts/gpc_sms_helper_macos.py
+++ b/scripts/gpc_sms_helper_macos.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Local macOS SMS OTP helper for GPC GoPay flows.
+
+Only macOS can read the Messages database used here. Before starting this helper,
+make sure the iPhone receiving GoPay SMS codes is signed in to the same Apple ID
+and SMS forwarding is enabled so the codes appear in the Mac Messages app.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import platform
+import re
+import shutil
+import sqlite3
+import sys
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Iterable, Optional
+from urllib.parse import parse_qs, urlparse
+
+HOST = "127.0.0.1"
+PORT = 18767
+DEFAULT_DB = "~/Library/Messages/chat.db"
+MAC_ABSOLUTE_EPOCH = dt.datetime(2001, 1, 1, tzinfo=dt.timezone.utc)
+
+OTP_PATTERNS = [
+    re.compile(r"(?i)\bOTP\s*[:：]?\s*([0-9]{4,8})\b"),
+    re.compile(r"#([0-9]{4,8})\b"),
+    re.compile(r"(?<!\d)([0-9]{6})(?!\d)"),
+]
+KEYWORDS = ("gojek", "gopay", "openai llc", "openai")
+
+STATE_LOCK = threading.Lock()
+STATE = {
+    "started_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+    "db_path": "",
+    "last_scan_at": "",
+    "last_error": "",
+    "last_rowid": 0,
+    "last_otp": None,
+    "otps": [],
+}
+
+
+def is_macos() -> bool:
+    override = os.environ.get("GPC_SMS_HELPER_ALLOW_NON_MAC", "").strip().lower()
+    return platform.system() == "Darwin" or override in {"1", "true", "yes"}
+
+
+def require_macos() -> None:
+    if not is_macos():
+        raise RuntimeError("GPC 本地 SMS Helper 仅支持 macOS：需要读取 ~/Library/Messages/chat.db。")
+
+
+def extract_gopay_otp(text: str, require_keywords: bool = True) -> Optional[str]:
+    raw = text or ""
+    lowered = raw.lower()
+    if require_keywords and not any(keyword in lowered for keyword in KEYWORDS):
+        return None
+    for pattern in OTP_PATTERNS:
+        match = pattern.search(raw)
+        if match:
+            return match.group(1)
+    return None
+
+
+def mac_message_time_to_datetime(value: int | float | None) -> dt.datetime:
+    if not value:
+        return dt.datetime.now(dt.timezone.utc)
+    seconds = float(value)
+    if seconds > 10_000_000_000:
+        seconds = seconds / 1_000_000_000
+    return MAC_ABSOLUTE_EPOCH + dt.timedelta(seconds=seconds)
+
+
+def copy_messages_db(source: Path) -> Path:
+    tmpdir = Path(tempfile.mkdtemp(prefix="gpc_messages_"))
+    target = tmpdir / "chat.db"
+    shutil.copy2(source, target)
+    for suffix in ("-wal", "-shm"):
+        sidecar = Path(str(source) + suffix)
+        if sidecar.exists():
+            shutil.copy2(sidecar, Path(str(target) + suffix))
+    return target
+
+
+def latest_rowid(db_path: Path) -> int:
+    snapshot = copy_messages_db(db_path)
+    try:
+        conn = sqlite3.connect(str(snapshot))
+        try:
+            value = conn.execute("SELECT COALESCE(MAX(ROWID), 0) FROM message").fetchone()[0]
+            return int(value or 0)
+        finally:
+            conn.close()
+    finally:
+        shutil.rmtree(snapshot.parent, ignore_errors=True)
+
+
+def read_messages(db_path: Path, after_rowid: int) -> Iterable[dict]:
+    snapshot = copy_messages_db(db_path)
+    try:
+        conn = sqlite3.connect(str(snapshot))
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                """
+                SELECT message.ROWID AS rowid, message.guid AS guid, message.text AS text,
+                       message.date AS message_date, handle.id AS handle_id
+                FROM message
+                LEFT JOIN handle ON handle.ROWID = message.handle_id
+                WHERE message.ROWID > ? AND message.text IS NOT NULL
+                ORDER BY message.ROWID ASC
+                """,
+                (after_rowid,),
+            ).fetchall()
+            for row in rows:
+                yield dict(row)
+        finally:
+            conn.close()
+    finally:
+        shutil.rmtree(snapshot.parent, ignore_errors=True)
+
+
+def make_otp_record(row: dict, otp: str) -> dict:
+    received_at = mac_message_time_to_datetime(row.get("message_date")).astimezone(dt.timezone.utc).isoformat()
+    return {
+        "otp": otp,
+        "code": otp,
+        "message_id": str(row.get("guid") or row.get("rowid") or ""),
+        "rowid": int(row.get("rowid") or 0),
+        "received_at": received_at,
+        "source": str(row.get("handle_id") or "macos_messages"),
+        "message_text": row.get("text") or "",
+    }
+
+
+def update_state(**updates: object) -> None:
+    with STATE_LOCK:
+        STATE.update(updates)
+
+
+def append_otp(record: dict, max_records: int = 30) -> None:
+    with STATE_LOCK:
+        records = [item for item in STATE.get("otps", []) if item.get("message_id") != record.get("message_id")]
+        records.append(record)
+        records = records[-max_records:]
+        STATE["otps"] = records
+        STATE["last_otp"] = record
+
+
+def snapshot_state() -> dict:
+    with STATE_LOCK:
+        return json.loads(json.dumps(STATE, ensure_ascii=False))
+
+
+def scan_once(db_path: Path, after_rowid: int, require_keywords: bool) -> int:
+    max_seen = after_rowid
+    for row in read_messages(db_path, after_rowid):
+        max_seen = max(max_seen, int(row.get("rowid") or 0))
+        otp = extract_gopay_otp(row.get("text") or "", require_keywords=require_keywords)
+        if not otp:
+            continue
+        record = make_otp_record(row, otp)
+        append_otp(record)
+        print(f"captured OTP {otp} from message {record['message_id']} at {record['received_at']}", flush=True)
+    update_state(last_rowid=max_seen, last_scan_at=dt.datetime.now(dt.timezone.utc).isoformat(), last_error="")
+    return max_seen
+
+
+def poll_loop(db_path: Path, after_rowid: int, interval: float, require_keywords: bool) -> None:
+    cursor = after_rowid
+    while True:
+        try:
+            cursor = scan_once(db_path, cursor, require_keywords=require_keywords)
+        except Exception as exc:  # noqa: BLE001 - keep local helper alive and visible.
+            update_state(last_error=str(exc), last_scan_at=dt.datetime.now(dt.timezone.utc).isoformat())
+            print(f"scan error: {exc}", file=sys.stderr, flush=True)
+        time.sleep(max(interval, 0.5))
+
+
+def write_json(handler: BaseHTTPRequestHandler, status: int, payload: dict) -> None:
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json; charset=utf-8")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.send_header("Access-Control-Allow-Origin", "*")
+    handler.send_header("Access-Control-Allow-Headers", "Content-Type")
+    handler.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+class GpcSmsHelperHandler(BaseHTTPRequestHandler):
+    server_version = "GpcSmsHelper/1.0"
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        print(f"[GpcSmsHelper] {self.address_string()} {fmt % args}", flush=True)
+
+    def do_OPTIONS(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler naming.
+        write_json(self, 200, {"ok": True})
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler naming.
+        parsed = urlparse(self.path)
+        if parsed.path == "/health":
+            state = snapshot_state()
+            write_json(self, 200, {
+                "ok": True,
+                "platform": platform.system(),
+                "db_path": state.get("db_path"),
+                "last_scan_at": state.get("last_scan_at"),
+                "last_error": state.get("last_error"),
+                "last_rowid": state.get("last_rowid"),
+                "has_otp": bool(state.get("last_otp")),
+            })
+            return
+
+        if parsed.path in ("/otp", "/latest-otp"):
+            query = parse_qs(parsed.query or "")
+            consume = str((query.get("consume") or [""])[0]).strip().lower() in {"1", "true", "yes"}
+            state = snapshot_state()
+            record = state.get("last_otp") or None
+            if not record:
+                write_json(self, 200, {"ok": True, "otp": "", "code": "", "status": "waiting", "message": "未查询到验证码"})
+                return
+            if consume:
+                update_state(last_otp=None)
+            write_json(self, 200, {"ok": True, "status": "ok", **record})
+            return
+
+        write_json(self, 404, {"ok": False, "error": f"unsupported path: {parsed.path}"})
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a local macOS Messages HTTP helper for GPC SMS OTP.")
+    parser.add_argument("--host", default=HOST, help="HTTP listen host")
+    parser.add_argument("--port", type=int, default=PORT, help="HTTP listen port")
+    parser.add_argument("--db", default=DEFAULT_DB, help="Messages chat.db path")
+    parser.add_argument("--interval", type=float, default=2.0, help="poll interval seconds")
+    parser.add_argument("--send-latest-on-start", action="store_true", help="scan existing recent messages on startup")
+    parser.add_argument("--no-keyword-filter", action="store_true", help="accept any 6 digit SMS code, not only GoPay/OpenAI messages")
+    return parser.parse_args()
+
+
+def main() -> int:
+    try:
+        require_macos()
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        print("请在 macOS 上运行，并确保 iPhone 短信已转发到这台 Mac 的 Messages/信息 app。", file=sys.stderr)
+        return 2
+
+    args = parse_args()
+    db_path = Path(os.path.expanduser(args.db))
+    if not db_path.exists():
+        print(f"Messages DB not found: {db_path}", file=sys.stderr)
+        print("请确认这台 Mac 已打开 Messages/信息 app，并且 iPhone 短信能同步到电脑。", file=sys.stderr)
+        return 2
+
+    after_rowid = 0 if args.send_latest_on_start else latest_rowid(db_path)
+    update_state(db_path=str(db_path), last_rowid=after_rowid)
+
+    print("GPC 本地 SMS Helper 仅支持 macOS。", flush=True)
+    print("启动前请确认：接收 GoPay SMS 的 iPhone 已开启短信转发，并且短信能在这台 Mac 的 Messages/信息 app 收到。", flush=True)
+    print(f"listening on http://{args.host}:{args.port}; db={db_path}; after_rowid={after_rowid}", flush=True)
+
+    thread = threading.Thread(
+        target=poll_loop,
+        args=(db_path, after_rowid, args.interval, not args.no_keyword_filter),
+        daemon=True,
+    )
+    thread.start()
+
+    server = ThreadingHTTPServer((args.host, args.port), GpcSmsHelperHandler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("stopping", flush=True)
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -291,6 +291,29 @@
         <span class="data-label">GPC 手机</span>
         <input type="text" id="input-gpc-helper-phone" class="data-input" placeholder="GPC 专用手机号，不读取 GoPay 手机字段" />
       </div>
+      <div class="data-row" id="row-gpc-helper-otp-channel" style="display:none;">
+        <span class="data-label">验证码通道</span>
+        <select id="select-gpc-helper-otp-channel" class="data-select">
+          <option value="whatsapp">WhatsApp</option>
+          <option value="sms">SMS 短信</option>
+        </select>
+      </div>
+      <div class="data-row" id="row-gpc-helper-local-sms-enabled" style="display:none;">
+        <span class="data-label">本地 SMS</span>
+        <div class="data-inline">
+          <label class="toggle-switch" for="input-gpc-helper-local-sms-enabled" title="仅 macOS 可用；请确认 iPhone 短信能转发到这台 Mac">
+            <input type="checkbox" id="input-gpc-helper-local-sms-enabled" />
+            <span class="toggle-switch-track" aria-hidden="true">
+              <span class="toggle-switch-thumb"></span>
+            </span>
+          </label>
+          <span class="data-value">开启本地 SMS 接码 Helper（仅 macOS，需 iPhone 短信能在电脑 Messages 中收到）</span>
+        </div>
+      </div>
+      <div class="data-row" id="row-gpc-helper-local-sms-url" style="display:none;">
+        <span class="data-label">SMS Helper</span>
+        <input type="text" id="input-gpc-helper-local-sms-url" class="data-input" placeholder="http://127.0.0.1:18767" />
+      </div>
       <div class="data-row" id="row-gpc-helper-pin" style="display:none;">
         <span class="data-label">GPC PIN</span>
         <div class="input-with-icon">

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -239,7 +239,9 @@
             <select id="select-plus-payment-method" class="data-select plus-payment-method-select" style="display:none;" aria-label="Plus 支付方式">
               <option value="paypal">PayPal 支付</option>
               <option value="gopay">GoPay 支付</option>
+              <option value="gpc-helper">GPC</option>
             </select>
+            <button id="btn-gpc-card-key-purchase" class="btn btn-outline btn-sm data-inline-btn" type="button" style="display:none;">购买卡密</button>
           </div>
         </div>
       </div>
@@ -250,6 +252,52 @@
             <option value="">请先添加 PayPal 账号</option>
           </select>
           <button id="btn-add-paypal-account" class="btn btn-outline btn-sm data-inline-btn" type="button">添加</button>
+        </div>
+      </div>
+      <div class="data-row" id="row-gpc-helper-api" style="display:none;">
+        <span class="data-label">GPC API</span>
+        <input type="text" id="input-gpc-helper-api" class="data-input" placeholder="https://gopay.hwork.pro" />
+      </div>
+      <div class="data-row" id="row-gpc-helper-card-key" style="display:none;">
+        <span class="data-label">GPC 卡密</span>
+        <div class="data-inline">
+          <div class="input-with-icon">
+            <input type="password" id="input-gpc-helper-card-key" class="data-input data-input-with-icon"
+              placeholder="请输入购买的 GPC 卡密" autocomplete="off" />
+            <button id="btn-toggle-gpc-helper-card-key" class="input-icon-btn" type="button"
+              data-password-toggle="input-gpc-helper-card-key" data-show-label="显示GPC卡密"
+              data-hide-label="隐藏GPC卡密" aria-label="显示GPC卡密" title="显示GPC卡密"></button>
+          </div>
+          <button id="btn-gpc-helper-balance" class="btn btn-ghost btn-xs data-inline-btn" type="button">查余额</button>
+          <span id="display-gpc-helper-balance" class="data-value mono">余额未获取</span>
+        </div>
+      </div>
+      <div class="data-row" id="row-gpc-helper-country-code" style="display:none;">
+        <span class="data-label">GPC 区号</span>
+        <select id="select-gpc-helper-country-code" class="data-select">
+          <option value="+86">+86 中国</option>
+          <option value="+62">+62 印尼</option>
+          <option value="+852">+852 香港</option>
+          <option value="+886">+886 台湾</option>
+          <option value="+1">+1 美国/加拿大</option>
+          <option value="+44">+44 英国</option>
+          <option value="+65">+65 新加坡</option>
+          <option value="+60">+60 马来西亚</option>
+          <option value="+66">+66 泰国</option>
+          <option value="+84">+84 越南</option>
+        </select>
+      </div>
+      <div class="data-row" id="row-gpc-helper-phone" style="display:none;">
+        <span class="data-label">GPC 手机</span>
+        <input type="text" id="input-gpc-helper-phone" class="data-input" placeholder="GPC 专用手机号，不读取 GoPay 手机字段" />
+      </div>
+      <div class="data-row" id="row-gpc-helper-pin" style="display:none;">
+        <span class="data-label">GPC PIN</span>
+        <div class="input-with-icon">
+          <input type="password" id="input-gpc-helper-pin" class="data-input data-input-with-icon" placeholder="GoPay PIN" autocomplete="off" />
+          <button id="btn-toggle-gpc-helper-pin" class="input-icon-btn" type="button"
+            data-password-toggle="input-gpc-helper-pin" data-show-label="显示GPC PIN"
+            data-hide-label="隐藏GPC PIN" aria-label="显示GPC PIN" title="显示GPC PIN"></button>
         </div>
       </div>
       <div class="data-row module-divider-start" id="row-mail-provider">
@@ -1377,6 +1425,7 @@
   <script src="../managed-alias-utils.js"></script>
   <script src="../mail2925-utils.js"></script>
   <script src="../paypal-utils.js"></script>
+  <script src="../gopay-utils.js"></script>
   <script src="../icloud-utils.js"></script>
   <script src="../mail-provider-utils.js"></script>
   <script src="../hotmail-utils.js"></script>

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -177,6 +177,12 @@ const rowGoPayHelperCountryCode = document.getElementById('row-gpc-helper-countr
 const selectGoPayHelperCountryCode = document.getElementById('select-gpc-helper-country-code');
 const rowGoPayHelperPhone = document.getElementById('row-gpc-helper-phone');
 const inputGoPayHelperPhone = document.getElementById('input-gpc-helper-phone');
+const rowGoPayHelperOtpChannel = document.getElementById('row-gpc-helper-otp-channel');
+const selectGoPayHelperOtpChannel = document.getElementById('select-gpc-helper-otp-channel');
+const rowGoPayHelperLocalSmsEnabled = document.getElementById('row-gpc-helper-local-sms-enabled');
+const inputGoPayHelperLocalSmsEnabled = document.getElementById('input-gpc-helper-local-sms-enabled');
+const rowGoPayHelperLocalSmsUrl = document.getElementById('row-gpc-helper-local-sms-url');
+const inputGoPayHelperLocalSmsUrl = document.getElementById('input-gpc-helper-local-sms-url');
 const rowGoPayHelperPin = document.getElementById('row-gpc-helper-pin');
 const inputGoPayHelperPin = document.getElementById('input-gpc-helper-pin');
 const selectMailProvider = document.getElementById('select-mail-provider');
@@ -567,6 +573,34 @@ function getSelectedPlusPaymentMethod() {
     return normalizePlusPaymentMethod(selectPlusPaymentMethod.value);
   }
   return normalizePlusPaymentMethod(latestState?.plusPaymentMethod || currentPlusPaymentMethod);
+}
+
+function normalizeGpcOtpChannelValue(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  return normalized === 'sms' ? 'sms' : 'whatsapp';
+}
+
+function normalizeGpcLocalSmsHelperBaseUrlValue(value = '') {
+  const trimmed = String(value || '').trim();
+  const fallback = 'http://127.0.0.1:18767';
+  if (!trimmed) {
+    return fallback;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      return fallback;
+    }
+    const endpointPath = parsed.pathname.replace(/\/+$/g, '') || '/';
+    if (['/otp', '/latest-otp', '/health'].includes(endpointPath)) {
+      parsed.pathname = '';
+      parsed.search = '';
+      parsed.hash = '';
+    }
+    return parsed.toString().replace(/\/$/, '');
+  } catch {
+    return fallback;
+  }
 }
 
 function getStepDefinitionsForMode(plusModeEnabled = false, plusPaymentMethod = 'paypal') {
@@ -2913,6 +2947,31 @@ function collectSettingsPayload() {
     gopayHelperPin: (typeof inputGoPayHelperPin !== 'undefined' && inputGoPayHelperPin)
       ? inputGoPayHelperPin.value
       : (latestState?.gopayHelperPin || ''),
+    gopayHelperOtpChannel: (typeof normalizeGpcOtpChannelValue === 'function'
+      ? normalizeGpcOtpChannelValue(
+        (typeof selectGoPayHelperOtpChannel !== 'undefined' && selectGoPayHelperOtpChannel)
+          ? selectGoPayHelperOtpChannel.value
+          : (latestState?.gopayHelperOtpChannel || 'whatsapp')
+      )
+      : (String(
+        (typeof selectGoPayHelperOtpChannel !== 'undefined' && selectGoPayHelperOtpChannel)
+          ? selectGoPayHelperOtpChannel.value
+          : (latestState?.gopayHelperOtpChannel || 'whatsapp')
+      ).trim().toLowerCase() === 'sms' ? 'sms' : 'whatsapp')),
+    gopayHelperLocalSmsHelperEnabled: (typeof inputGoPayHelperLocalSmsEnabled !== 'undefined' && inputGoPayHelperLocalSmsEnabled)
+      ? Boolean(inputGoPayHelperLocalSmsEnabled.checked)
+      : Boolean(latestState?.gopayHelperLocalSmsHelperEnabled),
+    gopayHelperLocalSmsHelperUrl: (typeof normalizeGpcLocalSmsHelperBaseUrlValue === 'function'
+      ? normalizeGpcLocalSmsHelperBaseUrlValue(
+        (typeof inputGoPayHelperLocalSmsUrl !== 'undefined' && inputGoPayHelperLocalSmsUrl)
+          ? inputGoPayHelperLocalSmsUrl.value
+          : (latestState?.gopayHelperLocalSmsHelperUrl || '')
+      )
+      : String(
+        (typeof inputGoPayHelperLocalSmsUrl !== 'undefined' && inputGoPayHelperLocalSmsUrl)
+          ? inputGoPayHelperLocalSmsUrl.value
+          : (latestState?.gopayHelperLocalSmsHelperUrl || 'http://127.0.0.1:18767')
+      ).trim()),
     paypalEmail: String(currentPayPalAccount?.email || latestState?.paypalEmail || '').trim(),
     paypalPassword: String(currentPayPalAccount?.password || latestState?.paypalPassword || ''),
     currentPayPalAccountId: String(latestState?.currentPayPalAccountId || '').trim(),
@@ -6590,6 +6649,22 @@ function updatePlusModeUI() {
     ? Boolean(inputPlusModeEnabled.checked)
     : false;
   const paymentMethod = getSelectedPlusPaymentMethod();
+  const normalizeOtpChannel = typeof normalizeGpcOtpChannelValue === 'function'
+    ? normalizeGpcOtpChannelValue
+    : ((value = '') => (String(value || '').trim().toLowerCase() === 'sms' ? 'sms' : 'whatsapp'));
+  let otpChannel = normalizeOtpChannel(
+    (typeof selectGoPayHelperOtpChannel !== 'undefined' && selectGoPayHelperOtpChannel)
+      ? selectGoPayHelperOtpChannel.value
+      : (latestState?.gopayHelperOtpChannel || 'whatsapp')
+  );
+  const localSmsEnabled = Boolean(
+    (typeof inputGoPayHelperLocalSmsEnabled !== 'undefined' && inputGoPayHelperLocalSmsEnabled)
+      ? inputGoPayHelperLocalSmsEnabled.checked
+      : latestState?.gopayHelperLocalSmsHelperEnabled
+  );
+  if (localSmsEnabled && otpChannel !== 'sms') {
+    otpChannel = 'sms';
+  }
   if (typeof selectPlusPaymentMethod !== 'undefined' && selectPlusPaymentMethod) {
     selectPlusPaymentMethod.value = paymentMethod;
     selectPlusPaymentMethod.style.display = enabled ? '' : 'none';
@@ -6610,12 +6685,23 @@ function updatePlusModeUI() {
     typeof rowGoPayHelperCardKey !== 'undefined' ? rowGoPayHelperCardKey : null,
     typeof rowGoPayHelperCountryCode !== 'undefined' ? rowGoPayHelperCountryCode : null,
     typeof rowGoPayHelperPhone !== 'undefined' ? rowGoPayHelperPhone : null,
+    typeof rowGoPayHelperOtpChannel !== 'undefined' ? rowGoPayHelperOtpChannel : null,
+    typeof rowGoPayHelperLocalSmsEnabled !== 'undefined' ? rowGoPayHelperLocalSmsEnabled : null,
     typeof rowGoPayHelperPin !== 'undefined' ? rowGoPayHelperPin : null,
   ].forEach((row) => {
     if (row) {
       row.style.display = enabled && paymentMethod === 'gpc-helper' ? '' : 'none';
     }
   });
+  if (typeof selectGoPayHelperOtpChannel !== 'undefined' && selectGoPayHelperOtpChannel) {
+    selectGoPayHelperOtpChannel.value = otpChannel;
+  }
+  if (typeof inputGoPayHelperLocalSmsEnabled !== 'undefined' && inputGoPayHelperLocalSmsEnabled) {
+    inputGoPayHelperLocalSmsEnabled.checked = localSmsEnabled;
+  }
+  if (typeof rowGoPayHelperLocalSmsUrl !== 'undefined' && rowGoPayHelperLocalSmsUrl) {
+    rowGoPayHelperLocalSmsUrl.style.display = enabled && paymentMethod === 'gpc-helper' && localSmsEnabled ? '' : 'none';
+  }
 }
 
 function setSettingsCardLocked(locked) {
@@ -6948,6 +7034,9 @@ function applySettingsState(state) {
   if (typeof inputGoPayHelperCardKey !== 'undefined' && inputGoPayHelperCardKey) inputGoPayHelperCardKey.value = String(state?.gopayHelperCardKey || '');
   if (typeof inputGoPayHelperPhone !== 'undefined' && inputGoPayHelperPhone) inputGoPayHelperPhone.value = String(state?.gopayHelperPhoneNumber || '');
   if (typeof selectGoPayHelperCountryCode !== 'undefined' && selectGoPayHelperCountryCode) selectGoPayHelperCountryCode.value = String(state?.gopayHelperCountryCode || '+86');
+  if (typeof selectGoPayHelperOtpChannel !== 'undefined' && selectGoPayHelperOtpChannel) selectGoPayHelperOtpChannel.value = typeof normalizeGpcOtpChannelValue === 'function' ? normalizeGpcOtpChannelValue(state?.gopayHelperOtpChannel || 'whatsapp') : (String(state?.gopayHelperOtpChannel || '').trim().toLowerCase() === 'sms' ? 'sms' : 'whatsapp');
+  if (typeof inputGoPayHelperLocalSmsEnabled !== 'undefined' && inputGoPayHelperLocalSmsEnabled) inputGoPayHelperLocalSmsEnabled.checked = Boolean(state?.gopayHelperLocalSmsHelperEnabled);
+  if (typeof inputGoPayHelperLocalSmsUrl !== 'undefined' && inputGoPayHelperLocalSmsUrl) inputGoPayHelperLocalSmsUrl.value = typeof normalizeGpcLocalSmsHelperBaseUrlValue === 'function' ? normalizeGpcLocalSmsHelperBaseUrlValue(state?.gopayHelperLocalSmsHelperUrl || '') : String(state?.gopayHelperLocalSmsHelperUrl || 'http://127.0.0.1:18767');
   if (typeof inputGoPayHelperPin !== 'undefined' && inputGoPayHelperPin) inputGoPayHelperPin.value = String(state?.gopayHelperPin || '');
   if (typeof updateGpcHelperBalanceDisplay === 'function') updateGpcHelperBalanceDisplay(state);
   inputVpsUrl.value = state?.vpsUrl || '';
@@ -9957,11 +10046,31 @@ if (typeof btnGpcCardKeyPurchase !== 'undefined' && btnGpcCardKeyPurchase) {
   typeof inputGoPayHelperCardKey !== 'undefined' ? inputGoPayHelperCardKey : null,
   typeof inputGoPayHelperPhone !== 'undefined' ? inputGoPayHelperPhone : null,
   typeof selectGoPayHelperCountryCode !== 'undefined' ? selectGoPayHelperCountryCode : null,
+  typeof selectGoPayHelperOtpChannel !== 'undefined' ? selectGoPayHelperOtpChannel : null,
+  typeof inputGoPayHelperLocalSmsEnabled !== 'undefined' ? inputGoPayHelperLocalSmsEnabled : null,
+  typeof inputGoPayHelperLocalSmsUrl !== 'undefined' ? inputGoPayHelperLocalSmsUrl : null,
   typeof inputGoPayHelperPin !== 'undefined' ? inputGoPayHelperPin : null,
 ].forEach((input) => {
   input?.addEventListener('change', () => {
+    if (input === inputGoPayHelperLocalSmsEnabled && input.checked && selectGoPayHelperOtpChannel) {
+      selectGoPayHelperOtpChannel.value = 'sms';
+    }
+    if (input === selectGoPayHelperOtpChannel || input === inputGoPayHelperLocalSmsEnabled) {
+      updatePlusModeUI();
+    }
     markSettingsDirty(true);
     saveSettings({ silent: true }).catch(() => {});
+  });
+  input?.addEventListener('input', () => {
+    if (input === inputGoPayHelperLocalSmsUrl) {
+      markSettingsDirty(true);
+      scheduleSettingsAutoSave();
+    }
+  });
+  input?.addEventListener('blur', () => {
+    if (input === inputGoPayHelperLocalSmsUrl) {
+      saveSettings({ silent: true }).catch(() => {});
+    }
   });
 });
 
@@ -11556,10 +11665,24 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
       if (message.payload.plusPaymentMethod !== undefined && selectPlusPaymentMethod) {
         selectPlusPaymentMethod.value = normalizePlusPaymentMethod(message.payload.plusPaymentMethod);
       }
+      if (message.payload.gopayHelperOtpChannel !== undefined && selectGoPayHelperOtpChannel) {
+        selectGoPayHelperOtpChannel.value = typeof normalizeGpcOtpChannelValue === 'function' ? normalizeGpcOtpChannelValue(message.payload.gopayHelperOtpChannel) : (String(message.payload.gopayHelperOtpChannel || '').trim().toLowerCase() === 'sms' ? 'sms' : 'whatsapp');
+      }
+      if (message.payload.gopayHelperLocalSmsHelperEnabled !== undefined && inputGoPayHelperLocalSmsEnabled) {
+        inputGoPayHelperLocalSmsEnabled.checked = Boolean(message.payload.gopayHelperLocalSmsHelperEnabled);
+      }
+      if (message.payload.gopayHelperLocalSmsHelperUrl !== undefined && inputGoPayHelperLocalSmsUrl) {
+        inputGoPayHelperLocalSmsUrl.value = typeof normalizeGpcLocalSmsHelperBaseUrlValue === 'function' ? normalizeGpcLocalSmsHelperBaseUrlValue(message.payload.gopayHelperLocalSmsHelperUrl) : String(message.payload.gopayHelperLocalSmsHelperUrl || 'http://127.0.0.1:18767');
+      }
       if (message.payload.gopayHelperBalance !== undefined || message.payload.gopayHelperBalanceError !== undefined) {
         updateGpcHelperBalanceDisplay({ ...latestState, ...(message.payload || {}) });
       }
-      if (message.payload.plusModeEnabled !== undefined || message.payload.plusPaymentMethod !== undefined) {
+      if (
+        message.payload.plusModeEnabled !== undefined
+        || message.payload.plusPaymentMethod !== undefined
+        || message.payload.gopayHelperOtpChannel !== undefined
+        || message.payload.gopayHelperLocalSmsHelperEnabled !== undefined
+      ) {
         syncStepDefinitionsForMode(
           Boolean(latestState?.plusModeEnabled),
           latestState?.plusPaymentMethod,

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -163,9 +163,22 @@ const rowCustomPassword = document.getElementById('row-custom-password');
 const rowPlusMode = document.getElementById('row-plus-mode');
 const inputPlusModeEnabled = document.getElementById('input-plus-mode-enabled');
 const selectPlusPaymentMethod = document.getElementById('select-plus-payment-method');
+const btnGpcCardKeyPurchase = document.getElementById('btn-gpc-card-key-purchase');
 const rowPayPalAccount = document.getElementById('row-paypal-account');
 const selectPayPalAccount = document.getElementById('select-paypal-account');
 const btnAddPayPalAccount = document.getElementById('btn-add-paypal-account');
+const rowGopayHelperApi = document.getElementById('row-gpc-helper-api');
+const inputGopayHelperApi = document.getElementById('input-gpc-helper-api');
+const rowGoPayHelperCardKey = document.getElementById('row-gpc-helper-card-key');
+const inputGoPayHelperCardKey = document.getElementById('input-gpc-helper-card-key');
+const btnGoPayHelperBalance = document.getElementById('btn-gpc-helper-balance');
+const displayGoPayHelperBalance = document.getElementById('display-gpc-helper-balance');
+const rowGoPayHelperCountryCode = document.getElementById('row-gpc-helper-country-code');
+const selectGoPayHelperCountryCode = document.getElementById('select-gpc-helper-country-code');
+const rowGoPayHelperPhone = document.getElementById('row-gpc-helper-phone');
+const inputGoPayHelperPhone = document.getElementById('input-gpc-helper-phone');
+const rowGoPayHelperPin = document.getElementById('row-gpc-helper-pin');
+const inputGoPayHelperPin = document.getElementById('input-gpc-helper-pin');
 const selectMailProvider = document.getElementById('select-mail-provider');
 const btnMailLogin = document.getElementById('btn-mail-login');
 const rowCustomMailProviderPool = document.getElementById('row-custom-mail-provider-pool');
@@ -542,7 +555,11 @@ const PLUS_CONTRIBUTION_PROMPT_LEDGER_STORAGE_KEY = 'multipage-plus-contribution
 const PHONE_VERIFICATION_SECTION_EXPANDED_STORAGE_KEY = 'multipage-phone-verification-section-expanded';
 
 function normalizePlusPaymentMethod(value = '') {
-  return String(value || '').trim().toLowerCase() === 'gopay' ? 'gopay' : 'paypal';
+  const normalized = String(value || '').trim().toLowerCase();
+  if (normalized === 'gpc-helper') {
+    return 'gpc-helper';
+  }
+  return normalized === 'gopay' ? 'gopay' : 'paypal';
 }
 
 function getSelectedPlusPaymentMethod() {
@@ -1301,11 +1318,30 @@ async function openConfirmModalWithOption({
 
 async function openPlusManualConfirmationDialog(options = {}) {
   const method = String(options.method || '').trim().toLowerCase();
-  const title = String(options.title || '').trim() || (method === 'gopay' ? 'GoPay 订阅确认' : '手动确认');
+  const title = String(options.title || '').trim() || (method === 'gopay' ? 'GoPay 订阅确认' : (method === 'gopay-otp' ? 'GPC OTP 验证' : '手动确认'));
   const message = String(options.message || '').trim()
     || (method === 'gopay'
       ? '请在当前订阅页中手动完成 GoPay 订阅，完成后点击“我已完成订阅”继续。'
-      : '请先在页面中完成当前手动操作，完成后点击确认继续。');
+      : (method === 'gopay-otp' ? '请输入收到的 OTP 验证码。' : '请先在页面中完成当前手动操作，完成后点击确认继续。'));
+
+  if (method === 'gopay-otp' && sharedFormDialog?.open) {
+    const result = await sharedFormDialog.open({
+      title,
+      message,
+      confirmLabel: '提交 OTP',
+      fields: [{
+        key: 'otp',
+        label: 'OTP',
+        inputMode: 'numeric',
+        placeholder: '请输入 OTP 验证码',
+        required: true,
+        requiredMessage: 'OTP 不能为空。',
+        validate: (value) => String(value || '').trim().replace(/[^\d]/g, '') ? '' : '请输入有效 OTP。',
+      }],
+    });
+    return result?.otp ? { action: 'confirm', otp: String(result.otp || '').trim().replace(/[^\d]/g, '') } : 'cancel';
+  }
+
   return openActionModal({
     title,
     message,
@@ -1351,7 +1387,7 @@ async function syncPlusManualConfirmationDialog() {
       return;
     }
 
-    const confirmed = choice === 'confirm';
+    const confirmed = choice === 'confirm' || choice?.action === 'confirm';
     const response = await chrome.runtime.sendMessage({
       type: 'RESOLVE_PLUS_MANUAL_CONFIRMATION',
       source: 'sidepanel',
@@ -1359,13 +1395,14 @@ async function syncPlusManualConfirmationDialog() {
         step,
         requestId,
         confirmed,
+        ...(choice?.otp ? { otp: choice.otp } : {}),
       },
     });
     if (response?.error) {
       throw new Error(response.error);
     }
     if (confirmed) {
-      showToast(method === 'gopay' ? 'GoPay 订阅已确认，正在继续 OAuth 登录...' : '已确认，流程继续执行中...', 'info', 2200);
+      showToast(method === 'gopay' ? 'GoPay 订阅已确认，正在继续 OAuth 登录...' : (method === 'gopay-otp' ? 'OTP 已提交，正在验证...' : '已确认，流程继续执行中...'), 'info', 2200);
     } else {
       showToast(method === 'gopay' ? '已取消 GoPay 订阅等待。' : '已取消当前手动确认。', 'warn', 2200);
     }
@@ -2861,6 +2898,21 @@ function collectSettingsPayload() {
       ? Boolean(inputPlusModeEnabled.checked)
       : Boolean(latestState?.plusModeEnabled),
     plusPaymentMethod,
+    gopayHelperApiUrl: (typeof inputGopayHelperApi !== 'undefined' && inputGopayHelperApi)
+      ? inputGopayHelperApi.value.trim()
+      : (latestState?.gopayHelperApiUrl || ''),
+    gopayHelperCardKey: (typeof inputGoPayHelperCardKey !== 'undefined' && inputGoPayHelperCardKey)
+      ? inputGoPayHelperCardKey.value.trim()
+      : (latestState?.gopayHelperCardKey || ''),
+    gopayHelperPhoneNumber: (typeof inputGoPayHelperPhone !== 'undefined' && inputGoPayHelperPhone)
+      ? inputGoPayHelperPhone.value.trim()
+      : (latestState?.gopayHelperPhoneNumber || ''),
+    gopayHelperCountryCode: (typeof selectGoPayHelperCountryCode !== 'undefined' && selectGoPayHelperCountryCode)
+      ? selectGoPayHelperCountryCode.value
+      : (latestState?.gopayHelperCountryCode || '+86'),
+    gopayHelperPin: (typeof inputGoPayHelperPin !== 'undefined' && inputGoPayHelperPin)
+      ? inputGoPayHelperPin.value
+      : (latestState?.gopayHelperPin || ''),
     paypalEmail: String(currentPayPalAccount?.email || latestState?.paypalEmail || '').trim(),
     paypalPassword: String(currentPayPalAccount?.password || latestState?.paypalPassword || ''),
     currentPayPalAccountId: String(latestState?.currentPayPalAccountId || '').trim(),
@@ -6477,6 +6529,62 @@ function updatePhoneVerificationSettingsUI() {
   }
 }
 
+function updateGpcHelperBalanceDisplay(state = latestState) {
+  if (typeof displayGoPayHelperBalance === 'undefined' || !displayGoPayHelperBalance) {
+    return;
+  }
+  const error = String(state?.gopayHelperBalanceError || '').trim();
+  const balance = String(state?.gopayHelperBalance || '').trim();
+  displayGoPayHelperBalance.textContent = error
+    ? `查询失败：${error}`
+    : (balance || '余额未获取');
+}
+
+async function refreshGpcHelperBalance(options = {}) {
+  const silent = Boolean(options.silent);
+  const apiUrl = String(
+    (typeof inputGopayHelperApi !== 'undefined' && inputGopayHelperApi)
+      ? inputGopayHelperApi.value
+      : (latestState?.gopayHelperApiUrl || '')
+  ).trim();
+  const cardKey = String(
+    (typeof inputGoPayHelperCardKey !== 'undefined' && inputGoPayHelperCardKey)
+      ? inputGoPayHelperCardKey.value
+      : (latestState?.gopayHelperCardKey || '')
+  ).trim();
+  if (!apiUrl) {
+    if (!silent) showToast('请先填写 GPC 接口地址。', 'warn', 1800);
+    return null;
+  }
+  if (!cardKey) {
+    if (!silent) showToast('请先填写 GPC 卡密。', 'warn', 1800);
+    return null;
+  }
+  const response = await chrome.runtime.sendMessage({
+    type: 'REFRESH_GPC_CARD_BALANCE',
+    source: 'sidepanel',
+    payload: {
+      gopayHelperApiUrl: apiUrl,
+      gopayHelperCardKey: cardKey,
+      plusPaymentMethod: 'gpc-helper',
+      reason: options.reason || 'manual',
+    },
+  });
+  if (response?.error) {
+    if (!silent) showToast(`GPC 余额查询失败：${response.error}`, 'warn', 2200);
+    return null;
+  }
+  updateGpcHelperBalanceDisplay({
+    ...latestState,
+    gopayHelperBalance: response?.balance || latestState?.gopayHelperBalance || '',
+    gopayHelperBalancePayload: response?.payload || latestState?.gopayHelperBalancePayload || null,
+    gopayHelperBalanceUpdatedAt: response?.updatedAt || Date.now(),
+    gopayHelperBalanceError: '',
+  });
+  if (!silent) showToast('GPC 余额已刷新。', 'info', 1600);
+  return response;
+}
+
 function updatePlusModeUI() {
   const enabled = typeof inputPlusModeEnabled !== 'undefined' && inputPlusModeEnabled
     ? Boolean(inputPlusModeEnabled.checked)
@@ -6486,6 +6594,9 @@ function updatePlusModeUI() {
     selectPlusPaymentMethod.value = paymentMethod;
     selectPlusPaymentMethod.style.display = enabled ? '' : 'none';
   }
+  if (typeof btnGpcCardKeyPurchase !== 'undefined' && btnGpcCardKeyPurchase) {
+    btnGpcCardKeyPurchase.style.display = enabled && paymentMethod === 'gpc-helper' ? '' : 'none';
+  }
   [
     typeof rowPayPalAccount !== 'undefined' ? rowPayPalAccount : null,
   ].forEach((row) => {
@@ -6493,6 +6604,17 @@ function updatePlusModeUI() {
       return;
     }
     row.style.display = enabled && paymentMethod === 'paypal' ? '' : 'none';
+  });
+  [
+    typeof rowGopayHelperApi !== 'undefined' ? rowGopayHelperApi : null,
+    typeof rowGoPayHelperCardKey !== 'undefined' ? rowGoPayHelperCardKey : null,
+    typeof rowGoPayHelperCountryCode !== 'undefined' ? rowGoPayHelperCountryCode : null,
+    typeof rowGoPayHelperPhone !== 'undefined' ? rowGoPayHelperPhone : null,
+    typeof rowGoPayHelperPin !== 'undefined' ? rowGoPayHelperPin : null,
+  ].forEach((row) => {
+    if (row) {
+      row.style.display = enabled && paymentMethod === 'gpc-helper' ? '' : 'none';
+    }
   });
 }
 
@@ -6822,6 +6944,12 @@ function applySettingsState(state) {
   if (typeof selectPlusPaymentMethod !== 'undefined' && selectPlusPaymentMethod) {
     selectPlusPaymentMethod.value = normalizePlusPaymentMethod(state?.plusPaymentMethod);
   }
+  if (typeof inputGopayHelperApi !== 'undefined' && inputGopayHelperApi) inputGopayHelperApi.value = String(state?.gopayHelperApiUrl || '');
+  if (typeof inputGoPayHelperCardKey !== 'undefined' && inputGoPayHelperCardKey) inputGoPayHelperCardKey.value = String(state?.gopayHelperCardKey || '');
+  if (typeof inputGoPayHelperPhone !== 'undefined' && inputGoPayHelperPhone) inputGoPayHelperPhone.value = String(state?.gopayHelperPhoneNumber || '');
+  if (typeof selectGoPayHelperCountryCode !== 'undefined' && selectGoPayHelperCountryCode) selectGoPayHelperCountryCode.value = String(state?.gopayHelperCountryCode || '+86');
+  if (typeof inputGoPayHelperPin !== 'undefined' && inputGoPayHelperPin) inputGoPayHelperPin.value = String(state?.gopayHelperPin || '');
+  if (typeof updateGpcHelperBalanceDisplay === 'function') updateGpcHelperBalanceDisplay(state);
   inputVpsUrl.value = state?.vpsUrl || '';
   inputVpsPassword.value = state?.vpsPassword || '';
   setLocalCpaStep9Mode(state?.localCpaStep9Mode);
@@ -7238,6 +7366,10 @@ function openExternalUrl(url) {
   }
 
   window.open(targetUrl, '_blank', 'noopener');
+}
+
+function openGpcCardKeyPurchasePage() {
+  openExternalUrl('https://pay.ldxp.cn/shop/gpc');
 }
 
 function getRepositoryHomeUrl() {
@@ -9810,6 +9942,29 @@ inputPlusModeEnabled?.addEventListener('change', () => {
   saveSettings({ silent: true }).catch(() => { });
 });
 
+if (typeof btnGoPayHelperBalance !== 'undefined' && btnGoPayHelperBalance) {
+  btnGoPayHelperBalance.addEventListener('click', () => {
+    void refreshGpcHelperBalance({ reason: 'manual' });
+  });
+}
+if (typeof btnGpcCardKeyPurchase !== 'undefined' && btnGpcCardKeyPurchase) {
+  btnGpcCardKeyPurchase.addEventListener('click', () => {
+    openGpcCardKeyPurchasePage();
+  });
+}
+[
+  typeof inputGopayHelperApi !== 'undefined' ? inputGopayHelperApi : null,
+  typeof inputGoPayHelperCardKey !== 'undefined' ? inputGoPayHelperCardKey : null,
+  typeof inputGoPayHelperPhone !== 'undefined' ? inputGoPayHelperPhone : null,
+  typeof selectGoPayHelperCountryCode !== 'undefined' ? selectGoPayHelperCountryCode : null,
+  typeof inputGoPayHelperPin !== 'undefined' ? inputGoPayHelperPin : null,
+].forEach((input) => {
+  input?.addEventListener('change', () => {
+    markSettingsDirty(true);
+    saveSettings({ silent: true }).catch(() => {});
+  });
+});
+
 selectPlusPaymentMethod?.addEventListener('change', () => {
   selectPlusPaymentMethod.value = normalizePlusPaymentMethod(selectPlusPaymentMethod.value);
   updatePlusModeUI();
@@ -11400,6 +11555,9 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
       }
       if (message.payload.plusPaymentMethod !== undefined && selectPlusPaymentMethod) {
         selectPlusPaymentMethod.value = normalizePlusPaymentMethod(message.payload.plusPaymentMethod);
+      }
+      if (message.payload.gopayHelperBalance !== undefined || message.payload.gopayHelperBalanceError !== undefined) {
+        updateGpcHelperBalanceDisplay({ ...latestState, ...(message.payload || {}) });
       }
       if (message.payload.plusModeEnabled !== undefined || message.payload.plusPaymentMethod !== undefined) {
         syncStepDefinitionsForMode(

--- a/tests/auto-run-add-phone-stop.test.js
+++ b/tests/auto-run-add-phone-stop.test.js
@@ -332,6 +332,155 @@ test('auto-run controller treats phone-number supply exhaustion as round-fatal a
   assert.equal(runtime.state.autoRunSessionId, 0);
 });
 
+
+test('auto-run controller skips Plus non-free-trial failures to next round without retrying same account', async () => {
+  const events = {
+    logs: [],
+    broadcasts: [],
+    accountRecords: [],
+    runCalls: 0,
+  };
+
+  let currentState = {
+    stepStatuses: {},
+    autoRunSkipFailures: true,
+    autoRunFallbackThreadIntervalMinutes: 0,
+    autoRunDelayEnabled: false,
+    autoRunDelayMinutes: 30,
+    autoStepDelaySeconds: null,
+    mailProvider: '163',
+    emailGenerator: 'duck',
+    tabRegistry: {},
+    sourceLastUrls: {},
+    autoRunRoundSummaries: [],
+  };
+
+  const runtime = {
+    state: {
+      autoRunActive: false,
+      autoRunCurrentRun: 0,
+      autoRunTotalRuns: 1,
+      autoRunAttemptRun: 0,
+      autoRunSessionId: 0,
+    },
+    get() {
+      return { ...this.state };
+    },
+    set(updates = {}) {
+      this.state = { ...this.state, ...updates };
+    },
+  };
+
+  let sessionSeed = 0;
+  const controller = api.createAutoRunController({
+    addLog: async (message, level = 'info') => events.logs.push({ message, level }),
+    appendAccountRunRecord: async (status, _state, reason) => {
+      events.accountRecords.push({ status, reason });
+      return { status, reason };
+    },
+    AUTO_RUN_MAX_RETRIES_PER_ROUND: 3,
+    AUTO_RUN_RETRY_DELAY_MS: 3000,
+    AUTO_RUN_TIMER_KIND_BEFORE_RETRY: 'before_retry',
+    AUTO_RUN_TIMER_KIND_BETWEEN_ROUNDS: 'between_rounds',
+    broadcastAutoRunStatus: async (phase, payload = {}) => {
+      events.broadcasts.push({ phase, ...payload });
+      currentState = {
+        ...currentState,
+        autoRunning: ['scheduled', 'running', 'waiting_step', 'waiting_email', 'retrying', 'waiting_interval'].includes(phase),
+        autoRunPhase: phase,
+        autoRunCurrentRun: payload.currentRun ?? runtime.state.autoRunCurrentRun,
+        autoRunTotalRuns: payload.totalRuns ?? runtime.state.autoRunTotalRuns,
+        autoRunAttemptRun: payload.attemptRun ?? runtime.state.autoRunAttemptRun,
+        autoRunSessionId: payload.sessionId ?? runtime.state.autoRunSessionId,
+      };
+    },
+    broadcastStopToContentScripts: async () => {},
+    cancelPendingCommands: () => {},
+    clearStopRequest: () => {},
+    createAutoRunSessionId: () => {
+      sessionSeed += 1;
+      return sessionSeed;
+    },
+    getAutoRunStatusPayload: (phase, payload = {}) => ({
+      autoRunning: ['scheduled', 'running', 'waiting_step', 'waiting_email', 'retrying', 'waiting_interval'].includes(phase),
+      autoRunPhase: phase,
+      autoRunCurrentRun: payload.currentRun ?? 0,
+      autoRunTotalRuns: payload.totalRuns ?? 1,
+      autoRunAttemptRun: payload.attemptRun ?? 0,
+      autoRunSessionId: payload.sessionId ?? 0,
+    }),
+    getErrorMessage: (error) => error?.message || String(error || ''),
+    getFirstUnfinishedStep: () => 1,
+    getPendingAutoRunTimerPlan: () => null,
+    getRunningSteps: () => [],
+    getState: async () => ({
+      ...currentState,
+      stepStatuses: { ...(currentState.stepStatuses || {}) },
+      tabRegistry: { ...(currentState.tabRegistry || {}) },
+      sourceLastUrls: { ...(currentState.sourceLastUrls || {}) },
+    }),
+    getStopRequested: () => false,
+    hasSavedProgress: () => false,
+    isAddPhoneAuthFailure: () => false,
+    isRestartCurrentAttemptError: () => false,
+    isStopError: (error) => (error?.message || String(error || '')) === '流程已被用户停止。',
+    launchAutoRunTimerPlan: async () => false,
+    normalizeAutoRunFallbackThreadIntervalMinutes: (value) => Math.max(0, Math.floor(Number(value) || 0)),
+    persistAutoRunTimerPlan: async () => ({}),
+    resetState: async () => {
+      currentState = {
+        ...currentState,
+        stepStatuses: {},
+        tabRegistry: {},
+        sourceLastUrls: {},
+      };
+    },
+    runAutoSequenceFromStep: async () => {
+      events.runCalls += 1;
+      if (events.runCalls === 1) {
+        throw new Error('PLUS_CHECKOUT_NON_FREE_TRIAL::步骤 6：GPC 接口返回余额非 0（Rp 29.000），当前账号没有免费试用资格，已跳过支付提交。');
+      }
+    },
+    runtime,
+    setState: async (updates = {}) => {
+      currentState = {
+        ...currentState,
+        ...updates,
+        stepStatuses: updates.stepStatuses ? { ...updates.stepStatuses } : currentState.stepStatuses,
+        tabRegistry: updates.tabRegistry ? { ...updates.tabRegistry } : currentState.tabRegistry,
+        sourceLastUrls: updates.sourceLastUrls ? { ...updates.sourceLastUrls } : currentState.sourceLastUrls,
+      };
+    },
+    sleepWithStop: async () => {},
+    throwIfAutoRunSessionStopped: (sessionId) => {
+      if (sessionId && sessionId !== runtime.state.autoRunSessionId) {
+        throw new Error('流程已被用户停止。');
+      }
+    },
+    waitForRunningStepsToFinish: async () => currentState,
+    chrome: {
+      runtime: {
+        sendMessage() {
+          return Promise.resolve();
+        },
+      },
+    },
+  });
+
+  await controller.autoRunLoop(2, {
+    autoRunSkipFailures: true,
+    mode: 'restart',
+  });
+
+  assert.equal(events.runCalls, 2, 'non-free-trial failure should fail current round and continue next round');
+  assert.equal(events.broadcasts.some(({ phase }) => phase === 'retrying'), false, 'non-free-trial failure should not retry the same account');
+  assert.equal(events.accountRecords.length, 1);
+  assert.equal(events.accountRecords[0].status, 'failed');
+  assert.match(events.accountRecords[0].reason, /PLUS_CHECKOUT_NON_FREE_TRIAL/);
+  assert.ok(events.logs.some(({ message }) => /没有 Plus 免费试用资格/.test(message)));
+  assert.equal(events.broadcasts.some(({ phase }) => phase === 'stopped'), false);
+});
+
 test('auto-run controller keeps same-round retrying for step9 local replacement exhaustion errors', async () => {
   const events = {
     logs: [],

--- a/tests/background-account-history-settings.test.js
+++ b/tests/background-account-history-settings.test.js
@@ -130,6 +130,7 @@ return {
   assert.equal(api.normalizePersistentSettingValue('accountRunHistoryTextEnabled', 1), true);
   assert.equal(api.normalizePersistentSettingValue('phoneVerificationEnabled', 1), true);
   assert.equal(api.normalizePersistentSettingValue('plusPaymentMethod', 'gopay'), 'gopay');
+  assert.equal(api.normalizePersistentSettingValue('plusPaymentMethod', 'gpc-helper'), 'gpc-helper');
   assert.equal(api.normalizePersistentSettingValue('plusPaymentMethod', 'paypal'), 'paypal');
   assert.equal(api.normalizePersistentSettingValue('plusPaymentMethod', 'unknown'), 'paypal');
   assert.equal(api.normalizePersistentSettingValue('verificationResendCount', '7'), 7);

--- a/tests/background-account-history-settings.test.js
+++ b/tests/background-account-history-settings.test.js
@@ -52,6 +52,9 @@ test('background account history settings are normalized independently from hotm
   const bundle = [
     extractFunction('normalizeCodex2ApiUrl'),
     extractFunction('normalizeHotmailLocalBaseUrl'),
+    extractFunction('normalizeGpcOtpChannel'),
+    extractFunction('normalizeGpcLocalSmsHelperBaseUrl'),
+    extractFunction('normalizePositiveIntegerSetting'),
     extractFunction('normalizeAccountRunHistoryHelperBaseUrl'),
     extractFunction('normalizeVerificationResendCount'),
     extractFunction('normalizePhoneSmsProvider'),
@@ -101,7 +104,11 @@ const HERO_SMS_COUNTRY_LABEL = 'Thailand';
 const PERSISTED_SETTING_DEFAULTS = {
   autoStepDelaySeconds: null,
   mailProvider: '163',
+  gopayHelperLocalSmsHelperUrl: 'http://127.0.0.1:18767',
+  gopayHelperLocalSmsTimeoutSeconds: 90,
+  gopayHelperLocalSmsPollIntervalSeconds: 2,
 };
+const self = { GoPayUtils: null };
 function normalizePanelMode(value) { return value === 'sub2api' ? 'sub2api' : (value === 'codex2api' ? 'codex2api' : 'cpa'); }
 function normalizeLocalCpaStep9Mode(value) { return value === 'bypass' ? 'bypass' : 'submit'; }
 function normalizeAutoRunFallbackThreadIntervalMinutes(value) { return Number(value) || 0; }
@@ -133,6 +140,12 @@ return {
   assert.equal(api.normalizePersistentSettingValue('plusPaymentMethod', 'gpc-helper'), 'gpc-helper');
   assert.equal(api.normalizePersistentSettingValue('plusPaymentMethod', 'paypal'), 'paypal');
   assert.equal(api.normalizePersistentSettingValue('plusPaymentMethod', 'unknown'), 'paypal');
+  assert.equal(api.normalizePersistentSettingValue('gopayHelperOtpChannel', 'sms'), 'sms');
+  assert.equal(api.normalizePersistentSettingValue('gopayHelperOtpChannel', 'wa'), 'whatsapp');
+  assert.equal(api.normalizePersistentSettingValue('gopayHelperLocalSmsHelperEnabled', 1), true);
+  assert.equal(api.normalizePersistentSettingValue('gopayHelperLocalSmsHelperUrl', 'http://127.0.0.1:18767/otp?x=1'), 'http://127.0.0.1:18767');
+  assert.equal(api.normalizePersistentSettingValue('gopayHelperLocalSmsTimeoutSeconds', '999'), 300);
+  assert.equal(api.normalizePersistentSettingValue('gopayHelperLocalSmsPollIntervalSeconds', '0'), 1);
   assert.equal(api.normalizePersistentSettingValue('verificationResendCount', '7'), 7);
   assert.equal(api.normalizePersistentSettingValue('verificationResendCount', '-1'), 0);
   assert.equal(api.normalizePersistentSettingValue('phoneVerificationReplacementLimit', '9'), 9);

--- a/tests/background-message-router-step2-skip.test.js
+++ b/tests/background-message-router-step2-skip.test.js
@@ -432,6 +432,27 @@ test('message router refreshes GPC balance on platform verify success', async ()
   assert.deepStrictEqual(events.balanceRefreshes[0].options, { reason: 'round_success' });
 });
 
+test('message router accepts GPC SMS helper OTP payload', async () => {
+  const state = {
+    plusManualConfirmationPending: true,
+    plusManualConfirmationStep: 7,
+    plusManualConfirmationMethod: 'gopay-otp',
+  };
+  const { router, events } = createRouter({ state });
+
+  const response = await router.handleMessage({
+    type: 'SUBMIT_GPC_SMS_OTP',
+    source: 'sidepanel',
+    payload: { message_text: 'GOJEK OpenAI LLC OTP: 567104 #567104', message_id: 'sms-1' },
+  }, {});
+
+  assert.equal(response.ok, true);
+  assert.equal(response.otp, '567104');
+  assert.equal(events.stateUpdates[0].gopayHelperResolvedOtp, '567104');
+  assert.equal(events.stateUpdates[0].gopayHelperSmsOtpPayload.message_id, 'sms-1');
+  assert.equal(events.logs.some((entry) => /SMS Helper/.test(entry.message)), true);
+});
+
 test('message router resolves GPC OTP manual confirmation without completing step early', async () => {
   const state = {
     plusManualConfirmationPending: true,

--- a/tests/background-message-router-step2-skip.test.js
+++ b/tests/background-message-router-step2-skip.test.js
@@ -18,6 +18,9 @@ function createRouter(overrides = {}) {
     securityBlocks: [],
     invalidations: [],
     executedSteps: [],
+    balanceRefreshes: [],
+    stateUpdates: [],
+    broadcasts: [],
   };
 
   const router = api.createMessageRouter({
@@ -29,7 +32,9 @@ function createRouter(overrides = {}) {
     buildLocalhostCleanupPrefix: () => '',
     buildLuckmailSessionSettingsPayload: () => ({}),
     buildPersistentSettingsPayload: () => ({}),
-    broadcastDataUpdate: () => {},
+    broadcastDataUpdate: (payload) => {
+      events.broadcasts.push(payload);
+    },
     cancelScheduledAutoRun: async () => {},
     checkIcloudSession: async () => {},
     clearAutoRunTimerAlarm: async () => {},
@@ -50,6 +55,10 @@ function createRouter(overrides = {}) {
     executeStepViaCompletionSignal: async () => {},
     exportSettingsBundle: async () => ({}),
     fetchGeneratedEmail: async () => '',
+    refreshGpcCardBalance: overrides.refreshGpcCardBalance || (async (state, options) => {
+      events.balanceRefreshes.push({ state, options });
+      return { balance: '余额 1', payload: { remaining_uses: 1 }, updatedAt: 123 };
+    }),
     finalizePhoneActivationAfterSuccessfulFlow: overrides.finalizePhoneActivationAfterSuccessfulFlow || (async (state) => {
       events.phoneFinalizations.push(state);
     }),
@@ -115,7 +124,9 @@ function createRouter(overrides = {}) {
     setLuckmailPurchasePreservedState: async () => {},
     setLuckmailPurchaseUsedState: async () => {},
     setPersistentSettings: async () => {},
-    setState: async () => {},
+    setState: async (updates) => {
+      events.stateUpdates.push(updates);
+    },
     setStepStatus: async (step, status) => {
       events.stepStatuses.push({ step, status });
     },
@@ -397,4 +408,53 @@ test('message router blocks manual step 4 execution when signup page tab is miss
 
   assert.deepStrictEqual(events.invalidations, []);
   assert.deepStrictEqual(events.executedSteps, []);
+});
+
+test('message router refreshes GPC balance on platform verify success', async () => {
+  const state = {
+    plusModeEnabled: true,
+    plusPaymentMethod: 'gpc-helper',
+    gopayHelperApiUrl: 'http://localhost:18473/',
+    gopayHelperCardKey: 'card_123',
+    stepStatuses: { 13: 'pending' },
+  };
+  const { router, events } = createRouter({
+    state,
+    getStepDefinitionForState: (step) => ({ id: step, key: step === 13 ? 'platform-verify' : '' }),
+  });
+
+  await router.handleStepData(13, {
+    localhostUrl: 'http://localhost:1455/auth/callback?code=ok',
+  });
+
+  assert.equal(events.balanceRefreshes.length, 1);
+  assert.equal(events.balanceRefreshes[0].state.gopayHelperCardKey, 'card_123');
+  assert.deepStrictEqual(events.balanceRefreshes[0].options, { reason: 'round_success' });
+});
+
+test('message router resolves GPC OTP manual confirmation without completing step early', async () => {
+  const state = {
+    plusManualConfirmationPending: true,
+    plusManualConfirmationRequestId: 'otp-request-1',
+    plusManualConfirmationStep: 7,
+    plusManualConfirmationMethod: 'gopay-otp',
+  };
+  const { router, events } = createRouter({ state });
+
+  const response = await router.handleMessage({
+    type: 'RESOLVE_PLUS_MANUAL_CONFIRMATION',
+    source: 'sidepanel',
+    payload: {
+      step: 7,
+      requestId: 'otp-request-1',
+      confirmed: true,
+      otp: ' 12-34 56 ',
+    },
+  }, {});
+
+  assert.deepStrictEqual(response, { ok: true });
+  assert.equal(events.notifyCompletions.length, 0);
+  assert.equal(events.stepStatuses.length, 0);
+  assert.equal(events.stateUpdates[0].gopayHelperResolvedOtp, '123456');
+  assert.equal(events.stateUpdates[0].plusManualConfirmationPending, false);
 });

--- a/tests/background-platform-verify-codex2api.test.js
+++ b/tests/background-platform-verify-codex2api.test.js
@@ -205,8 +205,8 @@ test('platform verify forwards Plus SUB2API completion using visible final step'
   const messages = [];
   const logs = [];
   const executor = api.createStep10Executor({
-    addLog: async (message, level = 'info') => {
-      logs.push({ message, level });
+    addLog: async (message, level = 'info', options = {}) => {
+      logs.push({ message, level, step: options.step, stepKey: options.stepKey });
     },
     chrome: {
       tabs: {
@@ -246,5 +246,8 @@ test('platform verify forwards Plus SUB2API completion using visible final step'
 
   assert.equal(messages.length, 1);
   assert.equal(messages[0].step, 13);
-  assert.equal(logs.some((entry) => /步骤 13：正在向 SUB2API 提交回调并创建账号/.test(entry.message)), true);
+  assert.equal(
+    logs.some((entry) => entry.message === '正在向 SUB2API 提交回调并创建账号...' && entry.step === 13),
+    true
+  );
 });

--- a/tests/background-platform-verify-codex2api.test.js
+++ b/tests/background-platform-verify-codex2api.test.js
@@ -196,3 +196,55 @@ test('platform verify retries transient SUB2API token_exchange_user_error before
     true
   );
 });
+
+
+test('platform verify forwards Plus SUB2API completion using visible final step', async () => {
+  const source = fs.readFileSync('background/steps/platform-verify.js', 'utf8');
+  const api = new Function('self', `${source}; return self.MultiPageBackgroundStep10;`)({});
+
+  const messages = [];
+  const logs = [];
+  const executor = api.createStep10Executor({
+    addLog: async (message, level = 'info') => {
+      logs.push({ message, level });
+    },
+    chrome: {
+      tabs: {
+        update: async () => {},
+      },
+    },
+    closeConflictingTabsForSource: async () => {},
+    completeStepFromBackground: async () => {},
+    ensureContentScriptReadyOnTab: async () => {},
+    getPanelMode: () => 'sub2api',
+    getTabId: async () => 12,
+    isLocalhostOAuthCallbackUrl: (value) => String(value || '').includes('/auth/callback?code='),
+    isTabAlive: async () => true,
+    normalizeCodex2ApiUrl: (value) => value,
+    normalizeSub2ApiUrl: () => 'https://sub2api.example.com/admin/accounts',
+    rememberSourceLastUrl: async () => {},
+    reuseOrCreateTab: async () => 12,
+    sendToContentScript: async (_source, message) => {
+      messages.push(message);
+      return { ok: true };
+    },
+    sendToContentScriptResilient: async () => ({}),
+    shouldBypassStep9ForLocalCpa: () => false,
+    SUB2API_STEP9_RESPONSE_TIMEOUT_MS: 120000,
+  });
+
+  await executor.executeStep10({
+    panelMode: 'sub2api',
+    visibleStep: 13,
+    localhostUrl: 'http://localhost:1455/auth/callback?code=callback-code&state=oauth-state',
+    sub2apiUrl: 'https://sub2api.example.com/admin/accounts',
+    sub2apiEmail: 'flow@example.com',
+    sub2apiPassword: 'secret',
+    sub2apiSessionId: 'session-123',
+    sub2apiOAuthState: 'oauth-state',
+  });
+
+  assert.equal(messages.length, 1);
+  assert.equal(messages[0].step, 13);
+  assert.equal(logs.some((entry) => /步骤 13：正在向 SUB2API 提交回调并创建账号/.test(entry.message)), true);
+});

--- a/tests/gopay-utils.test.js
+++ b/tests/gopay-utils.test.js
@@ -1,0 +1,98 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+function loadGoPayUtils() {
+  const source = fs.readFileSync('gopay-utils.js', 'utf8');
+  const globalScope = {};
+  return new Function('self', `${source}; return self.GoPayUtils;`)(globalScope);
+}
+
+test('GoPay utils keeps GPC helper payment method distinct', () => {
+  const api = loadGoPayUtils();
+  assert.equal(api.normalizePlusPaymentMethod('gpc-helper'), 'gpc-helper');
+  assert.equal(api.normalizePlusPaymentMethod('gopay'), 'gopay');
+  assert.equal(api.normalizePlusPaymentMethod('unknown'), 'paypal');
+});
+
+test('GoPay utils builds GPC card balance URL from helper endpoints', () => {
+  const api = loadGoPayUtils();
+  assert.equal(
+    api.buildGpcCardBalanceUrl('http://localhost:18473/', ' card key/1 '),
+    'http://localhost:18473/api/card/balance?card_key=card%20key%2F1'
+  );
+  assert.equal(
+    api.buildGpcCardBalanceUrl('https://gopay.hwork.pro/api/checkout/start', 'GPC-1'),
+    'https://gopay.hwork.pro/api/card/balance?card_key=GPC-1'
+  );
+  assert.equal(
+    api.buildGpcCardBalanceUrl('https://gopay.hwork.pro/api/card/balance?card_key=old', 'new'),
+    'https://gopay.hwork.pro/api/card/balance?card_key=new'
+  );
+});
+
+test('GoPay utils builds GPC OTP/PIN payloads with card_key and flow_id', () => {
+  const api = loadGoPayUtils();
+  assert.deepEqual(
+    api.buildGpcOtpPayload({
+      reference_id: ' ref_1 ',
+      otp: ' 12-34 56 ',
+      card_key: ' card_1 ',
+      gopay_guid: ' guid_1 ',
+      flow_id: ' flow_1 ',
+      redirect_url: 'https://pm-redirects.stripe.com/test',
+    }),
+    {
+      reference_id: 'ref_1',
+      otp: '123456',
+      card_key: 'card_1',
+      flow_id: 'flow_1',
+      gopay_guid: 'guid_1',
+      redirect_url: 'https://pm-redirects.stripe.com/test',
+    }
+  );
+  assert.deepEqual(
+    api.buildGpcOtpRetryPayload({ referenceId: 'ref_1', otp: '123456', cardKey: 'card_1', flowId: 'flow_1' }),
+    {
+      reference_id: 'ref_1',
+      otp: '123456',
+      card_key: 'card_1',
+      flow_id: 'flow_1',
+      code: '123456',
+    }
+  );
+  assert.deepEqual(
+    api.buildGpcPinPayload({
+      referenceId: 'ref_1',
+      challengeId: 'challenge_1',
+      gopayGuid: 'guid_1',
+      pin: '65-43-21',
+      cardKey: 'card_1',
+      flowId: 'flow_1',
+    }),
+    {
+      reference_id: 'ref_1',
+      challenge_id: 'challenge_1',
+      gopay_guid: 'guid_1',
+      pin: '654321',
+      card_key: 'card_1',
+      flow_id: 'flow_1',
+    }
+  );
+});
+
+test('GoPay utils formats balance and maps linked-account errors', () => {
+  const api = loadGoPayUtils();
+  assert.equal(
+    api.formatGpcBalancePayload({ remaining_uses: 12, card_status: 'active', flow_id: 'flow_1' }),
+    '余额 12，状态 active，flow_id flow_1'
+  );
+  assert.equal(
+    api.extractGpcResponseErrorDetail({ errors: [{ loc: ['body', 'otp'], msg: 'Field required' }] }, 422),
+    'body.otp: Field required'
+  );
+  assert.equal(
+    api.extractGpcResponseErrorDetail({ error_messages: ['account already linked'] }, 406),
+    'GOPAY已经绑了订阅，需要手动解绑'
+  );
+});

--- a/tests/gopay-utils.test.js
+++ b/tests/gopay-utils.test.js
@@ -15,6 +15,14 @@ test('GoPay utils keeps GPC helper payment method distinct', () => {
   assert.equal(api.normalizePlusPaymentMethod('unknown'), 'paypal');
 });
 
+test('GoPay utils normalizes GPC OTP channel aliases', () => {
+  const api = loadGoPayUtils();
+  assert.equal(api.normalizeGpcOtpChannel('sms'), 'sms');
+  assert.equal(api.normalizeGpcOtpChannel('whatsapp'), 'whatsapp');
+  assert.equal(api.normalizeGpcOtpChannel('wa'), 'whatsapp');
+  assert.equal(api.normalizeGpcOtpChannel(''), 'whatsapp');
+});
+
 test('GoPay utils builds GPC card balance URL from helper endpoints', () => {
   const api = loadGoPayUtils();
   assert.equal(

--- a/tests/gpc-sms-helper-script.test.js
+++ b/tests/gpc-sms-helper-script.test.js
@@ -1,0 +1,19 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const scriptPath = path.join(process.cwd(), 'scripts/gpc_sms_helper_macos.py');
+
+test('GPC SMS helper shows macOS and iPhone forwarding guidance on non-macOS', () => {
+  if (process.platform === 'darwin') {
+    return;
+  }
+  const result = spawnSync('python3', [scriptPath, '--help'], { encoding: 'utf8' });
+  // argparse --help exits before runtime checks, so run normally with a harmless db path.
+  const run = spawnSync('python3', [scriptPath, '--db', '/tmp/nonexistent-gpc-chat.db'], { encoding: 'utf8', timeout: 3000 });
+  assert.notEqual(run.status, 0);
+  assert.match(run.stderr, /仅支持 macOS/);
+  assert.match(run.stderr, /iPhone 短信已转发|短信.*转发/);
+  assert.equal(result.status, 0);
+});

--- a/tests/plus-checkout-address-input.test.js
+++ b/tests/plus-checkout-address-input.test.js
@@ -373,3 +373,14 @@ return { fillIfEmpty };
   assert.equal(input.value, '100-0005');
   assert.deepEqual(writes, ['100-0005']);
 });
+
+test('plus checkout state can include ChatGPT session accessToken for GPC', async () => {
+  const source = fs.readFileSync('content/plus-checkout.js', 'utf8');
+  const start = source.indexOf('async function readChatGptSessionAccessToken');
+  const inspectStart = source.indexOf('async function inspectPlusCheckoutState');
+  assert.notEqual(start, -1);
+  assert.notEqual(inspectStart, -1);
+  assert.match(source, /case 'PLUS_CHECKOUT_GET_STATE':[\s\S]*inspectPlusCheckoutState\(message\.payload \|\| \{\}\)/);
+  assert.match(source, /fetch\('\/api\/auth\/session',[\s\S]*credentials:\s*'include'/);
+  assert.match(source, /state\.accessToken = sessionState\.accessToken/);
+});

--- a/tests/plus-checkout-billing-tab-resolution.test.js
+++ b/tests/plus-checkout-billing-tab-resolution.test.js
@@ -52,6 +52,7 @@ function createExecutorHarness({
   stateByFrame,
   readyByFrame = {},
   fetchImpl = null,
+  getState = null,
   getAddressSeedForCountry = () => createAddressSeed(),
 }) {
   const api = loadPlusCheckoutBillingModule();
@@ -119,6 +120,7 @@ function createExecutorHarness({
     fetch: fetchImpl,
     generateRandomName: () => ({ firstName: 'Ada', lastName: 'Lovelace' }),
     getAddressSeedForCountry,
+    ...(typeof getState === 'function' ? { getState } : {}),
     getTabId: async () => null,
     isTabAlive: async () => false,
     setState: async (updates) => events.states.push(updates),
@@ -422,4 +424,150 @@ test('Plus checkout billing reports when the payment iframe exists but cannot re
     executor.executePlusCheckoutBilling({}),
     /已定位到 PayPal 所在 iframe（frameId=7），但账单脚本无法注入该 iframe/
   );
+});
+
+test('GPC billing normalizes API URL and submits OTP then PIN with card_key and flow_id', async () => {
+  const fetchCalls = [];
+  let currentState = {
+    plusManualConfirmationPending: true,
+    plusManualConfirmationRequestId: '',
+  };
+  const { events, executor } = createExecutorHarness({
+    frames: [],
+    stateByFrame: {},
+    getState: async () => currentState,
+    fetchImpl: async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      if (url.endsWith('/api/gopay/otp')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ reference_id: 'ref_123', challenge_id: 'challenge_456' }),
+        };
+      }
+      if (url.endsWith('/api/gopay/pin')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ stage: 'gopay_complete' }),
+        };
+      }
+      throw new Error(`unexpected url: ${url}`);
+    },
+  });
+
+  const run = executor.executePlusCheckoutBilling({
+    plusPaymentMethod: 'gpc-helper',
+    plusCheckoutSource: 'gpc-helper',
+    gopayHelperReferenceId: 'ref_123',
+    gopayHelperGoPayGuid: 'guid_789',
+    gopayHelperApiUrl: 'https://gopay.hwork.pro/api/checkout/start',
+    gopayHelperPin: '654321',
+    gopayHelperCardKey: 'card_billing_123',
+    gopayHelperFlowId: 'flow_billing_123',
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  const pending = events.states.find((state) => state.plusManualConfirmationMethod === 'gopay-otp');
+  assert.ok(pending);
+  currentState = {
+    plusManualConfirmationPending: false,
+    plusManualConfirmationRequestId: pending.plusManualConfirmationRequestId,
+    gopayHelperResolvedOtp: '123456',
+  };
+
+  await run;
+
+  assert.equal(fetchCalls[0].url, 'https://gopay.hwork.pro/api/gopay/otp');
+  assert.deepEqual(JSON.parse(fetchCalls[0].options.body), {
+    reference_id: 'ref_123',
+    otp: '123456',
+    card_key: 'card_billing_123',
+    flow_id: 'flow_billing_123',
+    gopay_guid: 'guid_789',
+  });
+  assert.equal(fetchCalls[1].url, 'https://gopay.hwork.pro/api/gopay/pin');
+  assert.deepEqual(JSON.parse(fetchCalls[1].options.body), {
+    reference_id: 'ref_123',
+    challenge_id: 'challenge_456',
+    gopay_guid: 'guid_789',
+    pin: '654321',
+    card_key: 'card_billing_123',
+    flow_id: 'flow_billing_123',
+  });
+  assert.equal(events.completed[0].step, 7);
+  assert.equal(events.completed[0].payload.plusCheckoutSource, 'gpc-helper');
+});
+
+test('GPC billing retries OTP with compatibility field after HTTP 400', async () => {
+  const fetchCalls = [];
+  let currentState = {
+    plusManualConfirmationPending: true,
+    plusManualConfirmationRequestId: '',
+  };
+  const { events, executor } = createExecutorHarness({
+    frames: [],
+    stateByFrame: {},
+    getState: async () => currentState,
+    fetchImpl: async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      if (url.endsWith('/api/gopay/otp') && fetchCalls.filter((call) => call.url.endsWith('/api/gopay/otp')).length === 1) {
+        return {
+          ok: false,
+          status: 400,
+          json: async () => ({ error: 'otp field invalid' }),
+        };
+      }
+      if (url.endsWith('/api/gopay/otp')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ challenge_id: 'challenge_retry' }),
+        };
+      }
+      if (url.endsWith('/api/gopay/pin')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ stage: 'gopay_complete' }),
+        };
+      }
+      throw new Error(`unexpected url: ${url}`);
+    },
+  });
+
+  const run = executor.executePlusCheckoutBilling({
+    plusPaymentMethod: 'gpc-helper',
+    plusCheckoutSource: 'gpc-helper',
+    gopayHelperReferenceId: 'ref_retry',
+    gopayHelperGoPayGuid: 'guid_retry',
+    gopayHelperRedirectUrl: 'https://pm-redirects.stripe.com/retry',
+    gopayHelperApiUrl: 'http://localhost:18473/',
+    gopayHelperPin: '654321',
+    gopayHelperCardKey: 'card_retry',
+    gopayHelperFlowId: 'flow_retry',
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  const pending = events.states.find((state) => state.plusManualConfirmationMethod === 'gopay-otp');
+  currentState = {
+    plusManualConfirmationPending: false,
+    plusManualConfirmationRequestId: pending.plusManualConfirmationRequestId,
+    gopayHelperResolvedOtp: '123456',
+  };
+
+  await run;
+
+  assert.equal(fetchCalls.filter((call) => call.url.endsWith('/api/gopay/otp')).length, 2);
+  assert.deepEqual(JSON.parse(fetchCalls[1].options.body), {
+    reference_id: 'ref_retry',
+    otp: '123456',
+    card_key: 'card_retry',
+    flow_id: 'flow_retry',
+    gopay_guid: 'guid_retry',
+    redirect_url: 'https://pm-redirects.stripe.com/retry',
+    code: '123456',
+  });
+  assert.equal(events.logs.some((entry) => /兼容字段重试/.test(entry.message)), true);
+  assert.equal(events.completed[0].step, 7);
 });

--- a/tests/plus-checkout-billing-tab-resolution.test.js
+++ b/tests/plus-checkout-billing-tab-resolution.test.js
@@ -499,6 +499,62 @@ test('GPC billing normalizes API URL and submits OTP then PIN with card_key and 
   assert.equal(events.completed[0].payload.plusCheckoutSource, 'gpc-helper');
 });
 
+test('GPC billing reads OTP from local SMS helper when enabled', async () => {
+  const fetchCalls = [];
+  const { events, executor } = createExecutorHarness({
+    frames: [],
+    stateByFrame: {},
+    fetchImpl: async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      if (url.startsWith('http://127.0.0.1:18767/otp')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ ok: true, otp: '654321', message_id: 'sms-1' }),
+        };
+      }
+      if (url.endsWith('/api/gopay/otp')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ challenge_id: 'challenge_sms' }),
+        };
+      }
+      if (url.endsWith('/api/gopay/pin')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ stage: 'gopay_complete' }),
+        };
+      }
+      throw new Error(`unexpected url: ${url}`);
+    },
+  });
+
+  await executor.executePlusCheckoutBilling({
+    plusPaymentMethod: 'gpc-helper',
+    plusCheckoutSource: 'gpc-helper',
+    gopayHelperReferenceId: 'ref_sms',
+    gopayHelperApiUrl: 'https://gopay.hwork.pro/',
+    gopayHelperPin: '654321',
+    gopayHelperCardKey: 'card_sms',
+    gopayHelperOtpChannel: 'sms',
+    gopayHelperLocalSmsHelperEnabled: true,
+    gopayHelperLocalSmsHelperUrl: 'http://127.0.0.1:18767',
+    gopayHelperPhoneNumber: '+8613800138000',
+  });
+
+  assert.equal(events.states.some((state) => state.plusManualConfirmationMethod === 'gopay-otp'), false);
+  assert.equal(events.states.some((state) => state.gopayHelperResolvedOtp === '654321'), true);
+  assert.equal(fetchCalls[0].url, 'http://127.0.0.1:18767/otp?reference_id=ref_sms&phone_number=%2B8613800138000');
+  assert.deepEqual(JSON.parse(fetchCalls[1].options.body), {
+    reference_id: 'ref_sms',
+    otp: '654321',
+    card_key: 'card_sms',
+  });
+  assert.equal(events.completed[0].step, 7);
+});
+
 test('GPC billing retries OTP with compatibility field after HTTP 400', async () => {
   const fetchCalls = [];
   let currentState = {

--- a/tests/plus-checkout-create-wait.test.js
+++ b/tests/plus-checkout-create-wait.test.js
@@ -180,6 +180,8 @@ test('GPC checkout injects Plus script before reading ChatGPT session token and 
   assert.equal(helperPayload.card_key, 'card_test_123');
   assert.deepEqual(helperPayload.gopay_link, {
     type: 'gopay',
+    phone_mode: 'manual',
+    otp_channel: 'whatsapp',
     country_code: '86',
     phone_number: '13800138000',
   });
@@ -188,6 +190,48 @@ test('GPC checkout injects Plus script before reading ChatGPT session token and 
   assert.equal(events.find((event) => event.type === 'set-state')?.payload?.gopayHelperFlowId, 'flow_789');
   assert.equal(events.find((event) => event.type === 'complete')?.step, 6);
   assert.equal(events.find((event) => event.type === 'complete')?.payload?.plusCheckoutSource, 'gpc-helper');
+});
+
+test('GPC checkout forwards selected SMS OTP channel', async () => {
+  const fetchCalls = [];
+  const executor = api.createPlusCheckoutCreateExecutor({
+    addLog: async () => {},
+    chrome: {
+      tabs: {
+        create: async () => ({ id: 78 }),
+        remove: async () => {},
+      },
+    },
+    completeStepFromBackground: async () => {},
+    ensureContentScriptReadyOnTabUntilStopped: async () => {},
+    fetch: async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ reference_id: 'ref_sms', next_action: 'enter_otp' }),
+      };
+    },
+    registerTab: async () => {},
+    sendTabMessageUntilStopped: async () => ({ accessToken: 'session-access-token' }),
+    setState: async () => {},
+    sleepWithStop: async () => {},
+    waitForTabCompleteUntilStopped: async () => {},
+  });
+
+  await executor.executePlusCheckoutCreate({
+    email: 'sms@example.com',
+    plusPaymentMethod: 'gpc-helper',
+    gopayHelperApiUrl: 'https://gopay.hwork.pro/',
+    gopayHelperPhoneNumber: '+8613800138000',
+    gopayHelperCountryCode: '+86',
+    gopayHelperPin: '123456',
+    gopayHelperCardKey: 'card_sms',
+    gopayHelperOtpChannel: 'sms',
+  });
+
+  assert.equal(JSON.parse(fetchCalls[0].options.body).gopay_link.otp_channel, 'sms');
+  assert.equal(JSON.parse(fetchCalls[0].options.body).gopay_link.phone_mode, 'manual');
 });
 
 test('GPC checkout treats non-zero API balance as non-free-trial and does not create order', async () => {

--- a/tests/plus-checkout-create-wait.test.js
+++ b/tests/plus-checkout-create-wait.test.js
@@ -106,3 +106,229 @@ test('GoPay plus checkout create forwards gopay payment method to the checkout c
 
   assert.deepStrictEqual(events[0]?.payload, { paymentMethod: 'gopay' });
 });
+
+test('GPC checkout injects Plus script before reading ChatGPT session token and sends card_key', async () => {
+  const events = [];
+  const fetchCalls = [];
+  const executor = api.createPlusCheckoutCreateExecutor({
+    addLog: async (message, level = 'info') => events.push({ type: 'log', message, level }),
+    chrome: {
+      tabs: {
+        create: async (payload) => {
+          events.push({ type: 'tab-create', payload });
+          return { id: 77 };
+        },
+        remove: async (tabId) => events.push({ type: 'tab-remove', tabId }),
+      },
+    },
+    completeStepFromBackground: async (step, payload) => events.push({ type: 'complete', step, payload }),
+    ensureContentScriptReadyOnTabUntilStopped: async (source, tabId, options) => events.push({ type: 'ready', source, tabId, options }),
+    fetch: async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          reference_id: 'ref_123',
+          gopay_guid: 'guid_456',
+          next_action: 'enter_otp',
+          flow_id: 'flow_789',
+        }),
+      };
+    },
+    registerTab: async (source, tabId) => events.push({ type: 'register', source, tabId }),
+    sendTabMessageUntilStopped: async (tabId, source, message) => {
+      events.push({ type: 'tab-message', tabId, source, message });
+      return { accessToken: 'session-access-token' };
+    },
+    setState: async (payload) => events.push({ type: 'set-state', payload }),
+    sleepWithStop: async (ms) => events.push({ type: 'sleep', ms }),
+    waitForTabCompleteUntilStopped: async () => events.push({ type: 'tab-complete' }),
+  });
+
+  await executor.executePlusCheckoutCreate({
+    email: 'Current.Round+GPC@Example.COM',
+    plusPaymentMethod: 'gpc-helper',
+    gopayHelperApiUrl: 'https://gopay.hwork.pro/',
+    gopayHelperPhoneNumber: '+8613800138000',
+    gopayPhone: '',
+    gopayHelperCountryCode: '+86',
+    gopayHelperPin: '123456',
+    gopayHelperCardKey: 'card_test_123',
+  });
+
+  const readyIndex = events.findIndex((event) => event.type === 'ready');
+  const messageIndex = events.findIndex((event) => event.type === 'tab-message');
+  assert.ok(readyIndex >= 0);
+  assert.ok(messageIndex > readyIndex);
+  assert.equal(events[messageIndex].message.type, 'PLUS_CHECKOUT_GET_STATE');
+  assert.deepEqual(events[messageIndex].message.payload, {
+    includeSession: true,
+    includeAccessToken: true,
+  });
+  assert.equal(events.some((event) => event.type === 'log' && /缺少 accessToken/.test(event.message)), false);
+  assert.equal(events.some((event) => event.type === 'log' && /正在获取 accessToken/.test(event.message)), true);
+  const obsoleteGpcLabels = ['GoPay ' + 'Helper', 'G' + 'AP', 'G' + 'AC', 'gopay' + '-helper'];
+  assert.equal(events.some((event) => (
+    event.type === 'log'
+    && obsoleteGpcLabels.some((label) => String(event.message || '').includes(label))
+  )), false);
+  assert.equal(fetchCalls.length, 1);
+  assert.equal(fetchCalls[0].url, 'https://gopay.hwork.pro/api/checkout/start');
+  const helperPayload = JSON.parse(fetchCalls[0].options.body);
+  assert.equal(helperPayload.customer_email, 'current.round+gpc@example.com');
+  assert.equal(helperPayload.card_key, 'card_test_123');
+  assert.deepEqual(helperPayload.gopay_link, {
+    type: 'gopay',
+    country_code: '86',
+    phone_number: '13800138000',
+  });
+  assert.equal(events.find((event) => event.type === 'set-state')?.payload?.plusCheckoutSource, 'gpc-helper');
+  assert.equal(events.find((event) => event.type === 'set-state')?.payload?.gopayHelperReferenceId, 'ref_123');
+  assert.equal(events.find((event) => event.type === 'set-state')?.payload?.gopayHelperFlowId, 'flow_789');
+  assert.equal(events.find((event) => event.type === 'complete')?.step, 6);
+  assert.equal(events.find((event) => event.type === 'complete')?.payload?.plusCheckoutSource, 'gpc-helper');
+});
+
+test('GPC checkout treats non-zero API balance as non-free-trial and does not create order', async () => {
+  const markCalls = [];
+  const fetchCalls = [];
+  const events = [];
+  const executor = api.createPlusCheckoutCreateExecutor({
+    addLog: async (message, level = 'info') => events.push({ type: 'log', message, level }),
+    chrome: {
+      tabs: {
+        create: async () => {
+          throw new Error('should not open token tab when direct access token exists');
+        },
+        remove: async () => {},
+      },
+    },
+    completeStepFromBackground: async () => {
+      throw new Error('should not complete step 6 for non-free-trial checkout');
+    },
+    ensureContentScriptReadyOnTabUntilStopped: async () => {},
+    fetch: async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          reference_id: 'ref_paid',
+          gopay_guid: 'guid_paid',
+          next_action: 'enter_otp',
+          checkout: { amount_due: 'Rp 29.000' },
+        }),
+      };
+    },
+    markCurrentRegistrationAccountUsed: async (state, options) => {
+      markCalls.push({ state, options });
+      return { updated: true };
+    },
+    registerTab: async () => {},
+    sendTabMessageUntilStopped: async () => {},
+    setState: async () => {},
+    sleepWithStop: async () => {},
+    waitForTabCompleteUntilStopped: async () => {},
+  });
+
+  await assert.rejects(
+    () => executor.executePlusCheckoutCreate({
+      email: 'paid@example.com',
+      plusPaymentMethod: 'gpc-helper',
+      gopayHelperApiUrl: 'https://gopay.hwork.pro/',
+      chatgptAccessToken: 'state-access-token',
+      gopayHelperPhoneNumber: '+8613800138000',
+      gopayHelperCountryCode: '+86',
+      gopayHelperPin: '123456',
+      gopayHelperCardKey: 'card_paid_456',
+    }),
+    /PLUS_CHECKOUT_NON_FREE_TRIAL::.*余额非 0/
+  );
+
+  assert.equal(fetchCalls.length, 1);
+  assert.equal(JSON.parse(fetchCalls[0].options.body).card_key, 'card_paid_456');
+  assert.equal(markCalls.length, 1);
+  assert.equal(markCalls[0].state.email, 'paid@example.com');
+  assert.equal(markCalls[0].options.reason, 'plus-checkout-non-free-trial');
+  assert.equal(events.some((event) => event.type === 'log' && /订单已创建/.test(event.message)), false);
+  assert.equal(events.some((event) => event.type === 'log' && /余额非 0/.test(event.message)), true);
+});
+
+test('GPC checkout does not fall back to browser GoPay phone fields', async () => {
+  const executor = api.createPlusCheckoutCreateExecutor({
+    addLog: async () => {},
+    chrome: {
+      tabs: {
+        create: async () => {
+          throw new Error('should not open token tab when direct access token exists');
+        },
+        remove: async () => {},
+      },
+    },
+    completeStepFromBackground: async () => {},
+    ensureContentScriptReadyOnTabUntilStopped: async () => {},
+    fetch: async () => {
+      throw new Error('should not call helper API without helper phone');
+    },
+    registerTab: async () => {},
+    sendTabMessageUntilStopped: async () => {},
+    setState: async () => {},
+    sleepWithStop: async () => {},
+    waitForTabCompleteUntilStopped: async () => {},
+  });
+
+  await assert.rejects(
+    () => executor.executePlusCheckoutCreate({
+      plusPaymentMethod: 'gpc-helper',
+      gopayHelperApiUrl: 'https://gopay.hwork.pro/',
+      chatgptAccessToken: 'state-access-token',
+      email: 'helper-phone-test@example.com',
+      gopayPhone: '+8613800138000',
+      gopayCountryCode: '+86',
+      gopayPin: '123456',
+      gopayHelperPhoneNumber: '',
+      gopayHelperPin: '123456',
+      gopayHelperCardKey: 'card_phone_test',
+    }),
+    /缺少手机号/
+  );
+});
+
+test('GPC checkout rejects missing card key before calling helper API', async () => {
+  const executor = api.createPlusCheckoutCreateExecutor({
+    addLog: async () => {},
+    chrome: {
+      tabs: {
+        create: async () => {
+          throw new Error('should not open token tab when direct access token exists');
+        },
+        remove: async () => {},
+      },
+    },
+    completeStepFromBackground: async () => {},
+    ensureContentScriptReadyOnTabUntilStopped: async () => {},
+    fetch: async () => {
+      throw new Error('should not call helper API without card key');
+    },
+    registerTab: async () => {},
+    sendTabMessageUntilStopped: async () => {},
+    setState: async () => {},
+    sleepWithStop: async () => {},
+    waitForTabCompleteUntilStopped: async () => {},
+  });
+
+  await assert.rejects(
+    () => executor.executePlusCheckoutCreate({
+      plusPaymentMethod: 'gpc-helper',
+      gopayHelperApiUrl: 'https://gopay.hwork.pro/',
+      chatgptAccessToken: 'state-access-token',
+      email: 'missing-card@example.com',
+      gopayHelperPhoneNumber: '+8613800138000',
+      gopayHelperCountryCode: '+86',
+      gopayHelperPin: '123456',
+      gopayHelperCardKey: '',
+    }),
+    /缺少卡密/
+  );
+});

--- a/tests/sidepanel-plus-payment-method.test.js
+++ b/tests/sidepanel-plus-payment-method.test.js
@@ -91,7 +91,13 @@ let latestState = { plusPaymentMethod: 'gopay' };
 let currentPlusPaymentMethod = 'paypal';
 const inputPlusModeEnabled = { checked: true };
 const selectPlusPaymentMethod = { value: 'gopay', style: { display: 'none' } };
+const btnGpcCardKeyPurchase = { style: { display: 'none' } };
 const rowPayPalAccount = { style: { display: '' } };
+const rowGopayHelperApi = { style: { display: 'none' } };
+const rowGoPayHelperCardKey = { style: { display: 'none' } };
+const rowGoPayHelperCountryCode = { style: { display: 'none' } };
+const rowGoPayHelperPhone = { style: { display: 'none' } };
+const rowGoPayHelperPin = { style: { display: 'none' } };
 ${bundle}
 return { updatePlusModeUI, selectPlusPaymentMethod, rowPayPalAccount };
 `)();
@@ -165,4 +171,184 @@ return { events, syncPlusManualConfirmationDialog };
   });
   assert.match(api.events[2].message, /GoPay/);
   assert.equal(api.events[2].tone, 'info');
+});
+
+test('sidepanel step definitions keep GPC helper mode distinct', () => {
+  const bundle = [
+    extractFunction('normalizePlusPaymentMethod'),
+    extractFunction('getStepDefinitionsForMode'),
+    extractFunction('rebuildStepDefinitionState'),
+    extractFunction('syncStepDefinitionsForMode'),
+  ].join('\n');
+
+  const api = new Function(`
+const calls = [];
+const window = {
+  MultiPageStepDefinitions: {
+    getSteps(options) {
+      calls.push({ type: 'getSteps', options });
+      return [{ id: options.plusPaymentMethod === 'gpc-helper' ? 10 : 6, order: 1 }];
+    },
+  },
+};
+let currentPlusModeEnabled = false;
+let currentPlusPaymentMethod = 'paypal';
+let stepDefinitions = [];
+let STEP_IDS = [];
+let STEP_DEFAULT_STATUSES = {};
+let SKIPPABLE_STEPS = new Set();
+function renderStepsList() {
+  calls.push({ type: 'render', stepIds: [...STEP_IDS] });
+}
+${bundle}
+return {
+  calls,
+  syncStepDefinitionsForMode,
+  getCurrentPlusPaymentMethod: () => currentPlusPaymentMethod,
+  getStepIds: () => [...STEP_IDS],
+};
+`)();
+
+  api.syncStepDefinitionsForMode(true, 'gpc-helper', { render: true });
+
+  assert.equal(api.getCurrentPlusPaymentMethod(), 'gpc-helper');
+  assert.deepEqual(api.getStepIds(), [10]);
+  assert.deepEqual(api.calls[0], {
+    type: 'getSteps',
+    options: { plusModeEnabled: true, plusPaymentMethod: 'gpc-helper' },
+  });
+});
+
+test('sidepanel Plus UI shows GPC fields and purchase button only for GPC', () => {
+  const bundle = [
+    extractFunction('normalizePlusPaymentMethod'),
+    extractFunction('getSelectedPlusPaymentMethod'),
+    extractFunction('updatePlusModeUI'),
+  ].join('\n');
+
+  const api = new Function(`
+let latestState = { plusPaymentMethod: 'gpc-helper' };
+let currentPlusPaymentMethod = 'paypal';
+const inputPlusModeEnabled = { checked: true };
+const selectPlusPaymentMethod = { value: 'gpc-helper', style: { display: 'none' } };
+const btnGpcCardKeyPurchase = { style: { display: 'none' } };
+const rowPayPalAccount = { style: { display: '' } };
+const rowGopayHelperApi = { style: { display: 'none' } };
+const rowGoPayHelperCardKey = { style: { display: 'none' } };
+const rowGoPayHelperCountryCode = { style: { display: 'none' } };
+const rowGoPayHelperPhone = { style: { display: 'none' } };
+const rowGoPayHelperPin = { style: { display: 'none' } };
+${bundle}
+return {
+  updatePlusModeUI,
+  selectPlusPaymentMethod,
+  btnGpcCardKeyPurchase,
+  rowPayPalAccount,
+  rows: { rowGopayHelperApi, rowGoPayHelperCardKey, rowGoPayHelperCountryCode, rowGoPayHelperPhone, rowGoPayHelperPin },
+};
+`)();
+
+  api.updatePlusModeUI();
+
+  assert.equal(api.rowPayPalAccount.style.display, 'none');
+  assert.equal(api.btnGpcCardKeyPurchase.style.display, '');
+  assert.equal(api.rows.rowGopayHelperApi.style.display, '');
+  assert.equal(api.rows.rowGoPayHelperCardKey.style.display, '');
+  assert.equal(api.rows.rowGoPayHelperPhone.style.display, '');
+
+  api.selectPlusPaymentMethod.value = 'gopay';
+  api.updatePlusModeUI();
+  assert.equal(api.btnGpcCardKeyPurchase.style.display, 'none');
+  assert.equal(api.rows.rowGopayHelperApi.style.display, 'none');
+  assert.equal(api.rowPayPalAccount.style.display, 'none');
+});
+
+test('sidepanel opens GPC card-key purchase page', () => {
+  const bundle = [
+    extractFunction('openExternalUrl'),
+    extractFunction('openGpcCardKeyPurchasePage'),
+  ].join('\n');
+
+  const api = new Function(`
+const opened = [];
+const chrome = {
+  tabs: {
+    create(payload) {
+      opened.push(payload);
+      return Promise.resolve();
+    },
+  },
+};
+const window = {
+  open(url, target, features) {
+    opened.push({ url, target, features });
+  },
+};
+${bundle}
+return { opened, openGpcCardKeyPurchasePage };
+`)();
+
+  api.openGpcCardKeyPurchasePage();
+
+  assert.deepEqual(api.opened[0], {
+    url: 'https://pay.ldxp.cn/shop/gpc',
+    active: true,
+  });
+});
+
+test('sidepanel resolves pending GPC OTP with typed code', async () => {
+  const bundle = [
+    extractFunction('openPlusManualConfirmationDialog'),
+    extractFunction('syncPlusManualConfirmationDialog'),
+  ].join('\n');
+
+  const api = new Function(`
+const events = [];
+let latestState = {
+  plusManualConfirmationPending: true,
+  plusManualConfirmationRequestId: 'otp-request-1',
+  plusManualConfirmationStep: 7,
+  plusManualConfirmationMethod: 'gopay-otp',
+  plusManualConfirmationTitle: 'GPC OTP 验证',
+  plusManualConfirmationMessage: '请输入 OTP。',
+};
+let activePlusManualConfirmationRequestId = '';
+let plusManualConfirmationDialogInFlight = false;
+const sharedFormDialog = {
+  async open(options) {
+    events.push({ type: 'form', options });
+    return { otp: ' 12-34 56 ' };
+  },
+};
+function openActionModal(options) {
+  events.push({ type: 'modal', options });
+  return Promise.resolve('confirm');
+}
+function showToast(message, tone) {
+  events.push({ type: 'toast', message, tone });
+}
+const chrome = {
+  runtime: {
+    async sendMessage(message) {
+      events.push({ type: 'send', message });
+      latestState = { ...latestState, plusManualConfirmationPending: false };
+      return { ok: true };
+    },
+  },
+};
+${bundle}
+return { events, syncPlusManualConfirmationDialog };
+`)();
+
+  await api.syncPlusManualConfirmationDialog();
+
+  assert.equal(api.events[0].type, 'form');
+  const sendEvent = api.events.find((event) => event.type === 'send');
+  assert.deepEqual(sendEvent.message.payload, {
+    step: 7,
+    requestId: 'otp-request-1',
+    confirmed: true,
+    otp: '123456',
+  });
+  assert.equal(api.events.some((event) => event.type === 'modal'), false);
 });

--- a/tests/sidepanel-plus-payment-method.test.js
+++ b/tests/sidepanel-plus-payment-method.test.js
@@ -223,6 +223,7 @@ test('sidepanel Plus UI shows GPC fields and purchase button only for GPC', () =
   const bundle = [
     extractFunction('normalizePlusPaymentMethod'),
     extractFunction('getSelectedPlusPaymentMethod'),
+    extractFunction('normalizeGpcOtpChannelValue'),
     extractFunction('updatePlusModeUI'),
   ].join('\n');
 
@@ -237,6 +238,11 @@ const rowGopayHelperApi = { style: { display: 'none' } };
 const rowGoPayHelperCardKey = { style: { display: 'none' } };
 const rowGoPayHelperCountryCode = { style: { display: 'none' } };
 const rowGoPayHelperPhone = { style: { display: 'none' } };
+const rowGoPayHelperOtpChannel = { style: { display: 'none' } };
+const selectGoPayHelperOtpChannel = { value: 'sms' };
+const rowGoPayHelperLocalSmsEnabled = { style: { display: 'none' } };
+const inputGoPayHelperLocalSmsEnabled = { checked: true };
+const rowGoPayHelperLocalSmsUrl = { style: { display: 'none' } };
 const rowGoPayHelperPin = { style: { display: 'none' } };
 ${bundle}
 return {
@@ -244,7 +250,7 @@ return {
   selectPlusPaymentMethod,
   btnGpcCardKeyPurchase,
   rowPayPalAccount,
-  rows: { rowGopayHelperApi, rowGoPayHelperCardKey, rowGoPayHelperCountryCode, rowGoPayHelperPhone, rowGoPayHelperPin },
+  rows: { rowGopayHelperApi, rowGoPayHelperCardKey, rowGoPayHelperCountryCode, rowGoPayHelperPhone, rowGoPayHelperOtpChannel, rowGoPayHelperLocalSmsEnabled, rowGoPayHelperLocalSmsUrl, rowGoPayHelperPin },
 };
 `)();
 
@@ -255,12 +261,53 @@ return {
   assert.equal(api.rows.rowGopayHelperApi.style.display, '');
   assert.equal(api.rows.rowGoPayHelperCardKey.style.display, '');
   assert.equal(api.rows.rowGoPayHelperPhone.style.display, '');
+  assert.equal(api.rows.rowGoPayHelperOtpChannel.style.display, '');
+  assert.equal(api.rows.rowGoPayHelperLocalSmsEnabled.style.display, '');
+  assert.equal(api.rows.rowGoPayHelperLocalSmsUrl.style.display, '');
 
   api.selectPlusPaymentMethod.value = 'gopay';
   api.updatePlusModeUI();
   assert.equal(api.btnGpcCardKeyPurchase.style.display, 'none');
   assert.equal(api.rows.rowGopayHelperApi.style.display, 'none');
   assert.equal(api.rowPayPalAccount.style.display, 'none');
+});
+
+test('sidepanel shows local SMS helper URL immediately when switch is enabled', () => {
+  const bundle = [
+    extractFunction('normalizePlusPaymentMethod'),
+    extractFunction('getSelectedPlusPaymentMethod'),
+    extractFunction('normalizeGpcOtpChannelValue'),
+    extractFunction('updatePlusModeUI'),
+  ].join('\n');
+
+  const api = new Function(`
+let latestState = { plusPaymentMethod: 'gpc-helper', gopayHelperOtpChannel: 'whatsapp' };
+let currentPlusPaymentMethod = 'paypal';
+const inputPlusModeEnabled = { checked: true };
+const selectPlusPaymentMethod = { value: 'gpc-helper', style: { display: 'none' } };
+const btnGpcCardKeyPurchase = { style: { display: 'none' } };
+const rowPayPalAccount = { style: { display: '' } };
+const rowGopayHelperApi = { style: { display: 'none' } };
+const rowGoPayHelperCardKey = { style: { display: 'none' } };
+const rowGoPayHelperCountryCode = { style: { display: 'none' } };
+const rowGoPayHelperPhone = { style: { display: 'none' } };
+const rowGoPayHelperOtpChannel = { style: { display: 'none' } };
+const selectGoPayHelperOtpChannel = { value: 'whatsapp' };
+const rowGoPayHelperLocalSmsEnabled = { style: { display: 'none' } };
+const inputGoPayHelperLocalSmsEnabled = { checked: false };
+const rowGoPayHelperLocalSmsUrl = { style: { display: 'none' } };
+const rowGoPayHelperPin = { style: { display: 'none' } };
+${bundle}
+return { updatePlusModeUI, selectGoPayHelperOtpChannel, inputGoPayHelperLocalSmsEnabled, rowGoPayHelperLocalSmsUrl };
+`)();
+
+  api.updatePlusModeUI();
+  assert.equal(api.rowGoPayHelperLocalSmsUrl.style.display, 'none');
+
+  api.inputGoPayHelperLocalSmsEnabled.checked = true;
+  api.updatePlusModeUI();
+  assert.equal(api.selectGoPayHelperOtpChannel.value, 'sms');
+  assert.equal(api.rowGoPayHelperLocalSmsUrl.style.display, '');
 });
 
 test('sidepanel opens GPC card-key purchase page', () => {

--- a/tests/step-definitions-module.test.js
+++ b/tests/step-definitions-module.test.js
@@ -10,6 +10,7 @@ test('step definitions module exposes ordered normal and Plus step metadata', ()
   const steps = api.getSteps();
   const plusSteps = api.getSteps({ plusModeEnabled: true });
   const goPaySteps = api.getSteps({ plusModeEnabled: true, plusPaymentMethod: 'gopay' });
+  const gpcSteps = api.getSteps({ plusModeEnabled: true, plusPaymentMethod: 'gpc-helper' });
 
   assert.equal(Array.isArray(steps), true);
   assert.equal(steps.length, 10);
@@ -80,6 +81,26 @@ test('step definitions module exposes ordered normal and Plus step metadata', ()
   assert.equal(api.getLastStepId({ plusModeEnabled: true, plusPaymentMethod: 'gopay' }), 13);
   assert.equal(goPaySteps[5].title, '打开 GoPay 订阅页');
   assert.equal(goPaySteps[6].title, '等待 GoPay 订阅确认');
+
+  assert.deepStrictEqual(
+    gpcSteps.map((step) => step.key),
+    [
+      'open-chatgpt',
+      'submit-signup-email',
+      'fill-password',
+      'fetch-signup-code',
+      'fill-profile',
+      'plus-checkout-create',
+      'plus-checkout-billing',
+      'oauth-login',
+      'fetch-login-code',
+      'confirm-oauth',
+      'platform-verify',
+    ]
+  );
+  assert.deepStrictEqual(api.getStepIds({ plusModeEnabled: true, plusPaymentMethod: 'gpc-helper' }), [1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13]);
+  assert.equal(gpcSteps[5].title, '创建 GPC 订单');
+  assert.equal(gpcSteps[6].title, 'GPC OTP/PIN 验证');
 });
 
 test('sidepanel html loads shared step definitions before sidepanel bootstrap', () => {
@@ -98,6 +119,13 @@ test('sidepanel html exposes Plus mode payment controls and PayPal settings', ()
   assert.match(html, /id="select-plus-payment-method"/);
   assert.match(html, /<option value="paypal">PayPal 支付<\/option>/);
   assert.match(html, /<option value="gopay">GoPay 支付<\/option>/);
+  assert.match(html, /<option value="gpc-helper">GPC<\/option>/);
+  assert.match(html, /id="btn-gpc-card-key-purchase"/);
+  assert.match(html, />购买卡密</);
+  assert.match(html, /id="input-gpc-helper-card-key"/);
+  assert.match(html, /id="btn-gpc-helper-balance"/);
+  assert.match(html, /id="input-gpc-helper-phone"/);
+  assert.match(html, /id="input-gpc-helper-pin"/);
   assert.match(html, /id="select-paypal-account"/);
   assert.match(html, /id="btn-add-paypal-account"/);
   assert.match(html, /id="shared-form-modal"/);

--- a/tests/step-definitions-module.test.js
+++ b/tests/step-definitions-module.test.js
@@ -125,6 +125,9 @@ test('sidepanel html exposes Plus mode payment controls and PayPal settings', ()
   assert.match(html, /id="input-gpc-helper-card-key"/);
   assert.match(html, /id="btn-gpc-helper-balance"/);
   assert.match(html, /id="input-gpc-helper-phone"/);
+  assert.match(html, /id="select-gpc-helper-otp-channel"/);
+  assert.match(html, /id="input-gpc-helper-local-sms-enabled"/);
+  assert.match(html, /id="input-gpc-helper-local-sms-url"/);
   assert.match(html, /id="input-gpc-helper-pin"/);
   assert.match(html, /id="select-paypal-account"/);
   assert.match(html, /id="btn-add-paypal-account"/);


### PR DESCRIPTION
## Summary
- add GPC helper checkout support with manual phone mode and WhatsApp/SMS OTP channel payloads
- add sidepanel controls for OTP channel plus local macOS SMS helper URL and toggle
- add local macOS Messages HTTP helper for SMS OTP polling and auto-submit integration

## Testing
- node --check background.js background/message-router.js background/steps/create-plus-checkout.js background/steps/fill-plus-checkout.js gopay-utils.js sidepanel/sidepanel.js
- python3 -m py_compile scripts/gpc_sms_helper_macos.py
- npm test
