### PR TITLE
feat: add Kiro-Go publish target

### DIFF
--- a/background.js
+++ b/background.js
@@ -13915,6 +13915,16 @@ const messageRouter = self.MultiPageBackgroundMessageRouter?.createMessageRouter
       typeof fetch === 'function' ? fetch.bind(globalThis) : null
     );
   },
+  testKiroGoConnection: async (baseUrl, adminPassword) => {
+    if (typeof self.MultiPageBackgroundKiroPublisherKiroRs?.checkKiroGoConnection !== 'function') {
+      throw new Error('Kiro-Go 连接测试能力尚未接入。');
+    }
+    return self.MultiPageBackgroundKiroPublisherKiroRs.checkKiroGoConnection(
+      baseUrl,
+      adminPassword,
+      typeof fetch === 'function' ? fetch.bind(globalThis) : null
+    );
+  },
   finalizeStep3Completion: async () => {
     const currentState = await getState();
     const signupTabId = await getTabId('signup-page');

--- a/background/kiro/publisher-kiro-rs.js
+++ b/background/kiro/publisher-kiro-rs.js
@@ -4,6 +4,8 @@
   const kiroStateApi = root?.MultiPageBackgroundKiroState || null;
   const DEFAULT_REGION = kiroStateApi?.DEFAULT_REGION || 'us-east-1';
   const DEFAULT_TARGET_ID = kiroStateApi?.DEFAULT_TARGET_ID || 'kiro-rs';
+  const KIRO_RS_TARGET_ID = 'kiro-rs';
+  const KIRO_GO_TARGET_ID = 'kiro-go';
   const BUILDER_ID_PROFILE_ARN = 'arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX';
 
   function isPlainObject(value) {
@@ -52,6 +54,10 @@
     return cleanString(value);
   }
 
+  function normalizeKiroGoAdminPassword(value = '') {
+    return cleanString(value);
+  }
+
   function buildKiroRsAdminHeaders(apiKey = '', extraHeaders = {}) {
     const normalizedApiKey = normalizeKiroRsApiKey(apiKey);
     return {
@@ -67,10 +73,24 @@
     return cleanString(body?.json?.error?.message || body?.json?.message || body?.text || fallback);
   }
 
+  function readKiroGoResponseMessage(body = {}, fallback = '') {
+    return cleanString(body?.json?.error || body?.json?.message || body?.text || fallback);
+  }
+
   function normalizeKiroRsBaseUrl(value = '') {
     const normalized = cleanString(value).replace(/\/+$/, '');
     if (!normalized) {
       throw new Error('缺少 kiro.rs 管理后台地址。');
+    }
+    return normalized.endsWith('/admin')
+      ? normalized.slice(0, -'/admin'.length)
+      : normalized;
+  }
+
+  function normalizeKiroGoBaseUrl(value = '') {
+    const normalized = cleanString(value).replace(/\/+$/, '');
+    if (!normalized) {
+      throw new Error('缺少 Kiro-Go 管理后台地址。');
     }
     return normalized.endsWith('/admin')
       ? normalized.slice(0, -'/admin'.length)
@@ -128,12 +148,28 @@
   }
 
   function resolveKiroTargetConfig(state = {}, targetId = DEFAULT_TARGET_ID) {
-    if (targetId !== DEFAULT_TARGET_ID) {
+    const normalizedTargetId = cleanString(targetId).toLowerCase() || DEFAULT_TARGET_ID;
+    const nestedConfig = state?.settingsState?.flows?.kiro?.targets?.[normalizedTargetId]
+      || state?.flows?.kiro?.targets?.[normalizedTargetId]
+      || {};
+
+    if (normalizedTargetId === KIRO_GO_TARGET_ID) {
+      return {
+        baseUrl: cleanString(nestedConfig.baseUrl || state?.kiroGoUrl),
+        adminPassword: normalizeKiroGoAdminPassword(
+          nestedConfig.adminPassword
+          ?? nestedConfig.apiKey
+          ?? state?.kiroGoPassword
+          ?? state?.kiroGoAdminPassword
+          ?? ''
+        ),
+      };
+    }
+
+    if (normalizedTargetId !== KIRO_RS_TARGET_ID) {
       throw new Error(`暂不支持 Kiro 发布目标：${targetId}`);
     }
-    const nestedConfig = state?.settingsState?.flows?.kiro?.targets?.[targetId]
-      || state?.flows?.kiro?.targets?.[targetId]
-      || {};
+
     return {
       baseUrl: cleanString(nestedConfig.baseUrl || state?.kiroRsUrl),
       apiKey: normalizeKiroRsApiKey(nestedConfig.apiKey ?? state?.kiroRsKey ?? ''),
@@ -289,6 +325,82 @@
     };
   }
 
+
+  async function checkKiroGoConnection(baseUrl, adminPassword, fetchImpl) {
+    const normalizedBaseUrl = normalizeKiroGoBaseUrl(baseUrl);
+    const normalizedAdminPassword = normalizeKiroGoAdminPassword(adminPassword);
+    const response = await fetchImpl(`${normalizedBaseUrl}/admin/api/accounts`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        ...(normalizedAdminPassword ? { 'X-Admin-Password': normalizedAdminPassword } : {}),
+      },
+    });
+    const body = await readResponse(response);
+    const detail = readKiroGoResponseMessage(body, response.statusText);
+    if (response.ok) {
+      return {
+        ok: true,
+        status: response.status,
+        message: `Kiro-Go 连接正常（HTTP ${response.status}）`,
+      };
+    }
+    if (response.status === 401 || response.status === 403) {
+      return {
+        ok: false,
+        status: response.status,
+        message: `Kiro-Go 管理密码被拒绝（HTTP ${response.status}${detail ? `：${detail}` : ''}）`,
+      };
+    }
+    if (response.status === 404) {
+      return {
+        ok: false,
+        status: response.status,
+        message: `未找到 Kiro-Go 管理接口（HTTP 404${detail ? `：${detail}` : ''}）`,
+      };
+    }
+    return {
+      ok: false,
+      status: response.status,
+      message: detail || `Kiro-Go 连接失败（HTTP ${response.status}）`,
+    };
+  }
+
+  async function uploadBuilderIdCredentialToKiroGo(baseUrl, adminPassword, payload, fetchImpl) {
+    const normalizedBaseUrl = normalizeKiroGoBaseUrl(baseUrl);
+    const normalizedAdminPassword = normalizeKiroGoAdminPassword(adminPassword);
+    const response = await fetchImpl(`${normalizedBaseUrl}/admin/api/auth/credentials`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        ...(normalizedAdminPassword ? { 'X-Admin-Password': normalizedAdminPassword } : {}),
+      },
+      body: JSON.stringify({
+        accessToken: payload.accessToken || '',
+        refreshToken: payload.refreshToken,
+        clientId: payload.clientId,
+        clientSecret: payload.clientSecret,
+        authMethod: payload.authMethod || 'idc',
+        provider: payload.provider || 'BuilderId',
+        region: payload.region,
+        profileArn: payload.profileArn,
+      }),
+    });
+    const body = await readResponse(response);
+    if (!response.ok || body.json?.success === false) {
+      const message = readKiroGoResponseMessage(body, response.statusText) || `HTTP ${response.status}`;
+      throw new Error(`Kiro-Go 凭据上传失败：${message}`);
+    }
+
+    return {
+      credentialId: cleanString(body.json?.account?.id) || null,
+      email: cleanString(body.json?.account?.email),
+      message: normalizeKiroUploadMessage(body.json?.message),
+      raw: body.json,
+    };
+  }
+
   function createKiroRsPublisher(deps = {}) {
     const {
       addLog = async () => {},
@@ -385,12 +497,6 @@
 
         const targetId = resolveKiroTargetId(currentState);
         const targetConfig = resolveKiroTargetConfig(currentState, targetId);
-        const baseUrl = normalizeKiroRsBaseUrl(targetConfig.baseUrl);
-        const apiKey = String(targetConfig.apiKey || '');
-        if (!apiKey) {
-          throw new Error('缺少 kiro.rs API Key。');
-        }
-
         const uploadInput = buildUploadPayload(currentState);
         const machineId = await buildMachineId(uploadInput.refreshToken);
 
@@ -407,28 +513,54 @@
           },
         });
 
