### PR TITLE
fix(gpc): 本地 Helper 支持 WhatsApp OTP

### DIFF
--- a/background/steps/fill-plus-checkout.js
+++ b/background/steps/fill-plus-checkout.js
@@ -423,8 +423,7 @@
       }
       await addLog(`步骤 7：GPC 模式开始 OTP 验证（reference_id: ${referenceId}）...`, 'info');
       let otp = '';
-      const useLocalSmsHelper = Boolean(state?.gopayHelperLocalSmsHelperEnabled)
-        && normalizeGpcOtpChannel(state?.gopayHelperOtpChannel) === 'sms';
+      const useLocalSmsHelper = Boolean(state?.gopayHelperLocalSmsHelperEnabled);
       if (useLocalSmsHelper) {
         try {
           await addLog('步骤 7：正在从本地 SMS Helper 等待 GPC OTP...', 'info');

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -323,17 +323,17 @@
         </select>
       </div>
       <div class="data-row" id="row-gpc-helper-local-sms-enabled" style="display:none;">
-        <span class="data-label">本地短信</span>
+        <span class="data-label">本地 OTP</span>
         <label class="toggle-switch">
           <input type="checkbox" id="input-gpc-helper-local-sms-enabled" />
           <span class="toggle-switch-track" aria-hidden="true">
             <span class="toggle-switch-thumb"></span>
           </span>
         </label>
-        <span class="setting-caption">从本机 macOS Messages helper 读取 SMS OTP</span>
+        <span class="setting-caption">从本机 helper 读取当前通道 OTP，失败后回退手动输入</span>
       </div>
       <div class="data-row" id="row-gpc-helper-local-sms-url" style="display:none;">
-        <span class="data-label">短信接口</span>
+        <span class="data-label">OTP 接口</span>
         <input type="text" id="input-gpc-helper-local-sms-url" class="data-input"
           placeholder="http://127.0.0.1:18767" autocomplete="off" />
       </div>

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -3147,7 +3147,7 @@ function collectSettingsPayload() {
       ? selectGpcHelperOtpChannel.value
       : (latestState?.gopayHelperOtpChannel || 'whatsapp')
   );
-  const selectedGpcLocalSmsHelperEnabled = selectedGpcOtpChannel === 'sms' && Boolean(
+  const selectedGpcLocalSmsHelperEnabled = Boolean(
     typeof inputGpcHelperLocalSmsEnabled !== 'undefined' && inputGpcHelperLocalSmsEnabled
       ? inputGpcHelperLocalSmsEnabled.checked
       : latestState?.gopayHelperLocalSmsHelperEnabled
@@ -7014,8 +7014,8 @@ function updatePlusModeUI() {
     ? normalizePlusPaymentMethod(selectPlusPaymentMethod.value)
     : method;
   const gpcRowsVisible = enabled && selectedMethod === gpcValue;
-  const localSmsControlsVisible = gpcRowsVisible && gpcOtpChannel === 'sms';
-  const effectiveLocalSmsEnabled = gpcOtpChannel === 'sms' && localSmsEnabled;
+  const localSmsControlsVisible = gpcRowsVisible;
+  const effectiveLocalSmsEnabled = localSmsEnabled;
   if (typeof selectPlusPaymentMethod !== 'undefined' && selectPlusPaymentMethod) {
     selectPlusPaymentMethod.value = method;
     if (selectPlusPaymentMethod.style) {
@@ -11229,9 +11229,6 @@ selectPlusPaymentMethod?.addEventListener('change', () => {
     scheduleSettingsAutoSave();
   });
   input?.addEventListener('change', () => {
-    if (input === inputGpcHelperLocalSmsEnabled && input.checked && selectGpcHelperOtpChannel) {
-      selectGpcHelperOtpChannel.value = 'sms';
-    }
     if (input === selectGpcHelperOtpChannel || input === inputGpcHelperLocalSmsEnabled) {
       updatePlusModeUI();
     }

--- a/tests/plus-checkout-billing-tab-resolution.test.js
+++ b/tests/plus-checkout-billing-tab-resolution.test.js
@@ -932,6 +932,65 @@ test('GPC billing reads OTP from local SMS helper when enabled', async () => {
   assert.equal(events.completed[0].step, 7);
 });
 
+test('GPC billing can read WhatsApp OTP from local helper when enabled', async () => {
+  const fetchCalls = [];
+  const { events, executor } = createExecutorHarness({
+    frames: [],
+    stateByFrame: {},
+    fetchImpl: async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      if (url.startsWith('http://127.0.0.1:18767/otp')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ ok: true, otp: '765432', message_id: 'wa-1' }),
+        };
+      }
+      if (url.endsWith('/api/gopay/otp')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ reference_id: 'ref_wa', challenge_id: 'challenge_wa' }),
+        };
+      }
+      if (url.endsWith('/api/gopay/pin')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ stage: 'gopay_complete' }),
+        };
+      }
+      throw new Error(`unexpected url: ${url}`);
+    },
+  });
+
+  await executor.executePlusCheckoutBilling({
+    plusPaymentMethod: 'gpc-helper',
+    plusCheckoutSource: 'gpc-helper',
+    gopayHelperReferenceId: 'ref_wa',
+    gopayHelperApiUrl: 'https://gopay.hwork.pro/',
+    gopayHelperPin: '654321',
+    gopayHelperCardKey: 'card_wa',
+    gopayHelperOtpChannel: 'whatsapp',
+    gopayHelperLocalSmsHelperEnabled: true,
+    gopayHelperLocalSmsHelperUrl: 'http://127.0.0.1:18767',
+    gopayHelperPhoneNumber: '+8613800138000',
+  });
+
+  assert.equal(events.states.some((state) => state.plusManualConfirmationMethod === 'gopay-otp'), false);
+  assert.equal(events.states.some((state) => state.gopayHelperResolvedOtp === '765432'), true);
+  const helperUrl = new URL(fetchCalls[0].url);
+  assert.equal(helperUrl.origin + helperUrl.pathname, 'http://127.0.0.1:18767/otp');
+  assert.equal(helperUrl.searchParams.get('reference_id'), 'ref_wa');
+  assert.equal(helperUrl.searchParams.get('phone_number'), '+8613800138000');
+  assert.deepEqual(JSON.parse(fetchCalls[1].options.body), {
+    reference_id: 'ref_wa',
+    otp: '765432',
+    card_key: 'card_wa',
+  });
+  assert.equal(events.completed[0].step, 7);
+});
+
 test('GPC billing retries OTP with compatibility field after HTTP 400', async () => {
   const fetchCalls = [];
   let currentState = {

--- a/tests/sidepanel-plus-payment-method.test.js
+++ b/tests/sidepanel-plus-payment-method.test.js
@@ -257,24 +257,20 @@ return {
   assert.equal(api.rows.rowGpcHelperCardKey.style.display, '');
   assert.equal(api.rows.rowGpcHelperPhone.style.display, '');
   assert.equal(api.rows.rowGpcHelperOtpChannel.style.display, '');
-  assert.equal(api.rows.rowGpcHelperLocalSmsEnabled.style.display, 'none');
+  assert.equal(api.rows.rowGpcHelperLocalSmsEnabled.style.display, '');
   assert.equal(api.rows.rowGpcHelperLocalSmsUrl.style.display, 'none');
   assert.match(api.plusPaymentMethodCaption.textContent, /GPC/);
 
-  api.selectGpcHelperOtpChannel.value = 'sms';
-  api.updatePlusModeUI();
-  assert.equal(api.rows.rowGpcHelperLocalSmsEnabled.style.display, '');
-  assert.equal(api.rows.rowGpcHelperLocalSmsUrl.style.display, 'none');
-
   api.inputGpcHelperLocalSmsEnabled.checked = true;
   api.updatePlusModeUI();
+  assert.equal(api.selectGpcHelperOtpChannel.value, 'whatsapp');
   assert.equal(api.rows.rowGpcHelperLocalSmsUrl.style.display, '');
 
-  api.selectGpcHelperOtpChannel.value = 'whatsapp';
+  api.selectGpcHelperOtpChannel.value = 'sms';
   api.updatePlusModeUI();
-  assert.equal(api.inputGpcHelperLocalSmsEnabled.checked, false);
-  assert.equal(api.rows.rowGpcHelperLocalSmsEnabled.style.display, 'none');
-  assert.equal(api.rows.rowGpcHelperLocalSmsUrl.style.display, 'none');
+  assert.equal(api.inputGpcHelperLocalSmsEnabled.checked, true);
+  assert.equal(api.rows.rowGpcHelperLocalSmsEnabled.style.display, '');
+  assert.equal(api.rows.rowGpcHelperLocalSmsUrl.style.display, '');
 
   api.selectPlusPaymentMethod.value = 'gopay';
   api.updatePlusModeUI();

--- a/项目完整链路说明.md
+++ b/项目完整链路说明.md
@@ -46,7 +46,7 @@
 - 查询 GitHub Releases 并展示更新卡片；当前更新服务会区分 `Ultra`、历史 `Pro` 与 legacy `v` 三个版本族，排序时固定以 `Ultra` 为最高正式系列，同时会在读取缓存后重新排序，避免历史 `Pro` 或 `v` 版本误显示为比 `Ultra` 更新
 - 展示一个单独的“接码”开关、注册方式 `signupMethod` 与“接码平台”下拉；接码平台当前支持 HeroSMS / 5sim / NexSMS。普通模式下开启接码后可把注册方式切到手机号注册，并在 OAuth 登录链路命中手机号登录验证码页时继续复用同一手机号续跑短信验证
 - 侧栏在接码卡内提供一个独立运行态“注册手机号”输入框，位于接码订单运行状态下方；第 2 步自动拿到号码后立即回填，用户手动接管手机号注册时也可以直接改写这一个运行态槽位。这个输入框表达账号身份，不等同于接码订单；后续自动拉短信仍依赖 `signupPhoneActivation / signupPhoneCompletedActivation`
-- 展示 `Plus 模式` 开关与 Plus 支付方式配置；支付方式支持 PayPal / GoPay / GPC，PayPal 展示账号池下拉与添加按钮，GoPay 展示手机号和 PIN，GPC 展示卡密、专用手机号、OTP 渠道、本地 macOS SMS helper 开关与 URL、PIN；步骤列表切换为 Plus 模式 13 步定义，普通模式的注册成功等待步骤不再显示或执行，登录验证码步骤会移动到 Plus 可见第 11 步
+- 展示 `Plus 模式` 开关与 Plus 支付方式配置；支付方式支持 PayPal / GoPay / GPC，PayPal 展示账号池下拉与添加按钮，GoPay 展示手机号和 PIN，GPC 展示卡密、专用手机号、OTP 渠道、本地 OTP helper 开关与 URL、PIN；步骤列表切换为 Plus 模式 13 步定义，普通模式的注册成功等待步骤不再显示或执行，登录验证码步骤会移动到 Plus 可见第 11 步
 - 为 Hotmail / 2925 账号池复用同一套“添加账号 / 取消添加 / 批量导入 / 收起列表”表单交互；共享的显隐控制放在 `sidepanel/account-pool-ui.js`，各自 manager 只保留 provider 相关字段校验与业务操作
 
 ### 2.2 Background Service Worker
@@ -548,7 +548,7 @@ Plus 模式可见步骤：
 
 1. 第 1~5 步：沿用普通注册入口、邮箱、密码、注册验证码、资料填写链路。
 2. 第 6 步 `创建 Plus Checkout`：打开已登录 ChatGPT 页面，通过 `/api/auth/session` 读取 accessToken，再请求 `https://chatgpt.com/backend-api/payments/checkout` 创建 `chatgptplusplan` 的 checkout session。PayPal 使用 `DE / EUR` 与 `https://chatgpt.com/checkout/openai_ie/{checkout_session_id}`；GoPay 使用 `ID / IDR` 与 `https://chatgpt.com/checkout/openai_llc/{checkout_session_id}`；GPC helper 模式改为把 accessToken、卡密、手机号、`otp_channel` 等提交给 helper API 创建 GPC 订单。
-3. 第 7 步 `填写账单并提交订阅`：按 `plusPaymentMethod` 选择 PayPal、GoPay 或 GPC。PayPal / GoPay 仍走 checkout 页面与 Stripe iframe 自动化；GPC helper 模式不再操作 checkout iframe，而是先提交 OTP，再提交 PIN。若侧栏启用本地 macOS SMS helper，后台会先轮询 `gopayHelperLocalSmsHelperUrl` 的 `/otp` 接口读取 SMS OTP，读取失败再回退到手动 OTP 输入弹窗。
+3. 第 7 步 `填写账单并提交订阅`：按 `plusPaymentMethod` 选择 PayPal、GoPay 或 GPC。PayPal / GoPay 仍走 checkout 页面与 Stripe iframe 自动化；GPC helper 模式不再操作 checkout iframe，而是先提交 OTP，再提交 PIN。若侧栏启用本地 OTP helper，后台会先轮询 `gopayHelperLocalSmsHelperUrl` 的 `/otp` 接口读取当前 OTP 通道的验证码，读取失败再回退到手动 OTP 输入弹窗；仓库内置的 `scripts/gpc_sms_helper_macos.py` 仍是 macOS Messages 短信读取实现，其他通道需要提供兼容的本地 `/otp` 接口。
 4. 第 8 步按当前支付方式显示为 `PayPal 登录与授权` 或 `GoPay 手机验证与授权`，底层 step key 仍为 `paypal-approve`。PayPal 模式后台优先读取侧边栏当前选中的 PayPal 账号；GoPay 模式读取侧边栏的国家区号、手机号、可选验证码和 PIN，先在 GoPay 页面填写手机号；验证码优先用侧边栏已填值，否则弹出插件输入框让用户手动填写，提交后继续填写 PIN。
 5. 第 9 步 `订阅回跳确认`：等待 PayPal / GoPay 授权后回跳到 ChatGPT / OpenAI 页面，页面加载完成后固定等待 1 秒。
 6. 第 10 步：复用原 Step 7 OAuth 登录执行器，但状态和日志按 Plus 可见第 10 步记录。

--- a/项目文件结构说明.md
+++ b/项目文件结构说明.md
@@ -150,7 +150,7 @@
   receive 模式把账号池开关一起隐藏；当前在 `邮箱生成` 区域新增 `自定义邮箱池` 选项和多行邮箱池输入框，并在 `邮箱服务 = 自定义邮箱` 时
   额外显示 `自定义号池` 文本框；当邮箱服务为 iCloud 时，额外提供目标邮箱类型与转发邮箱 provider 配置，用于选择直接从 iCloud 收件箱收
   码或从 QQ / 网易 / Gmail 转发目标邮箱收码；来源下拉框当前支持 `CPA / SUB2API / Codex2API`，其中 Codex2API 额外提供后台地址和管理密
-  钥配置行；设置卡片新增 `IP代理` 开关与代理配置折叠区，支持 711Proxy 账号密码模式、代理状态卡与出口检测按钮；接码卡内把注册方式、接码配置、接码订单运行态与“注册手机号”身份运行态分层展示，“注册手机号”位于订单运行状态下方，不嵌入当前分配/验证码网格；设置卡片新增 `Plus 模式` 开关与 PayPal 账号下拉框，右侧使用公共表单弹窗添加账号；GPC Plus 配置额外提供 OTP 渠道选择、本地 macOS SMS helper 开关和 helper URL；Hotmail / 2925 两个账号池当前都使用统一的头部“添加账号/取消添加”按钮和共享表单容器；设置卡片还新增“授权总超时”开关，用于控制 Step 7 后链 5 分钟总预算。
+  钥配置行；设置卡片新增 `IP代理` 开关与代理配置折叠区，支持 711Proxy 账号密码模式、代理状态卡与出口检测按钮；接码卡内把注册方式、接码配置、接码订单运行态与“注册手机号”身份运行态分层展示，“注册手机号”位于订单运行状态下方，不嵌入当前分配/验证码网格；设置卡片新增 `Plus 模式` 开关与 PayPal 账号下拉框，右侧使用公共表单弹窗添加账号；GPC Plus 配置额外提供 OTP 渠道选择、本地 OTP helper 开关和 helper URL；Hotmail / 2925 两个账号池当前都使用统一的头部“添加账号/取消添加”按钮和共享表单容器；设置卡片还新增“授权总超时”开关，用于控制 Step 7 后链 5 分钟总预算。
 - `sidepanel/paypal-manager.js`：侧边栏 PayPal 账号管理器，负责 Plus 模式下的账号下拉框渲染、添加账号弹窗、保存账号与切换当前账号。
 - `sidepanel/sidepanel.js`：侧边栏主入口脚本，负责 UI 状态同步、动态步骤渲染、按钮交互、共享验证码自动重发次数配置与广播接收，并装
   配 Hotmail / 2925 / iCloud / LuckMail / 贡献模式 / 账号记录面板 / 贡献内容更新服务；当前贡献模式的“开始贡献”会直接复用主自动流程启
@@ -215,7 +215,7 @@
 - `tests/paypal-approve-detection.test.js`：测试 Plus 第 8 步后台执行器对 PayPal 标签页发现、分离式账号/密码页识别、联合登录页识别，以及登录后直接离开 PayPal 页的分支判断。
 - `tests/paypal-flow-content.test.js`：测试 PayPal 内容脚本对可见邮箱/密码输入框的识别，并覆盖邮箱页即使已预填相同账号也会先清空再重填后继续下一步。
 - `tests/gpc-sms-helper-script.test.js`：测试 GPC macOS 本地短信 helper 在非 macOS 环境下会提示平台与 iPhone 短信转发要求。
-- `tests/plus-checkout-billing-tab-resolution.test.js`：测试 Plus 第 7 步可直接接管当前 checkout 标签页，并把 PayPal、账单地址、Google 地址推荐和订阅按钮操作路由到对应 Stripe iframe；当前也覆盖 GPC helper 的本地 SMS OTP 自动读取分支。
+- `tests/plus-checkout-billing-tab-resolution.test.js`：测试 Plus 第 7 步可直接接管当前 checkout 标签页，并把 PayPal、账单地址、Google 地址推荐和订阅按钮操作路由到对应 Stripe iframe；当前也覆盖 GPC helper 的本地 OTP 自动读取分支。
 - `tests/cloudflare-temp-email-provider.test.js`：测试 Cloudflare Temp Email provider 的轮询与目标邮箱选择逻辑。
 - `tests/cloudflare-temp-email-utils.test.js`：测试 Cloudflare Temp Email 工具层的 URL、域名、邮件解析逻辑。
 - `tests/content-utils.test.js`：测试内容脚本公共工具层对 `mail.126.com` 等网页邮箱来源的识别逻辑。


### PR DESCRIPTION
## 变更内容

- 放开 GPC 本地 SMS Helper 的通道限制，开启后 WhatsApp / SMS 都可以走本地 helper 取 OTP。
- 保持上游现有命名和 UI 文案，不引入新的 Helper 命名。
- 增加 WhatsApp 通道使用本地 helper 的回归测试，并更新侧边栏支付方式测试。

## 验证

- `git diff --check upstream/dev...HEAD`
- `node --check background/steps/fill-plus-checkout.js`
- `node --check sidepanel/sidepanel.js`
- `node --test tests/plus-checkout-billing-tab-resolution.test.js tests/sidepanel-plus-payment-method.test.js`
