### PR TITLE
修正 u6 手机号复用计数并同步兼容改动

### DIFF
--- a/background/phone-verification-flow.js
+++ b/background/phone-verification-flow.js
@@ -4759,6 +4759,54 @@
       );
     }
 
+    async function markFreeReusableActivationAfterInitialSuccess(state, activation) {
+      const normalizedActivation = normalizeActivation(activation);
+      if (
+        !normalizedActivation
+        || normalizedActivation.provider !== PHONE_SMS_PROVIDER_HERO
+        || isFreeAutoReuseActivation(normalizedActivation)
+      ) {
+        return;
+      }
+
+      const latestState = {
+        ...(state || {}),
+        ...(typeof getState === 'function' ? await getState() : {}),
+      };
+      const savedActivation = normalizeFreeReusablePhoneActivation(
+        latestState[FREE_REUSABLE_PHONE_ACTIVATION_STATE_KEY]
+      );
+      if (
+        !savedActivation
+        || !(
+          isSameActivation(savedActivation, normalizedActivation)
+          || phoneNumbersMatch(savedActivation.phoneNumber, normalizedActivation.phoneNumber)
+        )
+      ) {
+        return;
+      }
+
+      const maxUses = Math.max(1, Math.floor(Number(savedActivation.maxUses) || DEFAULT_PHONE_NUMBER_MAX_USES));
+      const successfulUses = Math.min(maxUses, Math.max(1, normalizeUseCount(savedActivation.successfulUses)));
+      if (successfulUses >= maxUses) {
+        await clearFreeReusableActivation();
+        await addLog(
+          `步骤 9：白嫖复用手机号 ${savedActivation.phoneNumber} 已达到 ${successfulUses}/${maxUses} 次，已清除本地记录。`,
+          'info'
+        );
+        return;
+      }
+
+      if (successfulUses !== savedActivation.successfulUses || savedActivation.maxUses !== maxUses) {
+        await persistFreeReusableActivation({
+          ...savedActivation,
+          source: 'free-manual-reuse',
+          successfulUses,
+          maxUses,
+        });
+      }
+    }
+
     async function waitForPhoneCodeOrRotateNumber(tabId, state, activation) {
       const normalizedActivation = normalizeActivation(activation);
       if (!normalizedActivation) {
@@ -6050,6 +6098,7 @@
                 `步骤 9：已跳过 HeroSMS 完成状态，保留 ${activation.phoneNumber} 供白嫖复用。`,
                 'info'
               );
+              await markFreeReusableActivationAfterInitialSuccess(latestSuccessState, activation);
             } else {
               await completePhoneActivation(latestSuccessState, activation);
             }

--- a/tests/phone-verification-flow.test.js
+++ b/tests/phone-verification-flow.test.js
@@ -4227,6 +4227,8 @@ test('phone verification helper preserves newly saved free-reuse activation afte
   assert.equal(currentState.freeReusablePhoneActivation.activationId, 'new-free-success');
   assert.equal(currentState.freeReusablePhoneActivation.phoneNumber, '66950007777');
   assert.equal(currentState.freeReusablePhoneActivation.source, 'free-manual-reuse');
+  assert.equal(currentState.freeReusablePhoneActivation.successfulUses, 1);
+  assert.equal(currentState.freeReusablePhoneActivation.maxUses, 3);
   assert.equal(
     requests.some((requestUrl) => (
       requestUrl.searchParams.get('action') === 'setStatus'


### PR DESCRIPTION
## 本次改动

- 补齐 u6 本地维护的 HeroSMS 白嫖复用、iCloud 稳定性、SUB2API 账号优先级、Step 6 等兼容改动，整理为一个上游 PR 提交。
- 修正白嫖复用手机号的最大使用次数语义：首次成功注册会计入 `successfulUses/maxUses`，避免界面显示 `0/3` 但实际可用 4 次。
- 增加和更新 phone flow、sidepanel、iCloud、SUB2API、Step 6 等相关回归测试。

## 风险与影响

- PR 覆盖范围较大，包含此前 u6 相对上游 `dev` 尚未合入的一批兼容改动。
- 接码复用逻辑的可见影响是：新保存的免费复用号码成功后会从 `1/3` 开始计数，`maxUses=3` 表示总共最多成功 3 次。
- 未改 SQL，未新增外部依赖。

## 测试情况

- `node --test tests/phone-verification-flow.test.js --test-name-pattern "preserves newly saved free-reuse activation"`：先验证新增断言能复现 `0 !== 1`，修复后通过。
- `node --test tests/phone-verification-flow.test.js --test-name-pattern "preserves newly saved free-reuse activation"`：64/64 通过。
- `npm test`：771/771 通过。