-        await log('步骤 9：正在上传 Builder ID 凭据到 kiro.rs...', 'info', nodeId);
-
-        const connection = await checkKiroRsConnection(baseUrl, apiKey, fetchImpl);
-        if (!connection.ok) {
-          throw new Error(connection.message);
+        let uploadResult;
+        if (targetId === KIRO_GO_TARGET_ID) {
+          const baseUrl = normalizeKiroGoBaseUrl(targetConfig.baseUrl);
+          const adminPassword = String(targetConfig.adminPassword || '');
+          if (!adminPassword) {
+            throw new Error('缺少 Kiro-Go 管理密码。');
+          }
+          await log('步骤 9：正在上传 Builder ID 凭据到 Kiro-Go...', 'info', nodeId);
+          const connection = await checkKiroGoConnection(baseUrl, adminPassword, fetchImpl);
+          if (!connection.ok) {
+            throw new Error(connection.message);
+          }
+          uploadResult = await uploadBuilderIdCredentialToKiroGo(baseUrl, adminPassword, {
+            refreshToken: uploadInput.refreshToken,
+            profileArn: uploadInput.profileArn,
+            authMethod: uploadInput.authMethod,
+            clientId: uploadInput.clientId,
+            clientSecret: uploadInput.clientSecret,
+            region: uploadInput.region,
+            email: uploadInput.email,
+          }, fetchImpl);
+        } else {
+          const baseUrl = normalizeKiroRsBaseUrl(targetConfig.baseUrl);
+          const apiKey = String(targetConfig.apiKey || '');
+          if (!apiKey) {
+            throw new Error('缺少 kiro.rs API Key。');
+          }
+          await log('步骤 9：正在上传 Builder ID 凭据到 kiro.rs...', 'info', nodeId);
+          const connection = await checkKiroRsConnection(baseUrl, apiKey, fetchImpl);
+          if (!connection.ok) {
+            throw new Error(connection.message);
+          }
+          uploadResult = await uploadBuilderIdCredential(baseUrl, apiKey, {
+            refreshToken: uploadInput.refreshToken,
+            profileArn: uploadInput.profileArn,
+            authMethod: uploadInput.authMethod,
+            clientId: uploadInput.clientId,
+            clientSecret: uploadInput.clientSecret,
+            region: uploadInput.region,
+            authRegion: uploadInput.authRegion,
+            apiRegion: uploadInput.apiRegion,
+            machineId,
+            email: uploadInput.email,
+            ...(uploadInput.proxyUrl ? { proxyUrl: uploadInput.proxyUrl } : {}),
+            ...(uploadInput.proxyUsername ? { proxyUsername: uploadInput.proxyUsername } : {}),
+            ...(uploadInput.proxyPassword ? { proxyPassword: uploadInput.proxyPassword } : {}),
+          }, fetchImpl);
         }
-
-        const uploadResult = await uploadBuilderIdCredential(baseUrl, apiKey, {
-          refreshToken: uploadInput.refreshToken,
-          profileArn: uploadInput.profileArn,
-          authMethod: uploadInput.authMethod,
-          clientId: uploadInput.clientId,
-          clientSecret: uploadInput.clientSecret,
-          region: uploadInput.region,
-          authRegion: uploadInput.authRegion,
-          apiRegion: uploadInput.apiRegion,
-          machineId,
-          email: uploadInput.email,
-          ...(uploadInput.proxyUrl ? { proxyUrl: uploadInput.proxyUrl } : {}),
-          ...(uploadInput.proxyUsername ? { proxyUsername: uploadInput.proxyUsername } : {}),
-          ...(uploadInput.proxyPassword ? { proxyPassword: uploadInput.proxyPassword } : {}),
-        }, fetchImpl);
 
         const uploadedAt = Date.now();
         const payload = await applyRuntimeState(currentState, {
@@ -445,7 +577,7 @@
             lastUploadedAt: uploadedAt,
           },
         });
