### PR TITLE
fix(signup): restart phone signup on step 3 phone-exists errors

### DIFF
--- a/content/signup-page.js
+++ b/content/signup-page.js
@@ -2493,7 +2493,7 @@ const SIGNUP_PHONE_PASSWORD_MISMATCH_ERROR_PREFIX = 'SIGNUP_PHONE_PASSWORD_MISMA
 const AUTH_MAX_CHECK_ATTEMPTS_ERROR_PREFIX = 'AUTH_MAX_CHECK_ATTEMPTS::';
 const STEP8_EMAIL_IN_USE_ERROR_PREFIX = 'STEP8_EMAIL_IN_USE::';
 const SIGNUP_EMAIL_EXISTS_PATTERN = /与此电子邮件地址相关联的帐户已存在|account\s+associated\s+with\s+this\s+email\s+address\s+already\s+exists|email\s+address.*already\s+exists/i;
-const SIGNUP_PHONE_PASSWORD_MISMATCH_PATTERN = /incorrect\s+phone\s+number\s+or\s+password|phone\s+number\s+or\s+password/i;
+const SIGNUP_PHONE_PASSWORD_MISMATCH_PATTERN = /incorrect\s+phone\s+number\s+or\s+password|phone\s+number\s+or\s+password|与此(?:电话|手机)号码相关联的帐户已存在|account\s+associated\s+with\s+this\s+phone\s+number\s+already\s+exists/i;
 
 const authPageRecovery = self.MultiPageAuthPageRecovery?.createAuthPageRecovery?.({
   detailPattern: AUTH_TIMEOUT_ERROR_DETAIL_PATTERN,
@@ -2552,9 +2552,9 @@ function createSignupUserAlreadyExistsError() {
 
 function createSignupPhonePasswordMismatchError(detailText = '') {
   const detail = String(detailText || '').replace(/\s+/g, ' ').trim();
-  const suffix = detail ? `页面提示：${detail}` : '页面提示手机号或密码不正确。';
+  const suffix = detail ? `页面提示：${detail}` : '页面提示注册手机号不可继续使用，需重新开始当前轮。';
   return new Error(
-    `${SIGNUP_PHONE_PASSWORD_MISMATCH_ERROR_PREFIX}步骤 3：检测到注册手机号或密码不正确，需要重新开始当前轮。${suffix}`
+    `${SIGNUP_PHONE_PASSWORD_MISMATCH_ERROR_PREFIX}步骤 3：检测到注册手机号异常，需要重新开始当前轮。${suffix}`
   );
 }
 

--- a/tests/step4-split-code-submit.test.js
+++ b/tests/step4-split-code-submit.test.js
@@ -806,3 +806,92 @@ return {
   assert.equal(result.clicks.length, 0);
   assert.equal(result.logs.some(({ message }) => /检测到密码页报错/.test(message)), true);
 });
+
+test('prepareSignupVerificationFlow stops immediately when password page shows phone already exists error', async () => {
+  const api = new Function(`
+const logs = [];
+const clicks = [];
+let now = 0;
+
+Date.now = () => now;
+
+function throwIfStopped() {}
+function log(message, level = 'info') { logs.push({ message, level }); }
+async function sleep(ms = 0) { now += ms || 200; }
+function isVisibleElement() { return true; }
+function isActionEnabled() { return true; }
+function getActionText(el) { return el?.textContent || ''; }
+function getCurrentAuthRetryPageState() { return null; }
+function isPhoneVerificationPageReady() { return false; }
+function findResendVerificationCodeTrigger() { return null; }
+function isEmailVerificationPage() { return false; }
+function getPageTextSnapshot() { return '与此电话号码相关联的帐户已存在'; }
+function getVerificationCodeTarget() { return null; }
+function is405MethodNotAllowedPage() { return false; }
+async function recoverCurrentAuthRetryPage() {}
+function createSignupUserAlreadyExistsError() { return new Error('user already exists'); }
+function getSignupPasswordInput() { return { value: 'Secret123!' }; }
+function getSignupPasswordSubmitButton() { return { textContent: 'Continue' }; }
+function isSignupEmailAlreadyExistsPage() { return false; }
+function isSignupPasswordErrorPage() { return false; }
+function getSignupPasswordTimeoutErrorPageState() { return null; }
+function isStep5Ready() { return false; }
+function getSignupPasswordFieldErrorText() { return '与此电话号码相关联的帐户已存在'; }
+function simulateClick(target) { clicks.push(target?.textContent || 'clicked'); }
+async function humanPause() {}
+function fillInput() {}
+function logSignupPasswordDiagnostics() {}
+function createSignupPhonePasswordMismatchError(detailText = '') {
+  return new Error('SIGNUP_PHONE_PASSWORD_MISMATCH::' + detailText);
+}
+
+const location = {
+  href: 'https://auth.openai.com/log-in/password',
+  pathname: '/log-in/password',
+};
+const document = {
+  readyState: 'complete',
+  title: '',
+  body: {
+    textContent: '与此电话号码相关联的帐户已存在',
+    innerText: '与此电话号码相关联的帐户已存在',
+  },
+  querySelector() {
+    return null;
+  },
+  querySelectorAll() {
+    return [];
+  },
+};
+
+${extractFunction('isSignupVerificationPageInteractiveReady')}
+${extractFunction('isVerificationPageStillVisible')}
+${extractFunction('isSignupProfilePageUrl')}
+${extractFunction('isLikelyLoggedInChatgptHomeUrl')}
+${extractFunction('getStep4PostVerificationState')}
+${extractFunction('inspectSignupVerificationState')}
+${extractFunction('waitForSignupVerificationTransition')}
+${extractFunction('prepareSignupVerificationFlow')}
+
+return {
+  async run() {
+    try {
+      await prepareSignupVerificationFlow({
+        password: 'Secret123!',
+        prepareLogLabel: '步骤 3 收尾',
+      }, 10000);
+      return { threw: false, logs, clicks };
+    } catch (error) {
+      return { threw: true, error: error.message, logs, clicks };
+    }
+  },
+};
+`)();
+
+  const result = await api.run();
+
+  assert.equal(result.threw, true);
+  assert.match(result.error, /SIGNUP_PHONE_PASSWORD_MISMATCH::与此电话号码相关联的帐户已存在/);
+  assert.equal(result.clicks.length, 0);
+  assert.equal(result.logs.some(({ message }) => /检测到密码页报错/.test(message)), true);
+});


### PR DESCRIPTION
<img width="2514" height="1378" alt="image" src="https://github.com/user-attachments/assets/9d532a28-a71e-47dd-86a2-be24b78e9ad3" />
Title

fix(signup): restart phone signup when step 3 shows phone already exists

Summary

这个 PR 修复了手机号注册模式下 Step 3 的一个异常场景：当密码页出现“与此电话号码相关联的帐户已存在”或对应英文文案时，流程现在会将其识别为与现有 SIGNUP_PHONE_PASSWORD_MISMATCH 相同的可重开错误，立即结束当前提交尝试并回到整轮重开逻辑，而不是继续停留在密码页反复点击“继续”。

同时补充了一条回归测试，覆盖中文“电话号码已关联账户存在”的页面报错，确保后续修改不会让这类场景重新退化成密码页重试循环。

Verification

运行了：

npm test -- tests/step4-split-code-submit.test.js tests/signup-verification-state-guard.test.js tests/signup-entry-diagnostics.test.js

结果：

785/785 通过