### PR TITLE
fix: 移除接码服务商下拉框里的开发提示文案

### DIFF
--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -986,9 +986,9 @@
             <div class="data-row" id="row-phone-sms-provider" style="display:none;">
               <span class="data-label">接码服务商</span>
               <select id="select-phone-sms-provider" class="data-select mono">
-                <option value="hero-sms">HeroSMS（原有）</option>
-                <option value="5sim">5sim（新增）</option>
-                <option value="nexsms">NexSMS（新增）</option>
+                <option value="hero-sms">HeroSMS</option>
+                <option value="5sim">5sim</option>
+                <option value="nexsms">NexSMS</option>
               </select>
             </div>
             <div class="data-row" id="row-phone-sms-provider-order" style="display:none;">

--- a/tests/sidepanel-phone-verification-settings.test.js
+++ b/tests/sidepanel-phone-verification-settings.test.js
@@ -61,6 +61,12 @@ test('sidepanel html exposes phone verification toggle and dedicated HeroSMS row
   assert.match(html, /id="input-phone-verification-enabled"/);
   assert.match(html, /id="row-phone-sms-provider"/);
   assert.match(html, /id="select-phone-sms-provider"/);
+  assert.match(html, /<option value="hero-sms">\s*HeroSMS\s*<\/option>/);
+  assert.match(html, /<option value="5sim">\s*5sim\s*<\/option>/);
+  assert.match(html, /<option value="nexsms">\s*NexSMS\s*<\/option>/);
+  assert.doesNotMatch(html, /HeroSMS（原有）/);
+  assert.doesNotMatch(html, /5sim（新增）/);
+  assert.doesNotMatch(html, /NexSMS（新增）/);
   assert.match(html, /id="row-phone-sms-provider-order"/);
   assert.match(html, /id="select-phone-sms-provider-order"[^>]*multiple/);
   assert.match(html, /id="btn-phone-sms-provider-order-menu"/);


### PR DESCRIPTION
## 本次改动
- 移除接码服务商下拉框里的开发环境提示文案，不再显示“原有”与“新增”
- 保留 HeroSMS、5sim、NexSMS 三个服务商选项值与顺序不变，只调整展示文本
- 补充 sidepanel HTML 断言测试，防止这些提示文案再次出现在用户界面

## 风险与影响
- 影响范围仅限 sidepanel 接码服务商下拉框展示文案
- 不涉及服务商选择逻辑、配置持久化或运行时流程变更

## 测试情况
- 已运行：`node --test tests/sidepanel-phone-verification-settings.test.js`