-        await log(`步骤 9：kiro.rs 上传完成，状态：${uploadResult.message || '上传成功'}`, 'ok', nodeId);
+        await log(`步骤 9：${targetId === KIRO_GO_TARGET_ID ? 'Kiro-Go' : 'kiro.rs'} 上传完成，状态：${uploadResult.message || '上传成功'}`, 'ok', nodeId);
         await completeNodeFromBackground(nodeId, payload);
       } catch (error) {
         const message = getErrorMessage(error);
@@ -462,10 +594,13 @@
   return {
     buildKiroRsPayload: buildUploadPayload,
     buildMachineId,
+    checkKiroGoConnection,
     checkKiroRsConnection,
     createKiroRsPublisher,
+    normalizeKiroGoBaseUrl,
     normalizeKiroRsBaseUrl,
     normalizeKiroUploadMessage,
     uploadBuilderIdCredential,
+    uploadBuilderIdCredentialToKiroGo,
   };
 });

--- a/background/message-router.js
+++ b/background/message-router.js
@@ -37,6 +37,7 @@
       exportSettingsBundle,
       fetchGeneratedEmail,
       refreshGpcCardBalance,
+      testKiroGoConnection,
       testKiroRsConnection,
       finalizePhoneActivationAfterSuccessfulFlow,
       finalizeStep3Completion,
@@ -1680,6 +1681,45 @@
             ?? ''
           );
           const result = await testKiroRsConnection(baseUrl, apiKey);
+          return {
+            ok: Boolean(result?.ok),
+            targetId,
+            status: Number(result?.status) || 0,
+            message: String(result?.message || '').trim(),
+          };
+        }
+
+
+        case 'CHECK_KIRO_GO_CONNECTION': {
+          if (typeof testKiroGoConnection !== 'function') {
+            throw new Error('Kiro-Go 连接测试能力尚未接入。');
+          }
+          const currentState = await getState();
+          const activeFlowId = normalizeMessageFlowId(
+            message.payload?.activeFlowId || currentState?.activeFlowId || 'kiro',
+            'kiro'
+          );
+          const targetId = normalizeMessageTargetId(
+            activeFlowId,
+            message.payload?.targetId || currentState?.kiroTargetId || 'kiro-go',
+            'kiro-go'
+          );
+          const nestedTargetConfig = currentState?.settingsState?.flows?.kiro?.targets?.[targetId]
+            || currentState?.flows?.kiro?.targets?.[targetId]
+            || {};
+          const baseUrl = String(
+            message.payload?.baseUrl
+            ?? nestedTargetConfig.baseUrl
+            ?? currentState?.kiroGoUrl
+            ?? ''
+          ).trim();
+          const adminPassword = String(
+            message.payload?.adminPassword
+            ?? nestedTargetConfig.adminPassword
+            ?? currentState?.kiroGoPassword
+            ?? ''
+          );
+          const result = await testKiroGoConnection(baseUrl, adminPassword);
           return {
             ok: Boolean(result?.ok),
             targetId,

--- a/shared/flow-registry.js
+++ b/shared/flow-registry.js
@@ -6,6 +6,8 @@
   const DEFAULT_KIRO_TARGET_ID = 'kiro-rs';
   const DEFAULT_KIRO_PUBLICATION_TARGET_ID = 'kiro-rs';
   const DEFAULT_KIRO_RS_URL = '';
+  const DEFAULT_KIRO_GO_URL = '';
+  const KIRO_TARGET_IDS = Object.freeze(['kiro-rs', 'kiro-go']);
   const OPENAI_TARGET_IDS = Object.freeze(['cpa', 'sub2api', 'codex2api']);
   const SHARED_SERVICE_IDS = Object.freeze(['account', 'email', 'proxy']);
 
@@ -222,7 +224,7 @@
         ...DEFAULT_FLOW_CAPABILITIES,
         supportsAccountContribution: true,
         contributionAdapterIds: ['kiro-builder-id'],
-        supportedTargetIds: [DEFAULT_KIRO_TARGET_ID],
+        supportedTargetIds: [...KIRO_TARGET_IDS],
         stepDefinitionMode: 'kiro',
       },
       baseGroups: [
@@ -234,11 +236,20 @@
           label: 'kiro.rs',
           groups: ['kiro-target-kiro-rs'],
         },
+        'kiro-go': {
+          id: 'kiro-go',
+          label: 'Kiro-Go',
+          groups: ['kiro-target-kiro-go'],
+        },
       },
       publicationTargets: {
         'kiro-rs': {
           id: 'kiro-rs',
           label: 'kiro.rs',
+        },
+        'kiro-go': {
+          id: 'kiro-go',
+          label: 'Kiro-Go',
         },
       },
       runtimeSources: {
@@ -379,6 +390,11 @@
       label: 'kiro.rs 配置',
       rowIds: ['row-kiro-rs-url', 'row-kiro-rs-key', 'row-kiro-rs-test-status'],
     },
