### PR TITLE
fix(signup): restart phone signup on step 3 phone-exists errors

### DIFF
--- a/background.js
+++ b/background.js
@@ -7441,7 +7441,7 @@ function isRestartCurrentAttemptError(error) {
 
 function isSignupPhonePasswordMismatchFailure(error) {
   const message = getErrorMessage(error);
-  return /SIGNUP_PHONE_PASSWORD_MISMATCH::/i.test(message);
+  return /SIGNUP_PHONE_PASSWORD_MISMATCH::|SIGNUP_PHONE_ALREADY_EXISTS::/i.test(message);
 }
 
 function getSignupPhonePasswordMismatchRestartPayload(preservedState = {}) {

--- a/background.js
+++ b/background.js
@@ -7436,7 +7436,7 @@ function isRestartCurrentAttemptError(error) {
     return loggingStatus.isRestartCurrentAttemptError(error);
   }
   const message = String(typeof error === 'string' ? error : error?.message || '');
-  return /当前邮箱已存在，需要重新开始新一轮|SIGNUP_PHONE_PASSWORD_MISMATCH::/i.test(message);
+  return /当前邮箱已存在，需要重新开始新一轮|SIGNUP_PHONE_PASSWORD_MISMATCH::|SIGNUP_PHONE_ALREADY_EXISTS::/i.test(message);
 }
 
 function isSignupPhonePasswordMismatchFailure(error) {

--- a/background/logging-status.js
+++ b/background/logging-status.js
@@ -113,7 +113,7 @@
 
     function isRestartCurrentAttemptError(error) {
       const message = String(typeof error === 'string' ? error : error?.message || '');
-      return /当前邮箱已存在，需要重新开始新一轮|SIGNUP_PHONE_PASSWORD_MISMATCH::/i.test(message);
+      return /当前邮箱已存在，需要重新开始新一轮|SIGNUP_PHONE_PASSWORD_MISMATCH::|SIGNUP_PHONE_ALREADY_EXISTS::/i.test(message);
     }
 
     function isSignupUserAlreadyExistsFailure(error) {

--- a/background/message-router.js
+++ b/background/message-router.js
@@ -591,7 +591,7 @@
           }
           const currentState = await getState();
           const currentStepStatus = currentState?.stepStatuses?.[message.step] || '';
-          const isSignupPhonePasswordMismatch = /SIGNUP_PHONE_PASSWORD_MISMATCH::/i.test(String(message.error || ''));
+          const isSignupPhonePasswordMismatch = /SIGNUP_PHONE_PASSWORD_MISMATCH::|SIGNUP_PHONE_ALREADY_EXISTS::/i.test(String(message.error || ''));
           if (isStopError(message.error)) {
             await setStepStatus(message.step, 'stopped');
             await addLog('已被用户停止', 'warn', { step: message.step });

--- a/content/signup-page.js
+++ b/content/signup-page.js
@@ -2490,10 +2490,18 @@ const STEP4_405_RECOVERY_ERROR_PREFIX = 'STEP4_405_RECOVERY_LIMIT::';
 const STEP4_405_RECOVERY_LIMIT = 3;
 const SIGNUP_USER_ALREADY_EXISTS_ERROR_PREFIX = 'SIGNUP_USER_ALREADY_EXISTS::';
 const SIGNUP_PHONE_PASSWORD_MISMATCH_ERROR_PREFIX = 'SIGNUP_PHONE_PASSWORD_MISMATCH::';
+const SIGNUP_PHONE_ALREADY_EXISTS_ERROR_PREFIX = 'SIGNUP_PHONE_ALREADY_EXISTS::';
 const AUTH_MAX_CHECK_ATTEMPTS_ERROR_PREFIX = 'AUTH_MAX_CHECK_ATTEMPTS::';
 const STEP8_EMAIL_IN_USE_ERROR_PREFIX = 'STEP8_EMAIL_IN_USE::';
 const SIGNUP_EMAIL_EXISTS_PATTERN = /与此电子邮件地址相关联的帐户已存在|account\s+associated\s+with\s+this\s+email\s+address\s+already\s+exists|email\s+address.*already\s+exists/i;
 const SIGNUP_PHONE_PASSWORD_MISMATCH_PATTERN = /incorrect\s+phone\s+number\s+or\s+password|phone\s+number\s+or\s+password/i;
+const SIGNUP_PHONE_ALREADY_EXISTS_PATTERN = /an\s+account\s+for\s+this\s+phone\s+number\s+already\s+exists|phone\s+number\s+already\s+exists|account\s+for\s+this\s+phone\s+number\s+already\s+exists|this\s+phone\s+number\s+already\s+exists|phone\s+number.*already\s+exists/i;
+
+function isSignupPhoneAlreadyExistsErrorText(text) {
+  const normalized = String(text || '').toLowerCase();
+  return normalized.includes('already exists')
+    && (normalized.includes('phone') || normalized.includes('account'));
+}
 
 const authPageRecovery = self.MultiPageAuthPageRecovery?.createAuthPageRecovery?.({
   detailPattern: AUTH_TIMEOUT_ERROR_DETAIL_PATTERN,
@@ -2558,6 +2566,14 @@ function createSignupPhonePasswordMismatchError(detailText = '') {
   );
 }
 
+function createSignupPhoneAlreadyExistsError(detailText = '') {
+  const detail = String(detailText || '').replace(/\s+/g, ' ').trim();
+  const suffix = detail ? `页面提示：${detail}` : '页面提示当前手机号已存在。';
+  return new Error(
+    `${SIGNUP_PHONE_ALREADY_EXISTS_ERROR_PREFIX}步骤 3：检测到注册手机号已存在，需要从步骤 1 重新开始当前轮。${suffix}`
+  );
+}
+
 function createAuthMaxCheckAttemptsError() {
   return new Error(`${AUTH_MAX_CHECK_ATTEMPTS_ERROR_PREFIX}max_check_attempts on auth retry page; restart the current auth step without clicking Retry.`);
 }
@@ -2593,7 +2609,7 @@ function getVisibleFieldErrorText() {
 
 function getSignupPasswordFieldErrorText() {
   const text = getVisibleFieldErrorText();
-  if (text && SIGNUP_PHONE_PASSWORD_MISMATCH_PATTERN.test(text)) {
+  if (text && (SIGNUP_PHONE_PASSWORD_MISMATCH_PATTERN.test(text) || isSignupPhoneAlreadyExistsErrorText(text))) {
     return text;
   }
 
@@ -2601,7 +2617,7 @@ function getSignupPasswordFieldErrorText() {
   if (passwordInput) {
     const wrapper = passwordInput.closest('form, [data-rac], [role="group"], section, div');
     const wrapperText = (wrapper?.textContent || '').replace(/\s+/g, ' ').trim();
-    if (wrapperText && SIGNUP_PHONE_PASSWORD_MISMATCH_PATTERN.test(wrapperText)) {
+    if (wrapperText && (SIGNUP_PHONE_PASSWORD_MISMATCH_PATTERN.test(wrapperText) || isSignupPhoneAlreadyExistsErrorText(wrapperText))) {
       return wrapperText;
     }
   }
@@ -4541,6 +4557,9 @@ async function prepareSignupVerificationFlow(payload = {}, timeout = 30000) {
     if (snapshot.state === 'password') {
       if (snapshot.passwordErrorText) {
         log(`${prepareLogLabel}：检测到密码页报错“${snapshot.passwordErrorText}”，当前轮将回到步骤 1 重新开始。`, 'warn');
+        if (isSignupPhoneAlreadyExistsErrorText(snapshot.passwordErrorText)) {
+          throw createSignupPhoneAlreadyExistsError(snapshot.passwordErrorText);
+        }
         throw createSignupPhonePasswordMismatchError(snapshot.passwordErrorText);
       }
       if (!passwordPageDiagnosticsLogged) {

--- a/content/signup-page.js
+++ b/content/signup-page.js
@@ -4558,8 +4558,10 @@ async function prepareSignupVerificationFlow(payload = {}, timeout = 30000) {
       if (snapshot.passwordErrorText) {
         log(`${prepareLogLabel}：检测到密码页报错“${snapshot.passwordErrorText}”，当前轮将回到步骤 1 重新开始。`, 'warn');
         if (isSignupPhoneAlreadyExistsErrorText(snapshot.passwordErrorText)) {
+          log(`${prepareLogLabel}：检测到“手机号已存在”报错，准备直接回到步骤 1 重开当前轮。`, 'warn');
           throw createSignupPhoneAlreadyExistsError(snapshot.passwordErrorText);
         }
+        log(`${prepareLogLabel}：检测到“手机号/密码不匹配”报错，准备直接回到步骤 1 重开当前轮。`, 'warn');
         throw createSignupPhonePasswordMismatchError(snapshot.passwordErrorText);
       }
       if (!passwordPageDiagnosticsLogged) {

--- a/tests/auto-run-fresh-attempt-reset.test.js
+++ b/tests/auto-run-fresh-attempt-reset.test.js
@@ -290,6 +290,10 @@ const runtime = {
   },
 };
 
+if (!isRestartCurrentAttemptError(new Error('SIGNUP_PHONE_ALREADY_EXISTS::步骤 3：检测到注册手机号已存在，需要从步骤 1 重新开始当前轮。页面提示：An account for this phone number already exists'))) {
+  throw new Error('phone already exists should be treated as a restart-current-attempt error');
+}
+
 const controller = self.MultiPageBackgroundAutoRunController.createAutoRunController({
   addLog,
   AUTO_RUN_MAX_RETRIES_PER_ROUND,

--- a/tests/auto-run-step4-restart.test.js
+++ b/tests/auto-run-step4-restart.test.js
@@ -623,6 +623,164 @@ return {
   assert.equal(events.logs.some(({ message }) => /已清空本轮注册手机号与接码订单/.test(message)), true);
 });
 
+test('auto-run clears fetched signup phone state before restarting when step 4 detects phone already exists', async () => {
+  const api = new Function(`
+const AUTO_STEP_DELAYS = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0, 9: 0, 10: 0 };
+const LAST_STEP_ID = 10;
+const FINAL_OAUTH_CHAIN_START_STEP = 7;
+const SIGNUP_METHOD_PHONE = 'phone';
+const chrome = {
+  tabs: {
+    update: async () => {},
+  },
+  runtime: {
+    sendMessage: async () => {},
+  },
+};
+
+let remainingFailures = 1;
+let currentState = {
+  email: '',
+  password: 'Secret123!',
+  signupMethod: 'phone',
+  accountIdentifierType: 'phone',
+  accountIdentifier: '+56988841722',
+  signupPhoneNumber: '+56988841722',
+  signupPhoneActivation: { activationId: 'signup-activation', phoneNumber: '+56988841722' },
+  signupPhoneCompletedActivation: { activationId: 'signup-completed', phoneNumber: '+56988841722' },
+  signupPhoneVerificationRequestedAt: 123456,
+  signupPhoneVerificationPurpose: 'signup',
+  stepStatuses: {
+    1: 'pending',
+    2: 'pending',
+    3: 'pending',
+    4: 'pending',
+    5: 'pending',
+    6: 'pending',
+    7: 'pending',
+    8: 'pending',
+    9: 'pending',
+    10: 'pending',
+  },
+};
+const events = {
+  steps: [],
+  invalidations: [],
+  logs: [],
+  setStateCalls: [],
+};
+
+async function addLog(message, level = 'info') {
+  events.logs.push({ message, level });
+}
+
+async function ensureAutoEmailReady() {
+  return '';
+}
+
+async function broadcastAutoRunStatus() {}
+async function ensureResolvedSignupMethodForRun() { return 'phone'; }
+
+async function getState() {
+  return currentState;
+}
+
+async function setState(updates) {
+  currentState = {
+    ...currentState,
+    ...updates,
+    stepStatuses: updates.stepStatuses ? { ...updates.stepStatuses } : currentState.stepStatuses,
+  };
+  events.setStateCalls.push(updates);
+}
+
+function isStopError(error) {
+  return (error?.message || String(error || '')) === '流程已被用户停止。';
+}
+
+function isStepDoneStatus(status) {
+  return status === 'completed' || status === 'manual_completed' || status === 'skipped';
+}
+
+async function executeStepAndWait(step) {
+  events.steps.push(step);
+  if (step === 4 && remainingFailures > 0) {
+    remainingFailures -= 1;
+    throw new Error('SIGNUP_PHONE_ALREADY_EXISTS::步骤 3：检测到注册手机号已存在，需要从步骤 1 重新开始当前轮。页面提示：An account for this phone number already exists');
+  }
+}
+
+async function getTabId() {
+  return 1;
+}
+
+async function invalidateDownstreamAfterStepRestart(step, options = {}) {
+  events.invalidations.push({ step, options });
+  currentState = {
+    ...currentState,
+    password: null,
+    stepStatuses: {
+      1: currentState.stepStatuses[1] || 'completed',
+      2: 'pending',
+      3: 'pending',
+      4: 'pending',
+      5: 'pending',
+      6: 'pending',
+      7: 'pending',
+      8: 'pending',
+      9: 'pending',
+      10: 'pending',
+    },
+  };
+}
+
+function getLoginAuthStateLabel(state) {
+  return state || 'unknown';
+}
+
+function getErrorMessage(error) {
+  return error?.message || String(error || '');
+}
+
+async function getLoginAuthStateFromContent() {
+  return { state: 'password_page', url: 'https://auth.openai.com/log-in' };
+}
+
+${bundle}
+
+return {
+  async run() {
+    await runAutoSequenceFromStep(1, {
+      targetRun: 1,
+      totalRuns: 1,
+      attemptRuns: 1,
+      continued: false,
+    });
+    return { events, currentState };
+  },
+};
+`)();
+
+  const { events, currentState } = await api.run();
+
+  assert.deepStrictEqual(events.invalidations, [
+    {
+      step: 1,
+      options: {
+        logLabel: '步骤 4 检测到手机号/密码不匹配后准备回到步骤 1 重新获取手机号重试（第 1 次重开）',
+      },
+    },
+  ]);
+  assert.equal(currentState.signupPhoneNumber, '');
+  assert.equal(currentState.signupPhoneActivation, null);
+  assert.equal(currentState.signupPhoneCompletedActivation, null);
+  assert.equal(currentState.accountIdentifierType, null);
+  assert.equal(currentState.accountIdentifier, '');
+  assert.equal(currentState.password, 'Secret123!');
+  assert.equal(events.logs.some(({ message }) => /丢弃当前注册手机号并回到步骤 1 重新开始/.test(message)), true);
+  assert.equal(events.logs.some(({ message }) => /已清空本轮注册手机号与接码订单/.test(message)), true);
+});
+
 test('auto-run clears manual signup phone state when step 3 detects phone/password mismatch', async () => {
   const api = new Function(`
 const AUTO_STEP_DELAYS = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0, 9: 0, 10: 0 };
@@ -705,6 +863,163 @@ async function executeStepAndWait(step) {
   if (step === 3 && remainingFailures > 0) {
     remainingFailures -= 1;
     throw new Error('SIGNUP_PHONE_PASSWORD_MISMATCH::步骤 3：检测到注册手机号或密码不正确，需要重新开始当前轮。页面提示：Incorrect phone number or password');
+  }
+}
+
+async function getTabId() {
+  return 1;
+}
+
+async function invalidateDownstreamAfterStepRestart(step, options = {}) {
+  events.invalidations.push({ step, options });
+  currentState = {
+    ...currentState,
+    password: null,
+    stepStatuses: {
+      1: currentState.stepStatuses[1] || 'completed',
+      2: 'pending',
+      3: 'pending',
+      4: 'pending',
+      5: 'pending',
+      6: 'pending',
+      7: 'pending',
+      8: 'pending',
+      9: 'pending',
+      10: 'pending',
+    },
+  };
+}
+
+function getLoginAuthStateLabel(state) {
+  return state || 'unknown';
+}
+
+function getErrorMessage(error) {
+  return error?.message || String(error || '');
+}
+
+async function getLoginAuthStateFromContent() {
+  return { state: 'password_page', url: 'https://auth.openai.com/log-in' };
+}
+
+${bundle}
+
+return {
+  async run() {
+    await runAutoSequenceFromStep(1, {
+      targetRun: 1,
+      totalRuns: 1,
+      attemptRuns: 1,
+      continued: false,
+    });
+    return { events, currentState };
+  },
+};
+`)();
+
+  const { events, currentState } = await api.run();
+
+  assert.deepStrictEqual(events.steps, [1, 2, 3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  assert.deepStrictEqual(events.invalidations, [
+    {
+      step: 1,
+      options: {
+        logLabel: '步骤 3 检测到手机号/密码不匹配后准备回到步骤 1 重新获取手机号重试（第 1 次重开）',
+      },
+    },
+  ]);
+  assert.equal(currentState.signupPhoneNumber, '');
+  assert.equal(currentState.signupPhoneActivation, null);
+  assert.equal(currentState.signupPhoneCompletedActivation, null);
+  assert.equal(currentState.accountIdentifierType, null);
+  assert.equal(currentState.accountIdentifier, '');
+  assert.equal(currentState.password, 'Secret123!');
+  assert.equal(events.logs.some(({ message }) => /步骤 3：检测到手机号\/密码不匹配/.test(message)), true);
+  assert.equal(events.logs.some(({ message }) => /步骤 3：已清空本轮注册手机号与接码订单/.test(message)), true);
+});
+
+test('auto-run clears manual signup phone state when step 3 detects phone already exists', async () => {
+  const api = new Function(`
+const AUTO_STEP_DELAYS = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0, 9: 0, 10: 0 };
+const LAST_STEP_ID = 10;
+const FINAL_OAUTH_CHAIN_START_STEP = 7;
+const SIGNUP_METHOD_PHONE = 'phone';
+const chrome = {
+  tabs: {
+    update: async () => {},
+  },
+  runtime: {
+    sendMessage: async () => {},
+  },
+};
+
+let remainingFailures = 1;
+let currentState = {
+  email: '',
+  password: 'Secret123!',
+  signupMethod: 'phone',
+  accountIdentifierType: 'phone',
+  accountIdentifier: '+56988841722',
+  signupPhoneNumber: '+56988841722',
+  signupPhoneActivation: null,
+  signupPhoneCompletedActivation: null,
+  stepStatuses: {
+    1: 'pending',
+    2: 'pending',
+    3: 'pending',
+    4: 'pending',
+    5: 'pending',
+    6: 'pending',
+    7: 'pending',
+    8: 'pending',
+    9: 'pending',
+    10: 'pending',
+  },
+};
+const events = {
+  steps: [],
+  invalidations: [],
+  logs: [],
+  setStateCalls: [],
+};
+
+async function addLog(message, level = 'info') {
+  events.logs.push({ message, level });
+}
+
+async function ensureAutoEmailReady() {
+  return '';
+}
+
+async function broadcastAutoRunStatus() {}
+async function ensureResolvedSignupMethodForRun() { return 'phone'; }
+
+async function getState() {
+  return currentState;
+}
+
+async function setState(updates) {
+  currentState = {
+    ...currentState,
+    ...updates,
+    stepStatuses: updates.stepStatuses ? { ...updates.stepStatuses } : currentState.stepStatuses,
+  };
+  events.setStateCalls.push(updates);
+}
+
+function isStopError(error) {
+  return (error?.message || String(error || '')) === '流程已被用户停止。';
+}
+
+function isStepDoneStatus(status) {
+  return status === 'completed' || status === 'manual_completed' || status === 'skipped';
+}
+
+async function executeStepAndWait(step) {
+  events.steps.push(step);
+  if (step === 3 && remainingFailures > 0) {
+    remainingFailures -= 1;
+    throw new Error('SIGNUP_PHONE_ALREADY_EXISTS::步骤 3：检测到注册手机号已存在，需要从步骤 1 重新开始当前轮。页面提示：An account for this phone number already exists');
   }
 }
 

--- a/tests/step4-submit-retry-recovery.test.js
+++ b/tests/step4-submit-retry-recovery.test.js
@@ -268,18 +268,27 @@ ${extractFunction('inspectSignupVerificationState')}
 ${extractFunction('prepareSignupVerificationFlow')}
 
 return {
-  run() {
-    return prepareSignupVerificationFlow({
-      password: 'Secret123!',
-      prepareLogLabel: '步骤 3 收尾',
-    }, 10000);
+  async run() {
+    try {
+      await prepareSignupVerificationFlow({
+        password: 'Secret123!',
+        prepareLogLabel: '步骤 3 收尾',
+      }, 10000);
+      return { threw: false, logs };
+    } catch (error) {
+      return { threw: true, error: error.message, logs };
+    }
   },
 };
 `)();
 
-  await assert.rejects(
-    api.run(),
-    /SIGNUP_PHONE_ALREADY_EXISTS::An account for this phone number already exists/
+  const result = await api.run();
+
+  assert.equal(result.threw, true);
+  assert.match(result.error, /SIGNUP_PHONE_ALREADY_EXISTS::An account for this phone number already exists/);
+  assert.equal(
+    result.logs.some(({ message }) => /检测到“手机号已存在”报错，准备直接回到步骤 1 重开当前轮/.test(message)),
+    true
   );
 });
 

--- a/tests/step4-submit-retry-recovery.test.js
+++ b/tests/step4-submit-retry-recovery.test.js
@@ -68,6 +68,12 @@ function isVerificationPageStillVisible() { return false; }
 function createSignupUserAlreadyExistsError() {
   return new Error('SIGNUP_USER_ALREADY_EXISTS::步骤 4：检测到 user_already_exists，说明当前用户已存在，当前轮将直接停止。');
 }
+function createSignupPhonePasswordMismatchError(detailText = '') {
+  return new Error('SIGNUP_PHONE_PASSWORD_MISMATCH::' + detailText);
+}
+function createSignupPhoneAlreadyExistsError(detailText = '') {
+  return new Error('SIGNUP_PHONE_ALREADY_EXISTS::' + detailText);
+}
 function getCurrentAuthRetryPageState(flow) {
   if (flow === 'signup' && retryVisible) {
     return {
@@ -197,6 +203,84 @@ return {
     skipProfileStep: true,
     url: 'https://chatgpt.com/',
   });
+});
+
+test('prepareSignupVerificationFlow restarts current attempt when password page shows phone already exists', async () => {
+  const api = new Function(`
+const logs = [];
+const clicks = [];
+let now = 0;
+
+Date.now = () => now;
+
+let retryVisible = false;
+const location = {
+  href: 'https://auth.openai.com/create-account/password',
+  pathname: '/create-account/password',
+};
+
+function throwIfStopped() {}
+function log(message, level = 'info') { logs.push({ message, level }); }
+async function sleep(ms = 0) { now += ms || 200; }
+function getVerificationErrorText() { return ''; }
+function isStep5Ready() { return false; }
+function isStep8Ready() { return false; }
+function isAddPhonePageReady() { return false; }
+function isVerificationPageStillVisible() { return false; }
+function isDocumentLoadComplete() { return true; }
+function isVisibleElement() { return true; }
+function isActionEnabled() { return true; }
+function getActionText(el) { return el?.textContent || ''; }
+function createSignupUserAlreadyExistsError() {
+  return new Error('SIGNUP_USER_ALREADY_EXISTS::步骤 4：检测到 user_already_exists，说明当前用户已存在，当前轮将直接停止。');
+}
+function createSignupPhonePasswordMismatchError(detailText = '') {
+  return new Error('SIGNUP_PHONE_PASSWORD_MISMATCH::' + detailText);
+}
+function createSignupPhoneAlreadyExistsError(detailText = '') {
+  return new Error('SIGNUP_PHONE_ALREADY_EXISTS::' + detailText);
+}
+function getCurrentAuthRetryPageState() { return null; }
+function getSignupPasswordInput() { return { value: 'Secret123!' }; }
+function getSignupPasswordSubmitButton() { return { textContent: 'Continue' }; }
+function getSignupPasswordFieldErrorText() { return 'An account for this phone number already exists'; }
+const SIGNUP_PHONE_ALREADY_EXISTS_PATTERN = /an\s+account\s+for\s+this\s+phone\s+number\s+already\s+exists|phone\s+number\s+already\s+exists|account\s+for\s+this\s+phone\s+number\s+already\s+exists|this\s+phone\s+number\s+already\s+exists|phone\s+number.*already\s+exists/i;
+function isSignupPhoneAlreadyExistsErrorText(text) {
+  const normalized = String(text || '').toLowerCase();
+  return normalized.includes('already exists')
+    && (normalized.includes('phone') || normalized.includes('account'));
+}
+function getSignupPasswordTimeoutErrorPageState() { return null; }
+function isSignupEmailAlreadyExistsPage() { return false; }
+function isSignupPasswordErrorPage() { return false; }
+function getVerificationCodeTarget() { return null; }
+function simulateClick(target) { clicks.push(target?.textContent || 'clicked'); }
+async function humanPause() {}
+function fillInput() {}
+function logSignupPasswordDiagnostics() {}
+function getStep4PostVerificationState() { return null; }
+
+${extractFunction('isSignupProfilePageUrl')}
+${extractFunction('isLikelyLoggedInChatgptHomeUrl')}
+${extractFunction('isSignupVerificationPageInteractiveReady')}
+${extractFunction('waitForSignupVerificationTransition')}
+${extractFunction('inspectSignupVerificationState')}
+${extractFunction('prepareSignupVerificationFlow')}
+
+return {
+  run() {
+    return prepareSignupVerificationFlow({
+      password: 'Secret123!',
+      prepareLogLabel: '步骤 3 收尾',
+    }, 10000);
+  },
+};
+`)();
+
+  await assert.rejects(
+    api.run(),
+    /SIGNUP_PHONE_ALREADY_EXISTS::An account for this phone number already exists/
+  );
 });
 
 test('waitForVerificationSubmitOutcome treats step 5 as success after submit even when verification ui residue remains', async () => {


### PR DESCRIPTION
## 本次改动
- 处理手机号注册链路第 3 步密码页出现 `An account for this phone number already exists` 的场景，直接识别为需要重开当前轮，而不是继续停留在密码页重试
- 为这类报错补充独立的 `SIGNUP_PHONE_ALREADY_EXISTS::` 错误前缀，并在 content/background 两侧统一归类为“回到步骤 1 重新开始当前轮”
- 补充回归测试，覆盖密码页手机号已存在报错，以及自动运行对该错误的重开分类

## 风险与影响
- 影响范围集中在手机号注册模式下步骤 3 提交密码后的异常分支识别，以及自动运行的失败分类逻辑
- 正常的手机号/密码不匹配分支保持不变；`user_already_exists` 的整轮失败逻辑也保持不变

## 测试情况
- 已运行：`node --test tests/step4-submit-retry-recovery.test.js tests/auto-run-fresh-attempt-reset.test.js tests/auto-run-step4-restart.test.js`

## 备注
- 当前仓库已有同题 PR #214；这版额外补了 background 侧的重开分类和对应回归测试。