### PR TITLE
修复 GPC 自动模式被切回手动的问题

### DIFF
--- a/background/steps/create-plus-checkout.js
+++ b/background/steps/create-plus-checkout.js
@@ -404,7 +404,10 @@
         remoteStage: String(taskData?.remote_stage || taskData?.remoteStage || '').trim(),
         orderCreatedAt,
         responsePayload: taskData && typeof taskData === 'object' && !Array.isArray(taskData) ? taskData : null,
-        phoneMode: normalizeGpcHelperPhoneMode(taskData?.phone_mode || taskData?.phoneMode || phoneMode),
+        phoneMode: (taskData?.phone_mode === undefined && taskData?.phoneMode === undefined)
+          || String(taskData?.phone_mode ?? taskData?.phoneMode ?? '').trim() === ''
+          ? phoneMode
+          : normalizeGpcHelperPhoneMode(taskData?.phone_mode ?? taskData?.phoneMode),
         country: 'ID',
         currency: 'IDR',
         checkoutSource: PLUS_PAYMENT_METHOD_GPC_HELPER,

--- a/background/steps/fill-plus-checkout.js
+++ b/background/steps/fill-plus-checkout.js
@@ -387,13 +387,20 @@
       return headers;
     }
 
-    function normalizeGpcTaskData(payload = {}) {
+    function normalizeGpcTaskData(payload = {}, fallbackPhoneMode = '') {
       const data = unwrapGpcResponse(payload);
       const task = data && typeof data === 'object' && !Array.isArray(data) ? { ...data } : {};
       task.task_id = String(task.task_id || task.taskId || '').trim();
       task.status = String(task.status || '').trim().toLowerCase();
       task.status_text = String(task.status_text || task.statusText || '').trim();
-      task.phone_mode = normalizeGpcHelperPhoneMode(task.phone_mode || task.phoneMode || '');
+      const rawPhoneMode = task.phone_mode ?? task.phoneMode;
+      const normalizedFallbackPhoneMode = normalizeGpcHelperPhoneMode(fallbackPhoneMode);
+      task.phone_mode = rawPhoneMode === undefined || rawPhoneMode === null || String(rawPhoneMode).trim() === ''
+        ? normalizedFallbackPhoneMode
+        : normalizeGpcHelperPhoneMode(rawPhoneMode);
+      task.phone_mode_source = rawPhoneMode === undefined || rawPhoneMode === null || String(rawPhoneMode).trim() === ''
+        ? 'fallback'
+        : 'remote';
       task.remote_stage = String(task.remote_stage || task.remoteStage || '').trim().toLowerCase();
       task.api_waiting_for = String(task.api_waiting_for || task.apiWaitingFor || '').trim().toLowerCase();
       task.api_input_deadline_at = String(task.api_input_deadline_at || task.apiInputDeadlineAt || '').trim();
@@ -406,12 +413,13 @@
       return task;
     }
 
-    async function setGpcTaskState(taskData = {}) {
-      const task = normalizeGpcTaskData(taskData);
+    async function setGpcTaskState(taskData = {}, fallbackPhoneMode = '') {
+      const task = normalizeGpcTaskData(taskData, fallbackPhoneMode);
       const updates = {
         gopayHelperTaskId: task.task_id,
         gopayHelperTaskStatus: task.status,
         gopayHelperStatusText: task.status_text,
+        ...(task.phone_mode_source === 'remote' ? { gopayHelperPhoneMode: task.phone_mode } : {}),
         gopayHelperRemoteStage: task.remote_stage,
         gopayHelperApiWaitingFor: task.api_waiting_for,
         gopayHelperApiInputDeadlineAt: task.api_input_deadline_at,
@@ -429,7 +437,7 @@
       return task;
     }
 
-    async function fetchGpcTaskStatus(apiUrl, taskId, apiKey) {
+    async function fetchGpcTaskStatus(apiUrl, taskId, apiKey, fallbackPhoneMode = '') {
       const requestUrl = buildGpcTaskQueryUrl(apiUrl, taskId);
       const { response, data } = await fetchJsonWithTimeout(requestUrl, {
         method: 'GET',
@@ -438,10 +446,10 @@
       if (!response?.ok || !isGpcUnifiedResponseOk(data)) {
         throw new Error(getGpcResponseErrorDetail(data, response?.status || 0));
       }
-      return setGpcTaskState(data);
+      return setGpcTaskState(data, fallbackPhoneMode);
     }
 
-    async function postGpcTaskAction(apiUrl, taskId, action, payload = {}, apiKey = '', timeoutMs = 30000) {
+    async function postGpcTaskAction(apiUrl, taskId, action, payload = {}, apiKey = '', timeoutMs = 30000, fallbackPhoneMode = '') {
       const requestUrl = buildGpcTaskActionUrl(apiUrl, taskId, action);
       const { response, data } = await fetchJsonWithTimeout(requestUrl, {
         method: 'POST',
@@ -454,7 +462,7 @@
       if (!response?.ok || !isGpcUnifiedResponseOk(data)) {
         throw new Error(getGpcResponseErrorDetail(data, response?.status || 0));
       }
-      return setGpcTaskState(data);
+      return setGpcTaskState(data, fallbackPhoneMode);
     }
 
     async function postGpcJsonWithFallback(apiUrl, endpointPath, primaryPayload, fallbackPayload, timeoutMs = 30000) {
@@ -1008,7 +1016,7 @@
       try {
         while (Date.now() <= deadline) {
           throwIfStopped();
-          const task = await fetchGpcTaskStatus(apiUrl, taskId, apiKey);
+          const task = await fetchGpcTaskStatus(apiUrl, taskId, apiKey, configuredPhoneMode);
           await addLog(formatGpcTaskStatusLog(task), 'info');
 
           if (task.status === 'completed') {
@@ -1101,7 +1109,8 @@
                 'otp',
                 buildGpcTaskOtpPayload({ otp: normalizedOtp }),
                 apiKey,
-                30000
+                30000,
+                configuredPhoneMode
               );
             } catch (error) {
               if (isGpcOtpFormatConflict(error)) {
@@ -1128,7 +1137,8 @@
                 'pin',
                 buildGpcTaskPinPayload({ pin }),
                 apiKey,
-                30000
+                30000,
+                configuredPhoneMode
               );
             } catch (error) {
               throw new Error(`GPC_TASK_ENDED::${error?.message || String(error || 'PIN 提交失败，请重新创建任务。')}`);

--- a/tests/plus-checkout-billing-tab-resolution.test.js
+++ b/tests/plus-checkout-billing-tab-resolution.test.js
@@ -965,6 +965,47 @@ test('GPC billing auto mode only polls until completed without OTP or PIN submis
   assert.equal(events.completed[0].payload.plusCheckoutSource, 'gpc-helper');
 });
 
+test('GPC billing auto mode keeps selected mode when task status omits phone_mode', async () => {
+  let pollCount = 0;
+  const { events, executor } = createExecutorHarness({
+    frames: [],
+    stateByFrame: {},
+    fetchImpl: async (url) => {
+      if (url === 'https://gpc.qlhazycoder.top/api/gp/tasks/task_auto_omitted_mode') {
+        pollCount += 1;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => createGpcTaskResponse({
+            task_id: 'task_auto_omitted_mode',
+            phone_mode: '',
+            status: pollCount === 1 ? 'active' : 'completed',
+            status_text: pollCount === 1 ? '处理中' : '充值完成',
+            remote_stage: pollCount === 1 ? 'auto_otp_wait' : 'completed',
+            api_waiting_for: pollCount === 1 ? 'otp' : '',
+          }),
+        };
+      }
+      throw new Error(`unexpected url: ${url}`);
+    },
+  });
+
+  await executor.executePlusCheckoutBilling({
+    plusPaymentMethod: 'gpc-helper',
+    plusCheckoutSource: 'gpc-helper',
+    gopayHelperTaskId: 'task_auto_omitted_mode',
+    gopayHelperPhoneMode: 'auto',
+    gopayHelperApiUrl: 'https://gpc.qlhazycoder.top/',
+    gopayHelperApiKey: 'gpc_auto',
+  });
+
+  assert.equal(events.states.some((state) => state.gopayHelperPhoneMode === 'manual'), false);
+  assert.equal(events.states.some((state) => state.plusManualConfirmationMethod === 'gopay-otp'), false);
+  assert.equal(events.states.some((state) => state.gopayHelperTaskId === 'task_auto_omitted_mode' && state.gopayHelperTaskStatus === 'completed'), true);
+  assert.equal(events.logs.some((entry) => entry.message === '步骤 7：GPC 任务状态：等待自动 OTP'), true);
+  assert.equal(events.completed[0].step, 7);
+});
+
 test('GPC billing logs checkout order stage in Chinese', async () => {
   let pollCount = 0;
   const { events, executor } = createExecutorHarness({

--- a/tests/plus-checkout-create-wait.test.js
+++ b/tests/plus-checkout-create-wait.test.js
@@ -510,6 +510,62 @@ test('GPC auto checkout only sends access token and API Key', async () => {
   assert.equal(events.find((event) => event.type === 'complete')?.step, 6);
 });
 
+test('GPC auto checkout keeps selected mode when task create response omits phone_mode', async () => {
+  const events = [];
+  const fetchCalls = [];
+  const executor = api.createPlusCheckoutCreateExecutor({
+    addLog: async (message, level = 'info') => events.push({ type: 'log', message, level }),
+    chrome: {
+      tabs: {
+        create: async () => {
+          throw new Error('should not open token tab when direct access token exists');
+        },
+        remove: async () => {},
+      },
+    },
+    completeStepFromBackground: async (step, payload) => events.push({ type: 'complete', step, payload }),
+    ensureContentScriptReadyOnTabUntilStopped: async () => {},
+    fetch: async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => url.endsWith('/api/gp/balance')
+          ? createGpcBalanceResponse({ auto_mode_enabled: true, remaining_uses: 998 })
+          : createGpcTaskResponse({
+              task_id: 'task_auto_without_mode',
+              status: 'queued',
+              status_text: '排队中',
+              phone_mode: '',
+              api_waiting_for: '',
+            }),
+      };
+    },
+    registerTab: async () => {},
+    sendTabMessageUntilStopped: async () => ({}),
+    setState: async (payload) => events.push({ type: 'set-state', payload }),
+    sleepWithStop: async () => {},
+    waitForTabCompleteUntilStopped: async () => {},
+  });
+
+  await executor.executePlusCheckoutCreate({
+    plusPaymentMethod: 'gpc-helper',
+    gopayHelperPhoneMode: 'auto',
+    gopayHelperApiUrl: 'https://gpc.qlhazycoder.top/',
+    chatgptAccessToken: 'state-access-token',
+    gopayHelperApiKey: 'gpc_auto_123',
+  });
+
+  assert.equal(fetchCalls.length, 2);
+  const helperPayload = JSON.parse(fetchCalls[1].options.body);
+  assert.equal(helperPayload.phone_mode, 'auto');
+  const statePayload = events.find((event) => event.type === 'set-state')?.payload || {};
+  assert.equal(statePayload.gopayHelperTaskId, 'task_auto_without_mode');
+  assert.equal(Object.prototype.hasOwnProperty.call(statePayload, 'gopayHelperPhoneMode'), false);
+  assert.equal(events.some((event) => event.type === 'log' && /GPC 自动模式任务已创建/.test(event.message)), true);
+  assert.equal(events.find((event) => event.type === 'complete')?.step, 6);
+});
+
 test('GPC auto checkout keeps running when balance payload omits auto mode permission', async () => {
   const events = [];
   const fetchCalls = [];


### PR DESCRIPTION
## 变更说明
- 修复 GPC 自动模式任务在创建或轮询时，如果远端响应缺失/空 `phone_mode`，前端会按默认值误判为手动模式的问题。
- 创建任务响应缺少 `phone_mode` 时沿用当前选择的模式，保证日志和后续步骤继续按自动模式执行。
- 轮询任务状态时只有远端明确返回 `phone_mode` 才更新侧边栏模式；缺失时使用当前选择作为运行时兜底，避免自动模式被误切成手动并弹出 OTP/PIN 输入。
- 增加回归测试覆盖创建任务和轮询任务缺少 `phone_mode` 的场景。

## 验证
- `node --test tests/plus-checkout-create-wait.test.js tests/plus-checkout-billing-tab-resolution.test.js tests/sidepanel-plus-payment-method.test.js`：59 passed
- `npm test`：948 passed