+    'kiro-target-kiro-go': {
+      id: 'kiro-target-kiro-go',
+      label: 'Kiro-Go 配置',
+      rowIds: ['row-kiro-go-url', 'row-kiro-go-password', 'row-kiro-go-test-status'],
+    },
     'kiro-runtime-status': {
       id: 'kiro-runtime-status',
       label: 'Kiro 运行态',
@@ -428,11 +444,11 @@
 
   function normalizeKiroTargetId(value = '', fallback = DEFAULT_KIRO_TARGET_ID) {
     const normalized = String(value || '').trim().toLowerCase();
-    if (normalized === DEFAULT_KIRO_TARGET_ID) {
+    if (KIRO_TARGET_IDS.includes(normalized)) {
       return normalized;
     }
     const fallbackValue = String(fallback || '').trim().toLowerCase();
-    return fallbackValue === DEFAULT_KIRO_TARGET_ID
+    return KIRO_TARGET_IDS.includes(fallbackValue)
       ? fallbackValue
       : DEFAULT_KIRO_TARGET_ID;
   }
@@ -553,8 +569,10 @@
     DEFAULT_KIRO_TARGET_ID,
     DEFAULT_KIRO_PUBLICATION_TARGET_ID,
     DEFAULT_KIRO_RS_URL,
+    DEFAULT_KIRO_GO_URL,
     DEFAULT_OPENAI_TARGET_ID,
     FLOW_DEFINITIONS,
+    KIRO_TARGET_IDS,
     OPENAI_TARGET_IDS,
     SETTINGS_GROUP_DEFINITIONS,
     SHARED_SERVICE_IDS,

--- a/shared/settings-schema.js
+++ b/shared/settings-schema.js
@@ -38,6 +38,7 @@
     const defaultOpenAiTargetId = flowRegistry.DEFAULT_OPENAI_TARGET_ID || 'cpa';
     const defaultKiroTargetId = flowRegistry.DEFAULT_KIRO_TARGET_ID || 'kiro-rs';
     const defaultKiroRsUrl = String(flowRegistry.DEFAULT_KIRO_RS_URL || '').trim();
+    const defaultKiroGoUrl = String(flowRegistry.DEFAULT_KIRO_GO_URL || '').trim();
     const normalizeFlowId = typeof flowRegistry.normalizeFlowId === 'function'
       ? flowRegistry.normalizeFlowId
       : ((value = '', fallback = defaultFlowId) => {
@@ -125,6 +126,10 @@
               'kiro-rs': {
                 baseUrl: defaultKiroRsUrl,
                 apiKey: '',
+              },
+              'kiro-go': {
+                baseUrl: defaultKiroGoUrl,
+                adminPassword: '',
               },
             },
             autoRun: {
@@ -367,6 +372,22 @@
                   ?? defaults.flows.kiro.targets['kiro-rs'].apiKey
                 ),
               },
+              'kiro-go': {
+                ...defaults.flows.kiro.targets['kiro-go'],
+                ...getIntegrationTargetValue(nested, (state) => state.flows?.kiro?.targets?.['kiro-go']),
+                baseUrl: String(
+                  input?.kiroGoUrl
+                  ?? input?.kiroGoBaseUrl
+                  ?? nested?.flows?.kiro?.targets?.['kiro-go']?.baseUrl
+                  ?? defaults.flows.kiro.targets['kiro-go'].baseUrl
+                ).trim() || defaults.flows.kiro.targets['kiro-go'].baseUrl,
+                adminPassword: String(
+                  input?.kiroGoPassword
+                  ?? input?.kiroGoAdminPassword
+                  ?? nested?.flows?.kiro?.targets?.['kiro-go']?.adminPassword
+                  ?? defaults.flows.kiro.targets['kiro-go'].adminPassword
+                ),
+              },
             },
             autoRun: {
               stepExecutionRange: normalizeStepExecutionRangeEntry(
@@ -486,6 +507,8 @@
       next.ipProxyMode = normalizedState.services.proxy.mode;
       next.kiroRsUrl = kiroState.targets['kiro-rs'].baseUrl;
       next.kiroRsKey = kiroState.targets['kiro-rs'].apiKey;
+      next.kiroGoUrl = kiroState.targets['kiro-go'].baseUrl;
+      next.kiroGoPassword = kiroState.targets['kiro-go'].adminPassword;
       next.stepExecutionRangeByFlow = buildStepExecutionRangeByFlow(normalizedState);
       next.settingsSchemaVersion = normalizedState.schemaVersion;
       next.settingsState = cloneValue(normalizedState);
@@ -502,6 +525,8 @@
           targetId,
           kiroRsUrl: normalizedState.flows.kiro.targets['kiro-rs'].baseUrl,
           kiroRsKey: normalizedState.flows.kiro.targets['kiro-rs'].apiKey,
+          kiroGoUrl: normalizedState.flows.kiro.targets['kiro-go'].baseUrl,
+          kiroGoPassword: normalizedState.flows.kiro.targets['kiro-go'].adminPassword,
         };
       }
       return {

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -278,6 +278,32 @@
         <span class="data-label">连接测试</span>
         <span id="display-kiro-rs-test-status" class="data-value mono">未测试</span>
       </div>
+      <div class="data-row" id="row-kiro-go-url" style="display:none;">
+        <span class="data-label">Kiro-Go</span>
+        <div class="data-inline">
+          <input type="text" id="input-kiro-go-url" class="data-input"
+            placeholder="请输入 Kiro-Go 管理地址" />
+          <button id="btn-open-kiro-go-github" class="btn btn-ghost btn-xs data-inline-btn" type="button">GitHub</button>
+        </div>
+      </div>
+      <div class="data-row" id="row-kiro-go-password" style="display:none;">
+        <span class="data-label">管理密码</span>
+        <div class="data-inline">
+          <div class="input-with-icon">
+            <input type="password" id="input-kiro-go-password" class="data-input data-input-with-icon"
+              placeholder="请输入 Kiro-Go 管理密码" />
+            <button id="btn-toggle-kiro-go-password" class="input-icon-btn" type="button"
+              data-password-toggle="input-kiro-go-password" data-show-label="显示 Kiro-Go 管理密码"
+              data-hide-label="隐藏 Kiro-Go 管理密码" aria-label="显示 Kiro-Go 管理密码"
+              title="显示 Kiro-Go 管理密码"></button>
+          </div>
+          <button id="btn-test-kiro-go" class="btn btn-ghost btn-xs data-inline-btn" type="button">测试</button>
+        </div>
+      </div>
+      <div class="data-row" id="row-kiro-go-test-status" style="display:none;">
+        <span class="data-label">连接测试</span>
+        <span id="display-kiro-go-test-status" class="data-value mono">未测试</span>
+      </div>
       <div class="data-row" id="row-kiro-web-status" style="display:none;">
         <span class="data-label">Kiro Web</span>
         <span id="display-kiro-web-status" class="data-value mono">未开始</span>

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -186,6 +186,14 @@ const inputKiroRsKey = document.getElementById('input-kiro-rs-key');
 const btnTestKiroRs = document.getElementById('btn-test-kiro-rs');
 const rowKiroRsTestStatus = document.getElementById('row-kiro-rs-test-status');
 const displayKiroRsTestStatus = document.getElementById('display-kiro-rs-test-status');
+const rowKiroGoUrl = document.getElementById('row-kiro-go-url');
+const inputKiroGoUrl = document.getElementById('input-kiro-go-url');
+const btnOpenKiroGoGithub = document.getElementById('btn-open-kiro-go-github');
+const rowKiroGoPassword = document.getElementById('row-kiro-go-password');
+const inputKiroGoPassword = document.getElementById('input-kiro-go-password');
+const btnTestKiroGo = document.getElementById('btn-test-kiro-go');
+const rowKiroGoTestStatus = document.getElementById('row-kiro-go-test-status');
+const displayKiroGoTestStatus = document.getElementById('display-kiro-go-test-status');
 const rowKiroWebStatus = document.getElementById('row-kiro-web-status');
 const displayKiroWebStatus = document.getElementById('display-kiro-web-status');
 const rowKiroLoginUrl = document.getElementById('row-kiro-login-url');
@@ -580,6 +588,7 @@ let currentPhoneSignupReloginAfterBindEmailEnabled = DEFAULT_PHONE_SIGNUP_RELOGI
 let currentStepDefinitionFlowId = DEFAULT_ACTIVE_FLOW_ID;
 let phoneSignupReuseUiWasLocked = false;
 let kiroRsConnectionTestStatusText = '未测试';
+let kiroGoConnectionTestStatusText = '未测试';
 let heroSmsCountrySelectionOrder = [];
 let phoneSmsProviderOrderSelection = [];
 let heroSmsCountryMenuSearchKeyword = '';
@@ -1566,6 +1575,7 @@ const PRIVACY_MASKED_INPUT_IDS = Object.freeze([
   'input-sub2api-default-proxy',
   'input-codex2api-url',
   'input-kiro-rs-url',
+  'input-kiro-go-url',
   'input-gpc-helper-api',
   'input-gpc-helper-phone',
   'input-gpc-helper-local-sms-url',
@@ -2564,6 +2574,14 @@ function setKiroRsConnectionTestStatus(message = '') {
   kiroRsConnectionTestStatusText = nextText;
   if (typeof displayKiroRsTestStatus !== 'undefined' && displayKiroRsTestStatus) {
     displayKiroRsTestStatus.textContent = nextText;
+  }
+}
+
+function setKiroGoConnectionTestStatus(message = '') {
+  const nextText = String(message || '').trim() || '未测试';
+  kiroGoConnectionTestStatusText = nextText;
+  if (typeof displayKiroGoTestStatus !== 'undefined' && displayKiroGoTestStatus) {
+    displayKiroGoTestStatus.textContent = nextText;
   }
 }
 
@@ -4600,6 +4618,7 @@ function collectSettingsPayload() {
     });
   const flowRegistryApi = typeof getFlowRegistry === 'function' ? getFlowRegistry() : null;
   const defaultKiroRsUrl = String(flowRegistryApi?.DEFAULT_KIRO_RS_URL || '').trim();
+  const defaultKiroGoUrl = String(flowRegistryApi?.DEFAULT_KIRO_GO_URL || '').trim();
   const normalizeKiroTargetIdSafe = typeof normalizeTargetIdForFlow === 'function'
     ? normalizeTargetIdForFlow
     : ((_flowId, targetId = '', fallback = 'kiro-rs') => {
@@ -4611,6 +4630,12 @@ function collectSettingsPayload() {
     : null;
   const currentKiroRsKeyValue = typeof inputKiroRsKey !== 'undefined' && inputKiroRsKey
     ? String(inputKiroRsKey.value ?? '').trim()
+    : null;
+  const currentKiroGoUrlValue = typeof inputKiroGoUrl !== 'undefined' && inputKiroGoUrl
+    ? String(inputKiroGoUrl.value ?? '').trim()
+    : null;
+  const currentKiroGoPasswordValue = typeof inputKiroGoPassword !== 'undefined' && inputKiroGoPassword
+    ? String(inputKiroGoPassword.value ?? '').trim()
     : null;
   const normalizeHostedCheckoutDelaySecondsSafe = typeof normalizePlusHostedCheckoutOauthDelaySeconds === 'function'
     ? normalizePlusHostedCheckoutOauthDelaySeconds
@@ -4639,6 +4664,12 @@ function collectSettingsPayload() {
     kiroRsKey: currentKiroRsKeyValue !== null
       ? currentKiroRsKeyValue
       : String(latestState?.kiroRsKey || '').trim(),
+    kiroGoUrl: currentKiroGoUrlValue !== null
+      ? (currentKiroGoUrlValue || defaultKiroGoUrl)
+      : (String(latestState?.kiroGoUrl || defaultKiroGoUrl).trim() || defaultKiroGoUrl),
+    kiroGoPassword: currentKiroGoPasswordValue !== null
+      ? currentKiroGoPasswordValue
+      : String(latestState?.kiroGoPassword || '').trim(),
     vpsUrl: inputVpsUrl.value.trim(),
     vpsPassword: inputVpsPassword.value,
     localCpaStep9Mode: getSelectedLocalCpaStep9Mode(),
@@ -10717,8 +10748,17 @@ function applySettingsState(state) {
   if (typeof inputKiroRsKey !== 'undefined' && inputKiroRsKey) {
     inputKiroRsKey.value = String(state?.kiroRsKey || '');
   }
+  if (typeof inputKiroGoUrl !== 'undefined' && inputKiroGoUrl) {
+    inputKiroGoUrl.value = String(state?.kiroGoUrl || '').trim();
+  }
+  if (typeof inputKiroGoPassword !== 'undefined' && inputKiroGoPassword) {
+    inputKiroGoPassword.value = String(state?.kiroGoPassword || '');
+  }
   if (typeof displayKiroRsTestStatus !== 'undefined' && displayKiroRsTestStatus) {
     displayKiroRsTestStatus.textContent = kiroRsConnectionTestStatusText;
+  }
+  if (typeof displayKiroGoTestStatus !== 'undefined' && displayKiroGoTestStatus) {
+    displayKiroGoTestStatus.textContent = kiroGoConnectionTestStatusText;
   }
   if (typeof displayKiroWebStatus !== 'undefined' && displayKiroWebStatus) {
     const kiroWebStatus = String(
@@ -14929,6 +14969,10 @@ btnOpenKiroRsGithub?.addEventListener('click', () => {
   openExternalUrl('https://github.com/QLHazyCoder/kiro.rs');
 });
 
+btnOpenKiroGoGithub?.addEventListener('click', () => {
+  openExternalUrl('https://github.com/tech-shrimp/Kiro-Go');
+});
+
 btnGpcHelperBalance?.addEventListener('click', async () => {
   try {
     const response = await chrome.runtime.sendMessage({
@@ -15011,6 +15055,42 @@ btnTestKiroRs?.addEventListener('click', async () => {
   } finally {
     btnTestKiroRs.disabled = false;
     btnTestKiroRs.textContent = defaultLabel;
+  }
+});
+
+
+btnTestKiroGo?.addEventListener('click', async () => {
+  const defaultLabel = btnTestKiroGo.textContent || '测试';
+  btnTestKiroGo.disabled = true;
+  btnTestKiroGo.textContent = '测试中';
+  setKiroGoConnectionTestStatus('测试中...');
+  try {
+    await persistCurrentSettingsForAction();
+    const activeFlowId = typeof getSelectedFlowId === 'function'
+      ? getSelectedFlowId(latestState)
+      : 'kiro';
+    const response = await sendSidepanelMessage({
+      type: 'CHECK_KIRO_GO_CONNECTION',
+      payload: {
+        activeFlowId,
+        targetId: 'kiro-go',
+        baseUrl: String(inputKiroGoUrl?.value || '').trim(),
+        adminPassword: String(inputKiroGoPassword?.value || ''),
+      },
+    });
+    if (response?.error) {
+      throw new Error(response.error);
+    }
+    const message = String(response?.message || '').trim() || 'Kiro-Go 测试完成。';
+    setKiroGoConnectionTestStatus(message);
+    showToast(message, response?.ok ? 'success' : 'error', response?.ok ? 2200 : 4200);
+  } catch (error) {
+    const message = error?.message || 'Kiro-Go 测试失败。';
+    setKiroGoConnectionTestStatus(message);
+    showToast(message, 'error', 4200);
+  } finally {
+    btnTestKiroGo.disabled = false;
+    btnTestKiroGo.textContent = defaultLabel;
   }
 });
 
@@ -15288,6 +15368,17 @@ selectPlusAccountAccessStrategy?.addEventListener('change', () => {
   input?.addEventListener('input', () => {
     markSettingsDirty(true);
     setKiroRsConnectionTestStatus('未测试');
+    scheduleSettingsAutoSave();
+  });
+  input?.addEventListener('blur', () => {
+    saveSettings({ silent: true }).catch(() => { });
+  });
+});
+
+[inputKiroGoUrl, inputKiroGoPassword].forEach((input) => {
+  input?.addEventListener('input', () => {
+    markSettingsDirty(true);
+    setKiroGoConnectionTestStatus('未测试');
     scheduleSettingsAutoSave();
   });
   input?.addEventListener('blur', () => {

--- a/tests/background-kiro-publisher-kiro-rs-module.test.js
+++ b/tests/background-kiro-publisher-kiro-rs-module.test.js
@@ -15,6 +15,8 @@ test('kiro publisher exposes a factory and upload payload helpers', () => {
   assert.equal(typeof api?.createKiroRsPublisher, 'function');
   assert.equal(typeof api?.buildKiroRsPayload, 'function');
   assert.equal(typeof api?.buildMachineId, 'function');
+  assert.equal(typeof api?.checkKiroGoConnection, 'function');
+  assert.equal(typeof api?.uploadBuilderIdCredentialToKiroGo, 'function');
 });
 
 test('kiro publisher builds kiro.rs payload from desktop auth runtime with BuilderId profileArn', async () => {
@@ -169,6 +171,97 @@ test('kiro publisher reads latest kiro.rs key from background state instead of s
   );
   assert.equal(completed.length, 1);
   assert.equal(completed[0].nodeId, 'kiro-upload-credential');
+});
+
+
+test('kiro publisher can upload Builder ID credentials to Kiro-Go', async () => {
+  const api = loadPublisherApi();
+  const requests = [];
+  let liveState = {
+    kiroTargetId: 'kiro-go',
+    email: 'aws-user@example.com',
+    kiroGoUrl: 'https://kiro-go.example.com/admin',
+    kiroGoPassword: 'go-secret',
+    kiroRuntime: {
+      register: {
+        email: 'aws-user@example.com',
+      },
+      desktopAuth: {
+        region: 'us-east-1',
+        clientId: 'client-001',
+        clientSecret: 'secret-001',
+        refreshToken: 'refresh-token-001',
+      },
+      upload: {
+        targetId: 'kiro-go',
+      },
+    },
+    settingsState: {
+      flows: {
+        kiro: {
+          targetId: 'kiro-go',
+          targets: {
+            'kiro-go': {
+              baseUrl: 'https://kiro-go.example.com/admin',
+              adminPassword: 'go-secret',
+            },
+          },
+        },
+      },
+    },
+  };
+  const completed = [];
+  const publisher = api.createKiroRsPublisher({
+    addLog: async () => {},
+    completeNodeFromBackground: async (nodeId, payload) => {
+      completed.push({ nodeId, payload });
+    },
+    fetchImpl: async (url, options = {}) => {
+      requests.push({
+        url,
+        method: options.method || 'GET',
+        adminPassword: options.headers?.['X-Admin-Password'],
+        body: options.body ? JSON.parse(options.body) : null,
+      });
+      if ((options.method || 'GET') === 'GET') {
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          text: async () => JSON.stringify([]),
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => JSON.stringify({
+          success: true,
+          account: { id: 'acc-001', email: 'aws-user@example.com' },
+        }),
+      };
+    },
+    getState: async () => ({ ...liveState }),
+    setState: async (updates = {}) => {
+      liveState = { ...liveState, ...updates };
+    },
+  });
+
+  await publisher.executeKiroUploadCredential({ nodeId: 'kiro-upload-credential' });
+
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0].url, 'https://kiro-go.example.com/admin/api/accounts');
+  assert.equal(requests[0].adminPassword, 'go-secret');
+  assert.equal(requests[1].url, 'https://kiro-go.example.com/admin/api/auth/credentials');
+  assert.equal(requests[1].adminPassword, 'go-secret');
+  assert.equal(requests[1].body.refreshToken, 'refresh-token-001');
+  assert.equal(requests[1].body.clientId, 'client-001');
+  assert.equal(requests[1].body.clientSecret, 'secret-001');
+  assert.equal(requests[1].body.authMethod, 'idc');
+  assert.equal(requests[1].body.provider, 'BuilderId');
+  assert.equal(requests[1].body.region, 'us-east-1');
+  assert.equal(completed.length, 1);
+  assert.equal(liveState.kiroRuntime.upload.credentialId, 'acc-001');
 });
 
 test('kiro publisher routes step 9 through public contribution upload when contribution mode is enabled', async () => {

--- a/tests/flow-registry-settings-schema.test.js
+++ b/tests/flow-registry-settings-schema.test.js
@@ -21,6 +21,7 @@ test('flow registry exposes canonical flow and target metadata', () => {
   assert.equal(flowRegistry.normalizeFlowId('unknown'), 'openai');
   assert.equal(flowRegistry.getFlowLabel('openai'), 'Codex / OpenAI');
   assert.equal(flowRegistry.normalizeTargetId('openai', 'sub2api'), 'sub2api');
+  assert.equal(flowRegistry.normalizeTargetId('kiro', 'kiro-go'), 'kiro-go');
   assert.equal(flowRegistry.normalizeTargetId('kiro', 'anything-else'), 'kiro-rs');
   assert.deepEqual(
     flowRegistry.getVisibleGroupIds('openai', 'cpa'),
@@ -35,10 +36,15 @@ test('flow registry exposes canonical flow and target metadata', () => {
     ['cpa', 'sub2api', 'codex2api']
   );
   assert.deepEqual(
+    flowRegistry.getTargetOptions('kiro').map((entry) => entry.id),
+    ['kiro-rs', 'kiro-go']
+  );
+  assert.deepEqual(
     flowRegistry.getSettingsGroupDefinition('openai-plus')?.rowIds,
     ['row-plus-mode', 'row-plus-account-access-strategy', 'row-plus-payment-method']
   );
   assert.equal(flowRegistry.getPublicationTargetDefinition('kiro', 'kiro-rs')?.label, 'kiro.rs');
+  assert.equal(flowRegistry.getPublicationTargetDefinition('kiro', 'kiro-go')?.label, 'Kiro-Go');
   assert.equal(flowRegistry.getFlowCapabilities('openai').supportsAccountContribution, true);
   assert.equal(flowRegistry.getFlowCapabilities('kiro').supportsAccountContribution, true);
   assert.deepEqual(
@@ -65,6 +71,8 @@ test('settings schema normalizes view input into canonical nested namespaces', (
     plusAccountAccessStrategy: 'sub2api_codex_session',
     kiroRsUrl: 'https://kiro.example.com/admin',
     kiroRsKey: 'secret-key',
+    kiroGoUrl: 'https://kiro-go.example.com/admin',
+    kiroGoPassword: 'admin-secret',
     stepExecutionRangeByFlow: {
       openai: { enabled: true, fromStep: 2, toStep: 9 },
       kiro: { enabled: true, fromStep: 1, toStep: 9 },
@@ -80,6 +88,8 @@ test('settings schema normalizes view input into canonical nested namespaces', (
   assert.equal(normalized.flows.kiro.targetId, 'kiro-rs');
   assert.equal(normalized.flows.kiro.targets['kiro-rs'].baseUrl, 'https://kiro.example.com/admin');
   assert.equal(normalized.flows.kiro.targets['kiro-rs'].apiKey, 'secret-key');
+  assert.equal(normalized.flows.kiro.targets['kiro-go'].baseUrl, 'https://kiro-go.example.com/admin');
+  assert.equal(normalized.flows.kiro.targets['kiro-go'].adminPassword, 'admin-secret');
   assert.deepEqual(normalized.flows.kiro.autoRun.stepExecutionRange, {
     enabled: true,
     fromStep: 1,
@@ -119,6 +129,8 @@ test('settings schema can project canonical state into a read view without legac
     kiroTargetId: 'kiro-rs',
     kiroRsUrl: 'https://kiro.example.com/admin',
     kiroRsKey: 'key-123',
+    kiroGoUrl: 'https://kiro-go.example.com/admin',
+    kiroGoPassword: 'go-secret',
     plusAccountAccessStrategy: 'sub2api_codex_session',
   });
   const view = schema.buildSettingsView(normalized);
@@ -129,6 +141,8 @@ test('settings schema can project canonical state into a read view without legac
   assert.equal(view.panelMode, 'cpa');
   assert.equal(view.kiroRsUrl, 'https://kiro.example.com/admin');
   assert.equal(view.kiroRsKey, 'key-123');
+  assert.equal(view.kiroGoUrl, 'https://kiro-go.example.com/admin');
+  assert.equal(view.kiroGoPassword, 'go-secret');
   assert.equal(view.plusAccountAccessStrategy, 'sub2api_codex_session');
   assert.equal(view.settingsSchemaVersion, 4);
   assert.equal(view.settingsState.activeFlowId, 'kiro');


### PR DESCRIPTION
## Summary
- rebuild on latest upstream `QLHazyCoder/FlowPilot` master (`065607b`)
- add Kiro-Go as a selectable Kiro publishing target alongside kiro.rs
- add Kiro-Go admin URL/password settings and connection test
- upload Builder ID credentials to Kiro-Go via `/admin/api/auth/credentials`

## Tests
- `node --check background/kiro/publisher-kiro-rs.js`
- `node --check background/message-router.js`
- `node --check sidepanel/sidepanel.js`
- `npm test -- --runInBand`