### PR TITLE
合并 GPC 任务过期与过期步骤消息处理

### DIFF
--- a/background/message-router.js
+++ b/background/message-router.js
@@ -167,6 +167,25 @@
       return '';
     }
 
+    function isStaleAutoRunStepMessage(step, state = {}) {
+      if (typeof isAutoRunLockedState !== 'function' || !isAutoRunLockedState(state)) {
+        return false;
+      }
+      const normalizedStep = Number(step);
+      if (!Number.isInteger(normalizedStep) || normalizedStep <= 0) {
+        return false;
+      }
+      const currentStatus = String(state?.stepStatuses?.[normalizedStep] || '').trim();
+      if (currentStatus === 'running') {
+        return false;
+      }
+      const currentStep = Number(state?.currentStep) || 0;
+      if (currentStep > 0 && normalizedStep !== currentStep) {
+        return true;
+      }
+      return ['completed', 'manual_completed', 'skipped', 'failed', 'stopped'].includes(currentStatus);
+    }
+
     function resolveSignupPhonePayload(payload = {}) {
       const directPhone = String(
         payload?.signupPhoneNumber
@@ -540,6 +559,11 @@
         }
 
         case 'STEP_COMPLETE': {
+          const currentState = await getState();
+          if (isStaleAutoRunStepMessage(message.step, currentState)) {
+            await addLog(`自动运行：忽略过期的步骤 ${message.step} 完成消息，当前流程已在步骤 ${currentState.currentStep || '未知'}。`, 'warn', { step: message.step });
+            return { ok: true, ignored: true };
+          }
           if (getStopRequested()) {
             await setStepStatus(message.step, 'stopped');
             await appendManualAccountRunRecordIfNeeded(`step${message.step}_stopped`, null, '流程已被用户停止。');
@@ -582,6 +606,11 @@
         }
 
         case 'STEP_ERROR': {
+          const staleCheckState = await getState();
+          if (isStaleAutoRunStepMessage(message.step, staleCheckState)) {
+            await addLog(`自动运行：忽略过期的步骤 ${message.step} 失败消息，当前流程已在步骤 ${staleCheckState.currentStep || '未知'}。原始错误：${message.error || '未知错误'}`, 'warn', { step: message.step });
+            return { ok: true, ignored: true };
+          }
           if (typeof isCloudflareSecurityBlockedError === 'function' && isCloudflareSecurityBlockedError(message.error)) {
             const userMessage = typeof handleCloudflareSecurityBlocked === 'function'
               ? await handleCloudflareSecurityBlocked(message.error)

--- a/background/steps/fill-plus-checkout.js
+++ b/background/steps/fill-plus-checkout.js
@@ -14,6 +14,7 @@
   const GPC_HELPER_PHONE_MODE_AUTO = 'auto';
   const GPC_HELPER_PHONE_MODE_MANUAL = 'manual';
   const GPC_TASK_POLL_INTERVAL_MS = 3000;
+  const GPC_TASK_STALE_STATUS_TIMEOUT_MS = 60000;
   const GPC_REMOTE_STAGE_LABELS = {
     auto_otp_wait: '等待自动 OTP',
     checkout_order_start: '创建订单',
@@ -786,6 +787,49 @@
       return ['completed', 'failed', 'expired', 'discarded'].includes(String(status || '').trim().toLowerCase());
     }
 
+    function buildGpcTaskProgressSignature(task = {}) {
+      return [
+        task?.status,
+        task?.status_text,
+        task?.remote_stage,
+        task?.api_waiting_for,
+        task?.last_input_error,
+        task?.otp_invalid_count,
+        task?.reference_id || task?.referenceId,
+        task?.redirect_url || task?.redirectUrl,
+        task?.flow_id || task?.flowId,
+        task?.challenge_id || task?.challengeId,
+        task?.gopay_guid || task?.gopayGuid,
+      ].map((value) => String(value ?? '').trim()).join('|');
+    }
+
+    function shouldWatchGpcTaskProgress(task = {}, state = {}) {
+      if (!task || isGpcTaskTerminal(task.status)) {
+        return false;
+      }
+      if (isGpcTaskOtpWait(task, state) || isGpcTaskPinWait(task, state)) {
+        return false;
+      }
+      return true;
+    }
+
+    function getGpcTaskStaleStatusTimeoutMs(state = {}) {
+      const configuredSeconds = Number(state?.gopayHelperTaskStaleSeconds);
+      if (Number.isFinite(configuredSeconds) && configuredSeconds > 0) {
+        return Math.max(15000, Math.min(600000, Math.floor(configuredSeconds * 1000)));
+      }
+      return GPC_TASK_STALE_STATUS_TIMEOUT_MS;
+    }
+
+    function buildGpcTaskStaleStatusError(task = {}, staleTimeoutMs = GPC_TASK_STALE_STATUS_TIMEOUT_MS) {
+      const seconds = Math.max(1, Math.round(staleTimeoutMs / 1000));
+      const label = formatGpcRemoteStageLabel(task?.remote_stage)
+        || task?.status_text
+        || task?.status
+        || '未知状态';
+      return new Error(`GPC_TASK_ENDED::GPC 任务状态超过 ${seconds} 秒无进展（${label}），请重新创建任务。`);
+    }
+
     function buildGpcTaskTerminalError(task = {}) {
       const status = String(task?.status || '').trim().toLowerCase();
       const remoteStage = String(task?.remote_stage || task?.remoteStage || '').trim();
@@ -927,6 +971,9 @@
       let lastSubmittedOtp = '';
       let pinSubmitted = false;
       let terminalReached = false;
+      let lastProgressSignature = '';
+      let lastProgressAt = Date.now();
+      const staleStatusTimeoutMs = getGpcTaskStaleStatusTimeoutMs(state);
 
       if (!taskId) {
         throw new Error('步骤 7：GPC 模式缺少 task_id，请先执行步骤 6。');
@@ -973,6 +1020,20 @@
           if (['failed', 'expired', 'discarded'].includes(task.status)) {
             terminalReached = true;
             throw buildGpcTaskEndedError(task, 'GPC 任务已结束，请重新创建任务。');
+          }
+
+          if (shouldWatchGpcTaskProgress(task, state)) {
+            const progressSignature = buildGpcTaskProgressSignature(task);
+            const now = Date.now();
+            if (progressSignature && progressSignature !== lastProgressSignature) {
+              lastProgressSignature = progressSignature;
+              lastProgressAt = now;
+            } else if (progressSignature && now - lastProgressAt >= staleStatusTimeoutMs) {
+              throw buildGpcTaskStaleStatusError(task, staleStatusTimeoutMs);
+            }
+          } else {
+            lastProgressSignature = '';
+            lastProgressAt = Date.now();
           }
 
           if (isGpcTaskOtpWait(task, state)) {

--- a/tests/background-message-router-step2-skip.test.js
+++ b/tests/background-message-router-step2-skip.test.js
@@ -23,13 +23,17 @@ function createRouter(overrides = {}) {
     securityBlocks: [],
     invalidations: [],
     executedSteps: [],
+    accountRecords: [],
   };
 
   const router = api.createMessageRouter({
     addLog: async (message, level, options = {}) => {
       events.logs.push({ message, level, step: options.step, stepKey: options.stepKey });
     },
-    appendAccountRunRecord: async () => null,
+    appendAccountRunRecord: overrides.appendAccountRunRecord || (async (status, state, reason) => {
+      events.accountRecords.push({ status, state, reason });
+      return null;
+    }),
     batchUpdateLuckmailPurchases: async () => {},
     buildLocalhostCleanupPrefix: () => '',
     buildLuckmailSessionSettingsPayload: () => ({}),
@@ -89,7 +93,7 @@ function createRouter(overrides = {}) {
       events.invalidations.push({ step, options });
     },
     isCloudflareSecurityBlockedError: overrides.isCloudflareSecurityBlockedError || ((error) => /^CF_SECURITY_BLOCKED::/.test(typeof error === 'string' ? error : error?.message || '')),
-    isAutoRunLockedState: () => false,
+    isAutoRunLockedState: overrides.isAutoRunLockedState || (() => false),
     isHotmailProvider: () => false,
     isLocalhostOAuthCallbackUrl: () => true,
     isLuckmailProvider: () => false,
@@ -561,4 +565,60 @@ test('message router refreshes GPC balance through explicit sidepanel message', 
   assert.equal(events.balanceRefreshes[0].state.gopayHelperApiUrl, 'http://localhost:18473/');
   assert.equal(events.balanceRefreshes[0].state.gopayHelperApiKey, 'payload_api_key');
   assert.deepStrictEqual(events.balanceRefreshes[0].options, { reason: 'manual' });
+});
+
+test('message router ignores stale step 2 errors while auto-run is already on a later step', async () => {
+  const { router, events } = createRouter({
+    state: {
+      autoRunning: true,
+      autoRunPhase: 'running',
+      currentStep: 6,
+      stepStatuses: {
+        2: 'completed',
+        6: 'running',
+      },
+    },
+    isAutoRunLockedState: (state) => Boolean(state?.autoRunning) && state?.autoRunPhase === 'running',
+  });
+
+  const response = await router.handleMessage({
+    type: 'STEP_ERROR',
+    step: 2,
+    error: '步骤 2：旧页面异步失败，不应覆盖当前第 6 步记录。',
+  }, {});
+
+  assert.deepStrictEqual(response, { ok: true, ignored: true });
+  assert.deepStrictEqual(events.stepStatuses, []);
+  assert.deepStrictEqual(events.notifyErrors, []);
+  assert.deepStrictEqual(events.accountRecords, []);
+  assert.equal(events.logs.some(({ message }) => /忽略过期的步骤 2 失败消息/.test(message)), true);
+});
+
+test('message router ignores stale step 2 completion while auto-run is already on a later step', async () => {
+  const { router, events } = createRouter({
+    state: {
+      autoRunning: true,
+      autoRunPhase: 'running',
+      currentStep: 6,
+      stepStatuses: {
+        2: 'completed',
+        6: 'running',
+      },
+    },
+    isAutoRunLockedState: (state) => Boolean(state?.autoRunning) && state?.autoRunPhase === 'running',
+  });
+
+  const response = await router.handleMessage({
+    type: 'STEP_COMPLETE',
+    step: 2,
+    payload: {
+      email: 'late@example.com',
+    },
+  }, {});
+
+  assert.deepStrictEqual(response, { ok: true, ignored: true });
+  assert.deepStrictEqual(events.stepStatuses, []);
+  assert.deepStrictEqual(events.notifyCompletions, []);
+  assert.deepStrictEqual(events.emailStates, []);
+  assert.equal(events.logs.some(({ message }) => /忽略过期的步骤 2 完成消息/.test(message)), true);
 });

--- a/tests/plus-checkout-billing-tab-resolution.test.js
+++ b/tests/plus-checkout-billing-tab-resolution.test.js
@@ -85,6 +85,7 @@ function createExecutorHarness({
   markCurrentRegistrationAccountUsed = async () => {},
   probeIpProxyExit = null,
   onSetState = null,
+  sleepWithStop = null,
   submitRedirectUrl = 'https://www.paypal.com/checkoutnow',
 }) {
   const api = loadPlusCheckoutBillingModule();
@@ -166,7 +167,7 @@ function createExecutorHarness({
         await onSetState(updates, events);
       }
     },
-    sleepWithStop: async (ms) => events.sleeps.push(ms),
+    sleepWithStop: sleepWithStop || (async (ms) => events.sleeps.push(ms)),
     waitForTabCompleteUntilStopped: async () => checkoutTab,
     waitForTabUrlMatchUntilStopped: async (tabId, matcher) => {
       events.waitedUrls.push({ tabId });
@@ -1014,6 +1015,70 @@ test('GPC billing logs checkout order stage in Chinese', async () => {
 
   assert.equal(events.logs.some((entry) => entry.message === '步骤 7：GPC 任务状态：创建订单'), true);
   assert.equal(events.logs.some((entry) => /checkout_order_start/.test(entry.message)), false);
+});
+
+test('GPC billing fails repeated checkout stage as stale so auto-run can recreate task', async () => {
+  const originalNow = Date.now;
+  let now = 1710000000000;
+  const fetchCalls = [];
+  const { events, executor } = createExecutorHarness({
+    frames: [],
+    stateByFrame: {},
+    sleepWithStop: async (ms) => {
+      events.sleeps.push(ms);
+      now += ms;
+    },
+    fetchImpl: async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      if (url === 'https://gpc.qlhazycoder.top/api/gp/tasks/task_stale') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => createGpcTaskResponse({
+            task_id: 'task_stale',
+            phone_mode: 'auto',
+            status: 'active',
+            status_text: '处理中',
+            remote_stage: 'checkout_order_start',
+            api_waiting_for: '',
+          }),
+        };
+      }
+      if (url.endsWith('/api/gp/tasks/task_stale/stop')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => createGpcTaskResponse({
+            task_id: 'task_stale',
+            status: 'discarded',
+            status_text: '已停止',
+          }),
+        };
+      }
+      throw new Error(`unexpected url: ${url}`);
+    },
+  });
+
+  Date.now = () => now;
+  try {
+    await assert.rejects(
+      () => executor.executePlusCheckoutBilling({
+        plusPaymentMethod: 'gpc-helper',
+        plusCheckoutSource: 'gpc-helper',
+        gopayHelperTaskId: 'task_stale',
+        gopayHelperPhoneMode: 'auto',
+        gopayHelperApiUrl: 'https://gpc.qlhazycoder.top/',
+        gopayHelperApiKey: 'gpc_auto',
+        gopayHelperTaskStaleSeconds: 15,
+      }),
+      /GPC_TASK_ENDED::GPC 任务状态超过 15 秒无进展（创建订单），请重新创建任务。/
+    );
+  } finally {
+    Date.now = originalNow;
+  }
+
+  assert.equal(fetchCalls.some((call) => call.url.endsWith('/api/gp/tasks/task_stale/stop')), true);
+  assert.equal(events.logs.some((entry) => entry.message === '步骤 7：GPC 任务状态：创建订单'), true);
 });
 
 test('GPC billing reads SMS OTP from local helper for sms_otp_wait', async () => {


### PR DESCRIPTION
## 本次改动
- 合并本地待处理的 GPC 任务过期状态处理。
- 合并过期步骤消息处理，自动运行中忽略已完成步骤的过期错误和完成消息。

## 风险与影响
- 只涉及 GPC checkout billing 与 message router 的过期/过时消息处理。
- 未修改 SQL。

## 测试情况
- node --test tests/plus-checkout-billing-tab-resolution.test.js tests/background-message-router-step2-skip.test.js（49/49 通过）