### PR TITLE
fix: parse HeroSMS country object response

### DIFF
--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -5813,6 +5813,26 @@ function buildHeroSmsCountryDisplayLabel(country = {}) {
   return chinese || english;
 }
 
+function normalizeHeroSmsCountriesPayload(payload = null) {
+  if (!payload) {
+    return [];
+  }
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  if (Array.isArray(payload?.value)) {
+    return payload.value;
+  }
+  if (payload.value && typeof payload.value === 'object' && !Array.isArray(payload.value)) {
+    return Object.values(payload.value);
+  }
+  if (typeof payload === 'object') {
+    return Object.values(payload).filter((entry) => entry && typeof entry === 'object' && !Array.isArray(entry));
+  }
+  return [];
+}
+
+
 function normalizeHeroSmsFetchErrorMessage(error) {
   const message = String(error?.message || error || '').trim();
   if (!message) {
@@ -7147,7 +7167,7 @@ async function loadHeroSmsCountries(options = {}) {
     });
     clearTimeout(timeoutId);
     const payload = await response.json();
-    const countries = Array.isArray(payload?.value) ? payload.value : (Array.isArray(payload) ? payload : []);
+    const countries = normalizeHeroSmsCountriesPayload(payload);
     if (!countries.length) {
       throw new Error('国家列表为空');
     }

--- a/tests/sidepanel-phone-verification-settings.test.js
+++ b/tests/sidepanel-phone-verification-settings.test.js
@@ -1394,3 +1394,14 @@ test('hero sms max price input does not auto-save partial typing states', () => 
     /inputHeroSmsMinPrice\?\.\s*addEventListener\('input',\s*\(\)\s*=>\s*\{\s*markSettingsDirty\(true\);\s*scheduleSettingsAutoSave\(\);/
   );
 });
+
+test('sidepanel parses HeroSMS getCountries object payload', () => {
+  const match = sidepanelSource.match(/function normalizeHeroSmsCountriesPayload\(payload = null\) \{[\s\S]*?\n\}/);
+  assert.ok(match, 'normalizeHeroSmsCountriesPayload should exist');
+  const normalizeHeroSmsCountriesPayload = new Function(`${match[0]}; return normalizeHeroSmsCountriesPayload;`)();
+  const countries = normalizeHeroSmsCountriesPayload({
+    6: { id: 6, eng: 'Indonesia', chn: '印度尼西亚' },
+    52: { id: 52, eng: 'Thailand', chn: '泰国' },
+  });
+  assert.deepStrictEqual(countries.map((item) => item.id), [6, 52]);
+});


### PR DESCRIPTION
Fix HeroSMS country list parsing when getCountries returns an object keyed by country id instead of an array/value array. Adds test coverage for object payloads.

Tests: npm test -- tests/sidepanel-phone-verification-settings.test.js