### PR TITLE
添加Yahoo邮箱服务

### DIFF
--- a/background.js
+++ b/background.js
@@ -1303,7 +1303,6 @@ const PERSISTED_SETTING_DEFAULTS = {
   customEmailPool: [],
   customEmailPoolEntries: [],
   yahooMailEmail: '',
-  yahooMailPassword: '',
   autoDeleteUsedIcloudAlias: false,
   icloudHostPreference: 'auto',
   icloudTargetMailboxType: 'icloud-inbox',
@@ -3351,8 +3350,6 @@ function normalizePersistentSettingValue(key, value) {
       return normalizeCustomEmailPoolEntryObjects(value);
     case 'yahooMailEmail':
       return String(value || '').trim();
-    case 'yahooMailPassword':
-      return String(value || '');
     case 'autoDeleteUsedIcloudAlias':
     case 'accountRunHistoryTextEnabled':
     case 'cloudflareTempEmailUseRandomSubdomain':
@@ -14317,7 +14314,7 @@ function getMailConfig(state) {
 
 async function openMailProviderLogin(payload = {}) {
   const state = await getState();
-  const provider = String(payload.provider || state.mailProvider || '').trim() || state.mailProvider || 'qq';
+  const provider = normalizeMailProvider(payload.provider || state.mailProvider || '');
   const mail = getMailConfig({
     ...state,
     mailProvider: provider,
@@ -14343,7 +14340,7 @@ async function openMailProviderLogin(payload = {}) {
       await chrome.tabs.update(tabId, { active: true }).catch(() => { });
     }
     const yahooMailEmail = String(payload.yahooMailEmail || state.yahooMailEmail || '').trim();
-    const yahooMailPassword = String(payload.yahooMailPassword || state.yahooMailPassword || '');
+    const yahooMailPassword = String(payload.yahooMailPassword || '');
     if (provider === YAHOO_PROVIDER && yahooMailEmail && yahooMailPassword) {
       try {
         const loginResult = await sendToContentScriptResilient(mail.source, {

--- a/background.js
+++ b/background.js
@@ -74,6 +74,7 @@ importScripts(
   'background/cloudmail-provider.js',
   'yyds-mail-utils.js',
   'background/yyds-mail-provider.js',
+  'yahoo-utils.js',
   'icloud-utils.js',
   'mail-provider-utils.js',
   'content/activation-utils.js'
@@ -390,6 +391,10 @@ const {
   normalizeYydsMailMessageDetail,
   normalizeYydsMailMessages,
 } = self.YydsMailUtils;
+const {
+  YAHOO_PROVIDER = 'yahoo',
+  YAHOO_GENERATOR = 'yahoo',
+} = self.YahooUtils || {};
 const {
   findIcloudAliasByEmail,
   getConfiguredIcloudHostPreference,
@@ -1297,6 +1302,8 @@ const PERSISTED_SETTING_DEFAULTS = {
   customMailProviderPool: [],
   customEmailPool: [],
   customEmailPoolEntries: [],
+  yahooMailEmail: '',
+  yahooMailPassword: '',
   autoDeleteUsedIcloudAlias: false,
   icloudHostPreference: 'auto',
   icloudTargetMailboxType: 'icloud-inbox',
@@ -2415,6 +2422,9 @@ function normalizeEmailGenerator(value = '') {
   const yydsMailGenerator = typeof YYDS_MAIL_GENERATOR === 'string'
     ? YYDS_MAIL_GENERATOR
     : 'yyds-mail';
+  const yahooGenerator = typeof YAHOO_GENERATOR === 'string'
+    ? YAHOO_GENERATOR
+    : 'yahoo';
   if (normalized === 'custom' || normalized === 'manual') {
     return 'custom';
   }
@@ -2430,6 +2440,7 @@ function normalizeEmailGenerator(value = '') {
   if (normalized === 'cloudflare') return 'cloudflare';
   if (normalized === CLOUDFLARE_TEMP_EMAIL_GENERATOR) return CLOUDFLARE_TEMP_EMAIL_GENERATOR;
   if (normalized === 'cloudmail') return 'cloudmail';
+  if (normalized === yahooGenerator) return yahooGenerator;
   if (normalized === yydsMailGenerator) return yydsMailGenerator;
   return 'duck';
 }
@@ -2669,10 +2680,14 @@ function normalizeMailProvider(value = '') {
   const yydsMailProvider = typeof YYDS_MAIL_PROVIDER === 'string'
     ? YYDS_MAIL_PROVIDER
     : 'yyds-mail';
+  const yahooProvider = typeof YAHOO_PROVIDER === 'string'
+    ? YAHOO_PROVIDER
+    : 'yahoo';
   switch (normalized) {
     case 'custom':
     case ICLOUD_PROVIDER:
     case GMAIL_PROVIDER:
+    case yahooProvider:
     case HOTMAIL_PROVIDER:
     case LUCKMAIL_PROVIDER:
     case CLOUDFLARE_TEMP_EMAIL_PROVIDER:
@@ -3334,6 +3349,10 @@ function normalizePersistentSettingValue(key, value) {
       return normalizeCustomEmailPool(value);
     case 'customEmailPoolEntries':
       return normalizeCustomEmailPoolEntryObjects(value);
+    case 'yahooMailEmail':
+      return String(value || '').trim();
+    case 'yahooMailPassword':
+      return String(value || '');
     case 'autoDeleteUsedIcloudAlias':
     case 'accountRunHistoryTextEnabled':
     case 'cloudflareTempEmailUseRandomSubdomain':
@@ -8671,6 +8690,8 @@ function matchesSourceUrlFamily(source, candidateUrl, referenceUrl) {
       return is163MailHost(candidate.hostname);
     case 'gmail-mail':
       return candidate.hostname === 'mail.google.com';
+    case 'yahoo-mail':
+      return candidate.hostname === 'mail.yahoo.com';
     case 'icloud-mail':
       return candidate.hostname === 'www.icloud.com' || candidate.hostname === 'www.icloud.com.cn';
     case 'inbucket-mail':
@@ -8974,6 +8995,7 @@ function getSourceLabel(source) {
   const labels = {
     'openai-auth': '认证页',
     'gmail-mail': 'Gmail 邮箱',
+    'yahoo-mail': 'Yahoo 邮箱',
     'sidepanel': '侧边栏',
     'signup-page': '认证页',
     'vps-panel': 'CPA 面板',
@@ -11579,6 +11601,9 @@ function getEmailGeneratorLabel(generator) {
   const yydsMailGenerator = typeof YYDS_MAIL_GENERATOR === 'string'
     ? YYDS_MAIL_GENERATOR
     : 'yyds-mail';
+  const yahooGenerator = typeof YAHOO_GENERATOR === 'string'
+    ? YAHOO_GENERATOR
+    : 'yahoo';
   if (generator === 'custom') {
     return '自定义邮箱';
   }
@@ -11594,6 +11619,7 @@ function getEmailGeneratorLabel(generator) {
   if (generator === 'cloudflare') return 'Cloudflare 邮箱';
   if (generator === CLOUDFLARE_TEMP_EMAIL_GENERATOR) return 'Cloudflare Temp Email';
   if (generator === CLOUD_MAIL_GENERATOR) return 'Cloud Mail';
+  if (generator === yahooGenerator) return 'Yahoo 临时邮箱';
   if (generator === yydsMailGenerator) return 'YYDS Mail';
   return 'Duck 邮箱';
 }
@@ -11767,6 +11793,10 @@ async function fetchCloudflareTempEmailAddress(state, options = {}) {
 
 async function fetchDuckEmail(options = {}) {
   return generatedEmailHelpers.fetchDuckEmail(options);
+}
+
+async function fetchYahooTempEmail(state, options = {}) {
+  return generatedEmailHelpers.fetchYahooTempEmail(state, options);
 }
 
 async function fetchGeneratedEmail(state, options = {}) {
@@ -12895,7 +12925,15 @@ async function runAutoSequenceFromNodeGraph(startNodeId, context = {}) {
         if (resolvedSignupMethod === SIGNUP_METHOD_PHONE) {
           await addLog(`=== 目标 ${targetRun}/${totalRuns} 轮：本轮注册方式为手机号注册，将跳过邮箱预获取 ===`, 'info');
         } else {
-          await ensureAutoEmailReady(targetRun, totalRuns, attemptRuns);
+          const readyEmail = await ensureAutoEmailReady(targetRun, totalRuns, attemptRuns);
+          const normalizedReadyEmail = String(readyEmail || '').trim();
+          if (normalizedReadyEmail) {
+            const latestEmailState = await getState();
+            const normalizedStateEmail = String(latestEmailState?.email || '').trim();
+            if (normalizedStateEmail.toLowerCase() !== normalizedReadyEmail.toLowerCase()) {
+              await setEmailState(normalizedReadyEmail);
+            }
+          }
         }
         await executeNodeAndWait('submit-signup-email', getAutoRunNodeDelayMs('submit-signup-email'));
       });
@@ -13318,12 +13356,14 @@ const verificationFlowHelpers = self.MultiPageBackgroundVerificationFlow?.create
   getHotmailVerificationPollConfig,
   getHotmailVerificationRequestTimestamp,
   handleMail2925LimitReachedError,
+  ensureContentScriptReadyOnTab,
   getState,
   getTabId,
   HOTMAIL_PROVIDER,
   isMail2925LimitReachedError,
   isRetryableContentScriptTransportError,
   isStopError,
+  isTabAlive,
   LUCKMAIL_PROVIDER,
   YYDS_MAIL_PROVIDER,
   MAIL_2925_VERIFICATION_INTERVAL_MS,
@@ -13333,6 +13373,7 @@ const verificationFlowHelpers = self.MultiPageBackgroundVerificationFlow?.create
   pollHotmailVerificationCode,
   pollLuckmailVerificationCode,
   pollYydsMailVerificationCode,
+  reuseOrCreateTab,
   sendToContentScript,
   sendToContentScriptResilient,
   sendToMailContentScriptResilient,
@@ -13903,6 +13944,7 @@ const messageRouter = self.MultiPageBackgroundMessageRouter?.createMessageRouter
   executeNodeViaCompletionSignal,
   exportSettingsBundle,
   fetchGeneratedEmail,
+  openMailProviderLogin,
   refreshGpcCardBalance,
   finalizePhoneActivationAfterSuccessfulFlow,
   testKiroRsConnection: async (baseUrl, apiKey) => {
@@ -14122,8 +14164,17 @@ async function ensureSignupPostEmailPageReadyInTab(tabId, step = 2, options = {}
   return signupFlowHelpers.ensureSignupPostEmailPageReadyInTab(tabId, step, options);
 }
 
-async function resolveSignupEmailForFlow(state) {
-  return signupFlowHelpers.resolveSignupEmailForFlow(state);
+async function resolveSignupEmailForFlow(state, options = {}) {
+  let latestState = null;
+  try {
+    latestState = await getState();
+  } catch {
+    latestState = null;
+  }
+  return signupFlowHelpers.resolveSignupEmailForFlow({
+    ...(state || {}),
+    ...(latestState || {}),
+  }, options);
 }
 
 // ============================================================
@@ -14159,11 +14210,25 @@ function getMailConfig(state) {
   const yydsMailProvider = typeof YYDS_MAIL_PROVIDER === 'string'
     ? YYDS_MAIL_PROVIDER
     : 'yyds-mail';
+  const yahooProvider = typeof YAHOO_PROVIDER === 'string'
+    ? YAHOO_PROVIDER
+    : 'yahoo';
   if (provider === 'custom') {
     return { provider: 'custom', label: '自定义邮箱' };
   }
   if (provider === HOTMAIL_PROVIDER) {
     return { provider: HOTMAIL_PROVIDER, label: 'Hotmail（API对接/本地助手）' };
+  }
+  if (provider === yahooProvider) {
+    return {
+      provider: yahooProvider,
+      source: 'yahoo-mail',
+      url: 'https://mail.yahoo.com/n/inbox/all?listFilter=ALL_INBOX',
+      label: 'Yahoo 邮箱',
+      navigateOnReuse: true,
+      inject: ['content/activation-utils.js', 'shared/source-registry.js', 'content/utils.js', 'content/yahoo-mail.js'],
+      injectSource: 'yahoo-mail',
+    };
   }
   if (provider === ICLOUD_PROVIDER) {
     const configuredHost = getConfiguredIcloudHostPreference(state)
@@ -14248,6 +14313,74 @@ function getMailConfig(state) {
     };
   }
   return { source: 'qq-mail', url: 'https://wx.mail.qq.com/', label: 'QQ 邮箱' };
+}
+
+async function openMailProviderLogin(payload = {}) {
+  const state = await getState();
+  const provider = String(payload.provider || state.mailProvider || '').trim() || state.mailProvider || 'qq';
+  const mail = getMailConfig({
+    ...state,
+    mailProvider: provider,
+  });
+
+  if (mail?.error) {
+    throw new Error(mail.error);
+  }
+
+  const requestedUrl = String(payload.url || '').trim();
+  const targetUrl = requestedUrl || String(mail?.url || '').trim();
+  if (!targetUrl) {
+    throw new Error(`${mail?.label || provider || '当前邮箱服务'}没有可跳转的登录页。`);
+  }
+
+  if (mail?.source) {
+    const tabId = await reuseOrCreateTab(mail.source, targetUrl, {
+      inject: mail.inject,
+      injectSource: mail.injectSource,
+      navigateOnReuse: mail.navigateOnReuse !== false,
+    });
+    if (payload.active !== false && Number.isInteger(tabId)) {
+      await chrome.tabs.update(tabId, { active: true }).catch(() => { });
+    }
+    const yahooMailEmail = String(payload.yahooMailEmail || state.yahooMailEmail || '').trim();
+    const yahooMailPassword = String(payload.yahooMailPassword || state.yahooMailPassword || '');
+    if (provider === YAHOO_PROVIDER && yahooMailEmail && yahooMailPassword) {
+      try {
+        const loginResult = await sendToContentScriptResilient(mail.source, {
+          type: 'YAHOO_LOGIN_WITH_CREDENTIALS',
+          payload: {
+            email: yahooMailEmail,
+            password: yahooMailPassword,
+          },
+        }, {
+          responseTimeoutMs: 45000,
+          logLabel: '填写 Yahoo 邮箱登录账号密码',
+        });
+        if (loginResult?.submitted) {
+          await addLog('Yahoo 邮箱：已自动填写登录账号密码并提交。', 'ok');
+        }
+      } catch (err) {
+        await addLog(`Yahoo 邮箱：自动填写登录账号密码失败，请在打开的页面手动完成登录。原因：${getErrorMessage(err)}`, 'warn');
+      }
+    }
+    await addLog(`${mail.label || '邮箱'}：已打开登录/收件箱页面。`, 'info');
+    return {
+      ok: true,
+      provider,
+      source: mail.source,
+      tabId,
+      url: targetUrl,
+    };
+  }
+
+  const tab = await chrome.tabs.create({ url: targetUrl, active: true });
+  await addLog(`${mail?.label || '邮箱'}：已打开登录页面。`, 'info');
+  return {
+    ok: true,
+    provider,
+    tabId: tab?.id ?? null,
+    url: targetUrl,
+  };
 }
 
 function normalizeInbucketOrigin(rawValue) {

--- a/background/generated-email-helpers.js
+++ b/background/generated-email-helpers.js
@@ -221,6 +221,53 @@
       return result.email;
     }
 
+    async function fetchYahooTempEmail(state, options = {}) {
+      throwIfStopped();
+      const latestState = state || await getState();
+      const yahooSettingsUrl = 'https://mail.yahoo.com/n/settings/2';
+      await addLog('Yahoo 临时邮箱：正在打开设置页并准备创建新别名...', 'info');
+
+      const yahooTabOptions = {
+        navigateOnReuse: true,
+        inject: ['content/activation-utils.js', 'shared/source-registry.js', 'content/utils.js', 'content/yahoo-mail.js'],
+        injectSource: 'yahoo-mail',
+      };
+      await reuseOrCreateTab('yahoo-mail', yahooSettingsUrl, yahooTabOptions);
+
+      const createMessage = {
+        type: 'YAHOO_CREATE_TEMP_ALIAS',
+        source: 'background',
+        payload: {
+          prefix: String(options.prefix || latestState.emailPrefix || '').trim().toLowerCase(),
+        },
+      };
+      const sendCreateRequest = async () => sendToContentScript('yahoo-mail', createMessage, {
+        responseTimeoutMs: 120000,
+      });
+
+      let result = await sendCreateRequest();
+      if (result?.error && shouldRetryYahooAliasCreationInForeground(result.error)) {
+        await addLog(`Yahoo 临时邮箱：后台创建需要前台页面交互，正在自动切换到 Yahoo 设置页后重试。原因：${result.error}`, 'warn');
+        await reuseOrCreateTab('yahoo-mail', yahooSettingsUrl, yahooTabOptions);
+        result = await sendCreateRequest();
+      }
+
+      if (result?.error) {
+        throw new Error(result.error);
+      }
+      if (!result?.email) {
+        throw new Error('Yahoo 临时邮箱创建后未返回可用邮箱地址。');
+      }
+
+      await setEmailState(result.email);
+      await addLog(`Yahoo 临时邮箱：已创建 ${result.email}`, 'ok');
+      return result.email;
+    }
+
+    function shouldRetryYahooAliasCreationInForeground(message = '') {
+      return /未找到“新建一次性电子邮箱|未找到“新建一次性电子邮箱\/地址|点击“添加”后未出现创建面板|未找到一次性邮箱输入框|未找到保存\/创建按钮|创建面板/.test(String(message || ''));
+    }
+
     async function fetchCustomEmailPoolEmail(state, options = {}) {
       throwIfStopped();
       const latestState = state || await getState();
@@ -340,6 +387,9 @@
       if (generator === CLOUDFLARE_TEMP_EMAIL_GENERATOR) {
         return fetchCloudflareTempEmailAddress(mergedState, options);
       }
+      if (generator === 'yahoo') {
+        return fetchYahooTempEmail(mergedState, options);
+      }
       const resolvedDuckBaselineEmail = typeof getRegistrationEmailBaseline === 'function'
         ? getRegistrationEmailBaseline(mergedState, {
           preferredEmail: options.currentEmail,
@@ -365,6 +415,7 @@
       fetchCloudflareTempEmailAddress,
       fetchDuckEmail,
       fetchGeneratedEmail,
+      fetchYahooTempEmail,
       generateCloudflareAliasLocalPart,
       requestCloudflareTempEmailJson,
     };

--- a/background/kiro/desktop-authorize-runner.js
+++ b/background/kiro/desktop-authorize-runner.js
@@ -913,6 +913,125 @@
       return Math.max(45000, maxAttempts * intervalMs + 25000);
     }
 
+    async function pollYahooKiroDesktopOtpCode(step, state = {}, mail = {}, pollPayload = {}, nodeId = '') {
+      const maxAttempts = Math.max(1, Math.floor(Number(pollPayload?.maxAttempts) || 5));
+      const intervalMs = Math.max(1000, Number(pollPayload?.intervalMs) || 3000);
+      const requestedAt = Math.max(0, Number(pollPayload?.filterAfterTimestamp || Date.now()) || Date.now());
+      let lastObservedTopMessageFingerprint = '';
+      let lastError = null;
+
+      await log(`步骤 ${step}：Yahoo 使用专用 Kiro 桌面授权取码链路：打开收件箱、检查顶部 AWS/Kiro 邮件，必要时点进邮件正文读码。`, 'warn', nodeId);
+      await focusOrOpenMailTab(mail);
+
+      for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+        throwIfStopped();
+        let result = await sendToMailContentScriptResilient(
+          mail,
+          {
+            type: 'YAHOO_CHECK_TOP_MESSAGE',
+            step,
+            source: 'background',
+            payload: {
+              ...pollPayload,
+              intervalMs,
+              maxAttempts: 1,
+              keepRefreshingUntilCode: false,
+              yahooTopRowOnly: true,
+              requestedAt,
+              previousTopMessageFingerprint: lastObservedTopMessageFingerprint,
+              previousAcceptedEmailTimestamp: 0,
+              yahooFreshnessSkewMs: Math.max(intervalMs * 2, 180000),
+            },
+          },
+          {
+            timeoutMs: 30000,
+            responseTimeoutMs: 30000,
+            maxRecoveryAttempts: 2,
+            logStep: step,
+            logStepKey: 'kiro-complete-desktop-authorize',
+          }
+        );
+
+        if (result?.error) {
+          throw new Error(result.error);
+        }
+        if (result?.needsOpenDetails) {
+          await log(`步骤 ${step}：Yahoo 顶部 Kiro/AWS 桌面授权邮件需要点进正文，正在单独打开详情页。`, 'warn', nodeId);
+          await sendToMailContentScriptResilient(
+            mail,
+            {
+              type: 'YAHOO_OPEN_TOP_MESSAGE',
+              step,
+              source: 'background',
+              payload: {
+                ...pollPayload,
+                forceOpenTopMessage: true,
+              },
+            },
+            {
+              timeoutMs: 6000,
+              responseTimeoutMs: 3000,
+              maxRecoveryAttempts: 0,
+              logStep: step,
+              logStepKey: 'kiro-complete-desktop-authorize',
+            }
+          ).catch((error) => {
+            log(`步骤 ${step}：Yahoo 打开桌面授权邮件详情命令已发出，但响应异常，将继续尝试读取当前页面正文：${getErrorMessage(error)}`, 'warn', nodeId);
+          });
+          result = {
+            ...result,
+            detailOpened: true,
+          };
+        }
+        if (result?.needsDetailRead || result?.detailOpened) {
+          await log(`步骤 ${step}：Yahoo 正在重连内容脚本读取桌面授权邮件正文验证码。`, 'warn', nodeId);
+          await sleepWithStop(1500);
+          result = await sendToMailContentScriptResilient(
+            mail,
+            {
+              type: 'YAHOO_READ_CURRENT_MESSAGE_CODE',
+              step,
+              source: 'background',
+              payload: {
+                ...pollPayload,
+              },
+            },
+            {
+              timeoutMs: 25000,
+              responseTimeoutMs: 20000,
+              maxRecoveryAttempts: 0,
+              logStep: step,
+              logStepKey: 'kiro-complete-desktop-authorize',
+            }
+          );
+          if (result?.error) {
+            throw new Error(result.error);
+          }
+        }
+        if (result?.topMessageFingerprint !== undefined) {
+          lastObservedTopMessageFingerprint = String(result.topMessageFingerprint || '').trim();
+        }
+        if (result?.code && result.freshnessMatched !== false) {
+          await log(`步骤 ${step}：Yahoo 已从 Kiro/AWS 邮件读取桌面授权验证码 ${result.code}`, 'warn', nodeId);
+          return result;
+        }
+
+        lastError = new Error(result?.reason || `步骤 ${step}：Yahoo 顶部 Kiro/AWS 邮件暂未读取到桌面授权验证码。`);
+        if (attempt < maxAttempts) {
+          await log(`步骤 ${step}：Yahoo 暂未命中 Kiro 桌面授权验证码，${Math.round(intervalMs / 1000)} 秒后刷新收件箱重试（${attempt}/${maxAttempts}）。`, 'warn', nodeId);
+          await sleepWithStop(intervalMs);
+          await reuseOrCreateTab(mail.source, mail.url, {
+            inject: mail.inject,
+            injectSource: mail.injectSource,
+            navigateOnReuse: true,
+            reloadIfSameUrl: true,
+          });
+        }
+      }
+
+      throw lastError || new Error(`步骤 ${step}：Yahoo Kiro 桌面授权取码链路结束，但未获取到验证码。`);
+    }
+
     async function pollDesktopOtpCode(step, state = {}, nodeId = '') {
       if (typeof getMailConfig !== 'function') {
         throw new Error('Kiro 桌面授权验证码步骤缺少邮箱配置能力，无法继续执行。');
@@ -975,6 +1094,10 @@
 
       if (typeof sendToMailContentScriptResilient !== 'function') {
         throw new Error('Kiro 桌面授权验证码步骤缺少邮箱内容脚本通信能力，无法继续执行。');
+      }
+
+      if (mail.provider === 'yahoo') {
+        return pollYahooKiroDesktopOtpCode(step, state, mail, pollPayload, nodeId);
       }
 
       const responseTimeoutMs = getMailPollingResponseTimeoutMs(pollPayload);

--- a/background/kiro/register-runner.js
+++ b/background/kiro/register-runner.js
@@ -32,6 +32,8 @@
     'https://profile.aws.amazon.com',
   ]);
   const MAIL_2925_FILTER_LOOKBACK_MS = 10 * 60 * 1000;
+  const KIRO_YAHOO_VERIFICATION_RESEND_INTERVAL_MS = 60 * 1000;
+  const KIRO_YAHOO_VERIFICATION_MAX_ATTEMPTS = 45;
   const KIRO_AWS_VERIFICATION_CODE_PATTERNS = Object.freeze([
     Object.freeze({
       source: '(?:verification\\s*code|验证码|Your code is|code is)[：:\\s]*(\\d{6})',
@@ -857,12 +859,16 @@
       const runtimeState = readKiroRuntime(state);
       const targetEmail = cleanString(runtimeState.register?.email || state?.email).toLowerCase();
       const targetEmailHints = targetEmail ? [targetEmail] : [];
-      const isMail2925Provider = String(mail?.provider || '').trim().toLowerCase() === '2925';
       const normalizedProvider = String(mail?.provider || '').trim().toLowerCase();
-      const maxAttempts = normalizedProvider === String(LUCKMAIL_PROVIDER || '').trim().toLowerCase()
+      const isMail2925Provider = normalizedProvider === '2925';
+      const isYahooProvider = normalizedProvider === 'yahoo';
+      const isLuckmailProvider = normalizedProvider === String(LUCKMAIL_PROVIDER || '').trim().toLowerCase();
+      const maxAttempts = isYahooProvider
+        ? KIRO_YAHOO_VERIFICATION_MAX_ATTEMPTS
+        : (isLuckmailProvider
         ? 3
-        : (isMail2925Provider ? MAIL_2925_VERIFICATION_MAX_ATTEMPTS : 5);
-      const intervalMs = normalizedProvider === String(LUCKMAIL_PROVIDER || '').trim().toLowerCase()
+          : (isMail2925Provider ? MAIL_2925_VERIFICATION_MAX_ATTEMPTS : 5));
+      const intervalMs = isLuckmailProvider
         ? 15000
         : (isMail2925Provider ? MAIL_2925_VERIFICATION_INTERVAL_MS : 3000);
 
@@ -887,6 +893,306 @@
       const maxAttempts = Math.max(1, Math.floor(Number(payload?.maxAttempts) || 1));
       const intervalMs = Math.max(1, Number(payload?.intervalMs) || 3000);
       return Math.max(45000, maxAttempts * intervalMs + 25000);
+    }
+
+    async function readKiroYahooTopMessageViaScripting(step, mail = {}, pollPayload = {}, nodeId = '') {
+      if (!chrome?.scripting?.executeScript) {
+        return null;
+      }
+
+      let tabId = await getTabId(mail.source);
+      if (!Number.isInteger(tabId) || !(await isTabAlive(mail.source))) {
+        tabId = await reuseOrCreateTab(mail.source, mail.url, {
+          inject: mail.inject,
+          injectSource: mail.injectSource,
+          navigateOnReuse: true,
+        });
+      }
+      if (!Number.isInteger(tabId)) {
+        return null;
+      }
+
+      const [{ result } = {}] = await chrome.scripting.executeScript({
+        target: { tabId },
+        func: (payload) => {
+          const normalizeText = (value) => String(value || '').replace(/\s+/g, ' ').trim();
+          const normalizeLowerText = (value) => normalizeText(value).toLowerCase();
+          const isVisible = (node) => {
+            if (!(node instanceof HTMLElement)) return false;
+            const style = getComputedStyle(node);
+            if (style.display === 'none' || style.visibility === 'hidden') return false;
+            const rect = node.getBoundingClientRect();
+            return rect.width > 0
+              && rect.height > 0
+              && rect.bottom > 0
+              && rect.right > 0
+              && rect.top < (window.innerHeight || document.documentElement.clientHeight || 99999)
+              && rect.left < (window.innerWidth || document.documentElement.clientWidth || 99999);
+          };
+          const joinUnique = (parts) => {
+            const seen = new Set();
+            return normalizeText(parts
+              .map((part) => normalizeText(part))
+              .filter(Boolean)
+              .filter((part) => {
+                if (seen.has(part)) return false;
+                seen.add(part);
+                return true;
+              })
+              .join(' '));
+          };
+          const rowText = (row) => {
+            const nodes = Array.from(row.querySelectorAll([
+              '[id^="email-sender-"]',
+              '[id^="email-subject-snippet-"]',
+              '[id^="email-subject-"]',
+              '[id^="email-snippet-"]',
+              '[id^="email-date-"]',
+              '[title]',
+            ].join(',')));
+            return joinUnique([
+              row.getAttribute('aria-label'),
+              row.getAttribute('title'),
+              row.innerText,
+              row.textContent,
+              ...nodes.map((node) => [
+                node.getAttribute?.('aria-label'),
+                node.getAttribute?.('title'),
+                node.innerText,
+                node.textContent,
+              ].filter(Boolean).join(' ')),
+            ]);
+          };
+          const extractCode = (text) => {
+            const source = String(text || '');
+            const patterns = Array.isArray(payload?.codePatterns) ? payload.codePatterns : [];
+            for (const pattern of patterns) {
+              try {
+                const regex = new RegExp(String(pattern?.source || pattern || ''), String(pattern?.flags || 'i'));
+                const match = source.match(regex);
+                const code = match?.[1] || match?.[0];
+                const normalized = String(code || '').match(/\b(\d{6})\b/)?.[1] || '';
+                if (normalized) return normalized;
+              } catch {}
+            }
+            return source.match(/(?:验证码|verification\s*code|code(?:\s+is)?)[^0-9]{0,24}(\d{6})/i)?.[1]
+              || source.match(/\b(\d{6})\b/)?.[1]
+              || '';
+          };
+          const rows = Array.from(document.querySelectorAll([
+            'li[data-test-id="message-list-item"]',
+            '[data-test-id="message-list"] li[data-test-id="message-list-item"]',
+            '[data-test-id="virtual-list"] li[data-test-id="message-list-item"]',
+            'li.H_A.hd_n.p_a.L_0.R_0',
+          ].join(',')))
+            .filter(isVisible)
+            .sort((left, right) => {
+              const leftRect = left.getBoundingClientRect();
+              const rightRect = right.getBoundingClientRect();
+              if (Math.abs(leftRect.top - rightRect.top) > 4) return leftRect.top - rightRect.top;
+              return leftRect.left - rightRect.left;
+            })
+            .slice(0, 8);
+
+          const topRow = rows[0] || null;
+          if (!topRow) {
+            return { ok: false, code: null, reason: '后台直读未找到可见 Yahoo 邮件行', preview: '' };
+          }
+          const text = rowText(topRow);
+          const lower = normalizeLowerText(text);
+          const looksKiroAws = /no-?reply@signin\.aws|signin\.aws|amazon web services|aws/.test(lower)
+            && /构建者|builder id|verification|验证码|code/.test(lower);
+          if (!looksKiroAws) {
+            return {
+              ok: false,
+              code: null,
+              reason: '后台直读顶部邮件不是 AWS/Kiro 验证邮件',
+              preview: text.slice(0, 200),
+              topMessageFingerprint: text.slice(0, 240),
+            };
+          }
+          const code = extractCode(text);
+          if (!code) {
+            return {
+              ok: false,
+              code: null,
+              reason: '后台直读顶部 AWS/Kiro 邮件未提取到验证码',
+              preview: text.slice(0, 200),
+              topMessageFingerprint: text.slice(0, 240),
+              needsOpenDetails: true,
+              needsDetailRead: true,
+            };
+          }
+          return {
+            ok: true,
+            code,
+            emailTimestamp: Date.now(),
+            preview: text.slice(0, 200),
+            topMessageFingerprint: text.slice(0, 240),
+            freshnessMatched: true,
+            freshnessReason: '后台 executeScript 直接读取 Yahoo 顶部 AWS/Kiro 邮件行',
+          };
+        },
+        args: [pollPayload],
+      });
+
+      if (result?.code) {
+        await log(`步骤 ${step}：Yahoo 后台直读已从顶部 AWS/Kiro 邮件行提取验证码 ${result.code}`, 'warn', nodeId);
+      }
+      return result || null;
+    }
+
+    async function resendKiroVerificationCodeFromRegisterPage(step, state = {}, nodeId = '') {
+      const tabId = await activateKiroRegisterTab(state, {
+        missingUrlMessage: '缺少 Kiro 注册页地址，无法重新发送验证码，请先执行步骤 1。',
+        openFailedMessage: '无法恢复 Kiro 注册页，无法重新发送验证码，请重新执行步骤 1。',
+      });
+      await ensureKiroPageState(tabId, {
+        step,
+        targetStates: ['register_otp_page'],
+        stableMs: 900,
+        initialDelayMs: 100,
+        injectLogMessage: `步骤 ${step}：Kiro 验证码页内容脚本未就绪，正在等待页面恢复后重新发送验证码...`,
+        readyLogMessage: `步骤 ${step}：正在确认 Kiro 验证码页以重新发送验证码...`,
+        timeoutMessage: 'Kiro 验证码页未恢复，无法点击重新发送验证码。',
+      });
+      const result = await sendToContentScriptResilient(KIRO_REGISTER_PAGE_SOURCE_ID, {
+        type: 'KIRO_RESEND_VERIFICATION_CODE',
+        step,
+        source: 'background',
+        payload: {
+          timeoutMs: 30000,
+          retryDelayMs: 250,
+        },
+      }, {
+        timeoutMs: 35000,
+        retryDelayMs: 700,
+        onRetryableError: buildKiroRetryRecovery(tabId, {}),
+        logStep: step,
+        logStepKey: 'kiro-submit-verification-code',
+        logMessage: `步骤 ${step}：正在回到 Kiro 验证码页点击重新发送...`,
+      });
+      if (result?.error) {
+        throw new Error(result.error);
+      }
+      await log(`步骤 ${step}：已在 Kiro 页面点击重新发送验证码，继续回 Yahoo 读取新邮件。`, 'warn', nodeId);
+      return result || { resent: true };
+    }
+
+    async function pollYahooKiroVerificationCode(step, state = {}, mail = {}, pollPayload = {}, nodeId = '') {
+      const maxAttempts = Math.max(1, Math.floor(Number(pollPayload?.maxAttempts) || 5));
+      const intervalMs = Math.max(1000, Number(pollPayload?.intervalMs) || 3000);
+      const requestedAt = Math.max(0, Number(pollPayload?.filterAfterTimestamp || Date.now()) || Date.now());
+      let lastObservedTopMessageFingerprint = '';
+      let lastKiroResendAt = Date.now();
+      let lastError = null;
+
+      await log(`步骤 ${step}：Yahoo 使用专用 Kiro 取码链路：打开收件箱、检查顶部 AWS/Kiro 邮件，必要时点进邮件正文读码。`, 'warn', nodeId);
+      await focusOrOpenMailTab(mail);
+
+      for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+        throwIfStopped();
+        const yahooPayload = {
+          ...pollPayload,
+          intervalMs,
+          maxAttempts: 1,
+          keepRefreshingUntilCode: false,
+          yahooTopRowOnly: true,
+          requestedAt,
+          previousTopMessageFingerprint: lastObservedTopMessageFingerprint,
+          previousAcceptedEmailTimestamp: 0,
+          yahooFreshnessSkewMs: Math.max(intervalMs * 2, 180000),
+        };
+        let result = await readKiroYahooTopMessageViaScripting(step, mail, yahooPayload, nodeId);
+        if (!result?.code) {
+          lastError = new Error(result?.reason || `步骤 ${step}：Yahoo 后台直读未获取到 Kiro/AWS 验证码。`);
+        }
+
+        if (result?.error) {
+          throw new Error(result.error);
+        }
+        if (result?.needsOpenDetails) {
+          await log(`步骤 ${step}：Yahoo 顶部 Kiro/AWS 邮件需要点进正文，正在单独打开详情页。`, 'warn', nodeId);
+          await sendToMailContentScriptResilient(
+            mail,
+            {
+              type: 'YAHOO_OPEN_TOP_MESSAGE',
+              step,
+              source: 'background',
+              payload: {
+                ...pollPayload,
+                forceOpenTopMessage: true,
+              },
+            },
+            {
+              timeoutMs: 6000,
+              responseTimeoutMs: 3000,
+              maxRecoveryAttempts: 0,
+              logStep: step,
+              logStepKey: 'kiro-submit-verification-code',
+            }
+          ).catch((error) => {
+            log(`步骤 ${step}：Yahoo 打开邮件详情命令已发出，但响应异常，将继续尝试读取当前页面正文：${getErrorMessage(error)}`, 'warn', nodeId);
+          });
+          result = {
+            ...result,
+            detailOpened: true,
+          };
+        }
+        if (result?.needsDetailRead || result?.detailOpened) {
+          await log(`步骤 ${step}：Yahoo 正在重连内容脚本读取正文验证码。`, 'warn', nodeId);
+          await sleepWithStop(1500);
+          result = await sendToMailContentScriptResilient(
+            mail,
+            {
+              type: 'YAHOO_READ_CURRENT_MESSAGE_CODE',
+              step,
+              source: 'background',
+              payload: {
+                ...pollPayload,
+              },
+            },
+            {
+              timeoutMs: 25000,
+              responseTimeoutMs: 20000,
+              maxRecoveryAttempts: 0,
+              logStep: step,
+              logStepKey: 'kiro-submit-verification-code',
+            }
+          );
+          if (result?.error) {
+            throw new Error(result.error);
+          }
+        }
+        if (result?.topMessageFingerprint !== undefined) {
+          lastObservedTopMessageFingerprint = String(result.topMessageFingerprint || '').trim();
+        }
+        if (result?.code && result.freshnessMatched !== false) {
+          await log(`步骤 ${step}：Yahoo 已从 Kiro/AWS 邮件读取验证码 ${result.code}`, 'warn', nodeId);
+          return result;
+        }
+
+        lastError = new Error(result?.reason || `步骤 ${step}：Yahoo 顶部 Kiro/AWS 邮件暂未读取到验证码。`);
+        if (attempt < maxAttempts) {
+          if (Date.now() - lastKiroResendAt >= KIRO_YAHOO_VERIFICATION_RESEND_INTERVAL_MS) {
+            await log(`步骤 ${step}：Yahoo 等待超过 1 分钟仍未收到 Kiro 验证码，回 Kiro 页面点击重新发送。`, 'warn', nodeId);
+            await resendKiroVerificationCodeFromRegisterPage(step, state, nodeId);
+            lastKiroResendAt = Date.now();
+            lastObservedTopMessageFingerprint = '';
+            await focusOrOpenMailTab(mail);
+          }
+          await log(`步骤 ${step}：Yahoo 暂未命中 Kiro 验证码，${Math.round(intervalMs / 1000)} 秒后刷新收件箱重试（${attempt}/${maxAttempts}）。`, 'warn', nodeId);
+          await sleepWithStop(intervalMs);
+          await reuseOrCreateTab(mail.source, mail.url, {
+            inject: mail.inject,
+            injectSource: mail.injectSource,
+            navigateOnReuse: true,
+            reloadIfSameUrl: true,
+          });
+        }
+      }
+
+      throw lastError || new Error(`步骤 ${step}：Yahoo Kiro 取码链路结束，但未获取到验证码。`);
     }
 
     async function pollKiroVerificationCode(step, state = {}, nodeId = '') {
@@ -953,6 +1259,10 @@
 
       if (typeof sendToMailContentScriptResilient !== 'function') {
         throw new Error('Kiro 验证码步骤缺少邮箱内容脚本通信能力，无法继续执行。');
+      }
+
+      if (mail.provider === 'yahoo') {
+        return pollYahooKiroVerificationCode(step, state, mail, pollPayload, nodeId);
       }
 
       const responseTimeoutMs = getMailPollingResponseTimeoutMs(pollPayload);

--- a/background/logging-status.js
+++ b/background/logging-status.js
@@ -21,6 +21,7 @@
       const labels = {
         'openai-auth': '认证页',
         'gmail-mail': 'Gmail 邮箱',
+        'yahoo-mail': 'Yahoo 邮箱',
         'sidepanel': '侧边栏',
         'signup-page': '认证页',
         'vps-panel': 'CPA 面板',

--- a/background/navigation-utils.js
+++ b/background/navigation-utils.js
@@ -139,7 +139,9 @@
         case 'gmail-mail':
           return candidate.hostname === 'mail.google.com';
         case 'yahoo-mail':
-          return candidate.hostname === 'mail.yahoo.com';
+          return candidate.hostname === 'mail.yahoo.com'
+            || candidate.hostname === 'login.yahoo.com'
+            || candidate.hostname === 'guce.yahoo.com';
         case 'icloud-mail':
           return candidate.hostname === 'www.icloud.com'
             || candidate.hostname === 'www.icloud.com.cn';

--- a/background/navigation-utils.js
+++ b/background/navigation-utils.js
@@ -138,6 +138,8 @@
           return is163MailHost(candidate.hostname);
         case 'gmail-mail':
           return candidate.hostname === 'mail.google.com';
+        case 'yahoo-mail':
+          return candidate.hostname === 'mail.yahoo.com';
         case 'icloud-mail':
           return candidate.hostname === 'www.icloud.com'
             || candidate.hostname === 'www.icloud.com.cn';

--- a/background/steps/fetch-login-code.js
+++ b/background/steps/fetch-login-code.js
@@ -389,24 +389,10 @@
     }
 
     function resolveEffectiveMailProvider(mail = {}, state = {}) {
-      const explicitProvider = String(mail?.provider || '').trim().toLowerCase();
-      if (explicitProvider) return explicitProvider;
-
-      const stateProvider = String(state?.mailProvider || '').trim().toLowerCase();
-      if (stateProvider) return stateProvider;
-
-      const source = String(mail?.source || '').trim().toLowerCase();
-      const injectSource = String(mail?.injectSource || '').trim().toLowerCase();
-      const label = String(mail?.label || '').trim().toLowerCase();
-      const url = String(mail?.url || '').trim().toLowerCase();
-      const combined = `${source} ${injectSource} ${label} ${url}`;
-      if (/yahoo/.test(combined)) return 'yahoo';
-      if (/2925/.test(combined)) return '2925';
-      if (/hotmail/.test(combined)) return HOTMAIL_PROVIDER;
-      if (/luckmail/.test(combined)) return LUCKMAIL_PROVIDER;
-      if (/cloudmail/.test(combined)) return CLOUD_MAIL_PROVIDER;
-      if (/cloudflare/.test(combined)) return CLOUDFLARE_TEMP_EMAIL_PROVIDER;
-      return explicitProvider || stateProvider || '';
+      if (typeof globalThis?.MailProviderUtils?.inferMailProvider === 'function') {
+        return globalThis.MailProviderUtils.inferMailProvider(mail, state);
+      }
+      return String(mail?.provider || state?.mailProvider || '').trim().toLowerCase();
     }
 
     async function focusOrOpenMailTab(mail) {

--- a/background/steps/fetch-login-code.js
+++ b/background/steps/fetch-login-code.js
@@ -2,6 +2,10 @@
   root.MultiPageBackgroundStep8 = factory();
 })(typeof self !== 'undefined' ? self : globalThis, function createBackgroundStep8Module() {
   const MAIL_2925_FILTER_LOOKBACK_MS = 10 * 60 * 1000;
+  const YAHOO_MAILBOX_REFRESH_INTERVAL_MS = 5 * 1000;
+  const YAHOO_MAILBOX_REFRESH_ROUNDS_BEFORE_RESEND = 5;
+  const YAHOO_MAILBOX_REFRESH_MAX_ATTEMPTS = 60;
+  const YAHOO_MAILBOX_RESEND_INTERVAL_MS = YAHOO_MAILBOX_REFRESH_INTERVAL_MS * YAHOO_MAILBOX_REFRESH_ROUNDS_BEFORE_RESEND;
 
   function createStep8Executor(deps = {}) {
     const {
@@ -384,6 +388,27 @@
       return String(state?.mail2925BaseEmail || '').trim().toLowerCase();
     }
 
+    function resolveEffectiveMailProvider(mail = {}, state = {}) {
+      const explicitProvider = String(mail?.provider || '').trim().toLowerCase();
+      if (explicitProvider) return explicitProvider;
+
+      const stateProvider = String(state?.mailProvider || '').trim().toLowerCase();
+      if (stateProvider) return stateProvider;
+
+      const source = String(mail?.source || '').trim().toLowerCase();
+      const injectSource = String(mail?.injectSource || '').trim().toLowerCase();
+      const label = String(mail?.label || '').trim().toLowerCase();
+      const url = String(mail?.url || '').trim().toLowerCase();
+      const combined = `${source} ${injectSource} ${label} ${url}`;
+      if (/yahoo/.test(combined)) return 'yahoo';
+      if (/2925/.test(combined)) return '2925';
+      if (/hotmail/.test(combined)) return HOTMAIL_PROVIDER;
+      if (/luckmail/.test(combined)) return LUCKMAIL_PROVIDER;
+      if (/cloudmail/.test(combined)) return CLOUD_MAIL_PROVIDER;
+      if (/cloudflare/.test(combined)) return CLOUDFLARE_TEMP_EMAIL_PROVIDER;
+      return explicitProvider || stateProvider || '';
+    }
+
     async function focusOrOpenMailTab(mail) {
       const alive = await isTabAlive(mail.source);
       if (alive) {
@@ -408,6 +433,10 @@
 
     function getStep8ResendIntervalMs(state = {}) {
       const mail = getMailConfig(state);
+      const effectiveProvider = resolveEffectiveMailProvider(mail, state);
+      if (effectiveProvider === 'yahoo') {
+        return YAHOO_MAILBOX_RESEND_INTERVAL_MS;
+      }
       if (mail?.provider === LUCKMAIL_PROVIDER) {
         return 15000;
       }
@@ -559,8 +588,16 @@
       const notifyResendRequestedAt = typeof runtime?.onResendRequestedAt === 'function'
         ? runtime.onResendRequestedAt
         : null;
-      const mail = getMailConfig(preparedState);
-      if (mail.error) throw new Error(mail.error);
+      const rawMail = getMailConfig(preparedState);
+      if (rawMail.error) throw new Error(rawMail.error);
+      const effectiveProvider = resolveEffectiveMailProvider(rawMail, preparedState);
+      const mail = effectiveProvider && effectiveProvider !== rawMail.provider
+        ? { ...rawMail, provider: effectiveProvider }
+        : { ...rawMail };
+      if (effectiveProvider === 'yahoo') {
+        mail.url = 'https://mail.yahoo.com/n/inbox/all?listFilter=ALL_INBOX';
+        mail.navigateOnReuse = true;
+      }
       const stepStartedAt = Date.now();
       const verificationFilterAfterTimestamp = mail.provider === '2925'
         ? Math.max(0, stepStartedAt - MAIL_2925_FILTER_LOOKBACK_MS)
@@ -608,6 +645,8 @@
         || mail.provider === CLOUD_MAIL_PROVIDER
       ) {
         await addLog(`步骤 ${visibleStep}：正在通过 ${mail.label} 轮询验证码...`);
+      } else if (mail.provider === 'yahoo') {
+        await addLog(`步骤 ${visibleStep}：Yahoo 使用专用取码流程：先在认证页重新获取验证码，再跳转收件箱检查顶部邮件；进入步骤时不预先打开旧收件箱轮询。`, 'warn');
       } else {
         await addLog(`步骤 ${visibleStep}：正在打开${mail.label}...`);
         if (mail.provider === '2925' && typeof ensureMail2925MailboxSession === 'function') {
@@ -626,6 +665,7 @@
         }
       }
 
+      const useYahooMailboxRefreshResendCycle = effectiveProvider === 'yahoo';
       await resolveVerificationStep(8, {
         ...preparedState,
         step8VerificationTargetEmail: displayedVerificationEmail || '',
@@ -636,7 +676,7 @@
         disableTimeBudgetCap: mail.provider === '2925',
         getRemainingTimeMs: getStep8RemainingTimeResolver(preparedState?.oauthUrl || '', visibleStep),
         requestFreshCodeFirst: false,
-        lastResendAt: latestResendAt,
+        lastResendAt: useYahooMailboxRefreshResendCycle ? (latestResendAt || stepStartedAt) : latestResendAt,
         onResendRequestedAt: async (requestedAt) => {
           const numericRequestedAt = Number(requestedAt) || 0;
           if (numericRequestedAt > 0) {
@@ -647,14 +687,20 @@
           }
         },
         targetEmail: fixedTargetEmail,
-        maxResendRequests: mail.provider === '2925' ? 2 : undefined,
+        maxResendRequests: useYahooMailboxRefreshResendCycle ? 0 : (mail.provider === '2925' ? 2 : undefined),
         initialPollMaxAttempts: mail.provider === '2925' ? 5 : undefined,
         pollAttemptPlan: mail.provider === '2925' ? [2, 3, 15] : undefined,
+        intervalMs: useYahooMailboxRefreshResendCycle ? YAHOO_MAILBOX_REFRESH_INTERVAL_MS : undefined,
+        maxAttempts: useYahooMailboxRefreshResendCycle ? YAHOO_MAILBOX_REFRESH_MAX_ATTEMPTS : undefined,
+        refreshesBeforeResend: useYahooMailboxRefreshResendCycle ? YAHOO_MAILBOX_REFRESH_ROUNDS_BEFORE_RESEND : undefined,
+        keepRefreshingUntilCode: useYahooMailboxRefreshResendCycle ? false : undefined,
         resendIntervalMs: mail.provider === LUCKMAIL_PROVIDER
           ? 15000
           : ((mail.provider === HOTMAIL_PROVIDER || mail.provider === '2925')
             ? 0
-            : STANDARD_MAIL_VERIFICATION_RESEND_INTERVAL_MS),
+            : (useYahooMailboxRefreshResendCycle
+              ? YAHOO_MAILBOX_RESEND_INTERVAL_MS
+              : STANDARD_MAIL_VERIFICATION_RESEND_INTERVAL_MS)),
       });
       return {
         lastResendAt: latestResendAt,

--- a/background/steps/fetch-signup-code.js
+++ b/background/steps/fetch-signup-code.js
@@ -2,6 +2,10 @@
   root.MultiPageBackgroundStep4 = factory();
 })(typeof self !== 'undefined' ? self : globalThis, function createBackgroundStep4Module() {
   const MAIL_2925_FILTER_LOOKBACK_MS = 10 * 60 * 1000;
+  const YAHOO_MAILBOX_REFRESH_INTERVAL_MS = 5 * 1000;
+  const YAHOO_MAILBOX_REFRESH_ROUNDS_BEFORE_RESEND = 5;
+  const YAHOO_MAILBOX_REFRESH_MAX_ATTEMPTS = 60;
+  const YAHOO_MAILBOX_RESEND_INTERVAL_MS = YAHOO_MAILBOX_REFRESH_INTERVAL_MS * YAHOO_MAILBOX_REFRESH_ROUNDS_BEFORE_RESEND;
 
   function createStep4Executor(deps = {}) {
     const {
@@ -68,6 +72,27 @@
         || Boolean(state?.signupPhoneActivation);
     }
 
+    function resolveEffectiveMailProvider(mail = {}, state = {}) {
+      const explicitProvider = String(mail?.provider || '').trim().toLowerCase();
+      if (explicitProvider) return explicitProvider;
+
+      const stateProvider = String(state?.mailProvider || '').trim().toLowerCase();
+      if (stateProvider) return stateProvider;
+
+      const source = String(mail?.source || '').trim().toLowerCase();
+      const injectSource = String(mail?.injectSource || '').trim().toLowerCase();
+      const label = String(mail?.label || '').trim().toLowerCase();
+      const url = String(mail?.url || '').trim().toLowerCase();
+      const combined = `${source} ${injectSource} ${label} ${url}`;
+      if (/yahoo/.test(combined)) return 'yahoo';
+      if (/2925/.test(combined)) return '2925';
+      if (/hotmail/.test(combined)) return HOTMAIL_PROVIDER;
+      if (/luckmail/.test(combined)) return LUCKMAIL_PROVIDER;
+      if (/cloudmail/.test(combined)) return CLOUD_MAIL_PROVIDER;
+      if (/cloudflare/.test(combined)) return CLOUDFLARE_TEMP_EMAIL_PROVIDER;
+      return explicitProvider || stateProvider || '';
+    }
+
     async function executeSignupPhoneCodeStep(state, signupTabId) {
       if (typeof phoneVerificationHelpers?.completeSignupPhoneVerificationFlow !== 'function') {
         throw new Error('步骤 4：手机号注册验证码流程不可用，接码模块尚未初始化。');
@@ -98,8 +123,12 @@
         return;
       }
 
-      const mail = getMailConfig(state);
-      if (mail.error) throw new Error(mail.error);
+      const rawMail = getMailConfig(state);
+      if (rawMail.error) throw new Error(rawMail.error);
+      const effectiveProvider = resolveEffectiveMailProvider(rawMail, state);
+      const mail = effectiveProvider && effectiveProvider !== rawMail.provider
+        ? { ...rawMail, provider: effectiveProvider }
+        : { ...rawMail };
 
       const verificationFilterAfterTimestamp = mail.provider === '2925'
         ? Math.max(0, stepStartedAt - MAIL_2925_FILTER_LOOKBACK_MS)
@@ -136,17 +165,22 @@
           await focusOrOpenMailTab(mail);
         }
         await addLog(`步骤 4：将直接使用当前已登录的 ${mail.label} 轮询验证码。`, 'info');
+      } else if (mail.provider === 'yahoo') {
+        await addLog('步骤 4：Yahoo 使用专用取码流程：先在认证页重新获取验证码，再跳转收件箱检查顶部邮件；进入步骤时不预先打开旧收件箱轮询。', 'warn');
       } else {
         await addLog(`步骤 4：正在打开${mail.label}...`);
         await focusOrOpenMailTab(mail);
       }
 
-      const shouldRequestFreshCodeFirst = ![
-        HOTMAIL_PROVIDER,
-        LUCKMAIL_PROVIDER,
-        CLOUDFLARE_TEMP_EMAIL_PROVIDER,
-        CLOUD_MAIL_PROVIDER,
-      ].includes(mail.provider);
+      const useYahooMailboxRefreshResendCycle = effectiveProvider === 'yahoo';
+      const shouldRequestFreshCodeFirst = useYahooMailboxRefreshResendCycle
+        ? false
+        : ![
+          HOTMAIL_PROVIDER,
+          LUCKMAIL_PROVIDER,
+          CLOUDFLARE_TEMP_EMAIL_PROVIDER,
+          CLOUD_MAIL_PROVIDER,
+        ].includes(mail.provider);
       const signupProfile = buildSignupProfileForVerificationStep();
 
       await resolveVerificationStep(4, state, mail, {
@@ -155,11 +189,19 @@
         disableTimeBudgetCap: mail.provider === '2925',
         requestFreshCodeFirst: shouldRequestFreshCodeFirst,
         signupProfile,
+        lastResendAt: useYahooMailboxRefreshResendCycle ? stepStartedAt : 0,
+        intervalMs: useYahooMailboxRefreshResendCycle ? YAHOO_MAILBOX_REFRESH_INTERVAL_MS : undefined,
+        maxAttempts: useYahooMailboxRefreshResendCycle ? YAHOO_MAILBOX_REFRESH_MAX_ATTEMPTS : undefined,
+        refreshesBeforeResend: useYahooMailboxRefreshResendCycle ? YAHOO_MAILBOX_REFRESH_ROUNDS_BEFORE_RESEND : undefined,
+        maxResendRequests: useYahooMailboxRefreshResendCycle ? 0 : undefined,
+        keepRefreshingUntilCode: useYahooMailboxRefreshResendCycle ? false : undefined,
         resendIntervalMs: mail.provider === LUCKMAIL_PROVIDER
           ? 15000
           : ((mail.provider === HOTMAIL_PROVIDER || mail.provider === '2925')
             ? 0
-            : STANDARD_MAIL_VERIFICATION_RESEND_INTERVAL_MS),
+            : (useYahooMailboxRefreshResendCycle
+              ? YAHOO_MAILBOX_RESEND_INTERVAL_MS
+              : STANDARD_MAIL_VERIFICATION_RESEND_INTERVAL_MS)),
       });
     }
 

--- a/background/steps/fetch-signup-code.js
+++ b/background/steps/fetch-signup-code.js
@@ -73,24 +73,10 @@
     }
 
     function resolveEffectiveMailProvider(mail = {}, state = {}) {
-      const explicitProvider = String(mail?.provider || '').trim().toLowerCase();
-      if (explicitProvider) return explicitProvider;
-
-      const stateProvider = String(state?.mailProvider || '').trim().toLowerCase();
-      if (stateProvider) return stateProvider;
-
-      const source = String(mail?.source || '').trim().toLowerCase();
-      const injectSource = String(mail?.injectSource || '').trim().toLowerCase();
-      const label = String(mail?.label || '').trim().toLowerCase();
-      const url = String(mail?.url || '').trim().toLowerCase();
-      const combined = `${source} ${injectSource} ${label} ${url}`;
-      if (/yahoo/.test(combined)) return 'yahoo';
-      if (/2925/.test(combined)) return '2925';
-      if (/hotmail/.test(combined)) return HOTMAIL_PROVIDER;
-      if (/luckmail/.test(combined)) return LUCKMAIL_PROVIDER;
-      if (/cloudmail/.test(combined)) return CLOUD_MAIL_PROVIDER;
-      if (/cloudflare/.test(combined)) return CLOUDFLARE_TEMP_EMAIL_PROVIDER;
-      return explicitProvider || stateProvider || '';
+      if (typeof globalThis?.MailProviderUtils?.inferMailProvider === 'function') {
+        return globalThis.MailProviderUtils.inferMailProvider(mail, state);
+      }
+      return String(mail?.provider || state?.mailProvider || '').trim().toLowerCase();
     }
 
     async function executeSignupPhoneCodeStep(state, signupTabId) {

--- a/background/steps/submit-signup-email.js
+++ b/background/steps/submit-signup-email.js
@@ -187,10 +187,15 @@
     }
 
     async function keepSignupTabWindowInBackgroundForStep2(tabId) {
-      // Intentionally no-op: the task tab is locked to the selected Chrome
-      // window by the tab-runtime layer. Step 2 must not focus/raise that
-      // window while the user is working in another app or browser window.
-      void tabId;
+      if (!Number.isInteger(tabId) || typeof chrome?.tabs?.get !== 'function') {
+        return;
+      }
+      try {
+        const tab = await chrome.tabs.get(tabId);
+        if (Number.isInteger(tab?.windowId) && typeof chrome?.windows?.update === 'function') {
+          await chrome.windows.update(tab.windowId, { focused: true }).catch(() => {});
+        }
+      } catch {}
     }
 
     async function ensureSignupPhoneEntryReady(tabId) {
@@ -239,6 +244,7 @@
       } else {
         await chrome.tabs.update(signupTabId, { active: true });
         await keepSignupTabWindowInBackgroundForStep2(signupTabId);
+        await addLog('步骤 2：已从邮箱页面恢复到 ChatGPT 注册页，准备提交注册邮箱。', 'info');
         await waitForStep2SignupTabToSettle(
           signupTabId,
           '步骤 2：已切换到注册页标签，正在等待页面加载完成并额外稳定 3 秒...'

--- a/background/steps/submit-signup-email.js
+++ b/background/steps/submit-signup-email.js
@@ -187,15 +187,10 @@
     }
 
     async function keepSignupTabWindowInBackgroundForStep2(tabId) {
-      if (!Number.isInteger(tabId) || typeof chrome?.tabs?.get !== 'function') {
-        return;
-      }
-      try {
-        const tab = await chrome.tabs.get(tabId);
-        if (Number.isInteger(tab?.windowId) && typeof chrome?.windows?.update === 'function') {
-          await chrome.windows.update(tab.windowId, { focused: true }).catch(() => {});
-        }
-      } catch {}
+      // Intentionally no-op: the task tab is locked to the selected Chrome
+      // window by the tab-runtime layer. Step 2 should not focus/raise that
+      // window while the user is working in another app or browser window.
+      void tabId;
     }
 
     async function ensureSignupPhoneEntryReady(tabId) {

--- a/background/verification-flow.js
+++ b/background/verification-flow.js
@@ -14,6 +14,7 @@
       CLOUD_MAIL_PROVIDER = 'cloudmail',
       completeNodeFromBackground,
       confirmCustomVerificationStepBypassRequest,
+      ensureContentScriptReadyOnTab,
       getNodeIdByStepForState,
       getHotmailVerificationPollConfig,
       getHotmailVerificationRequestTimestamp,
@@ -23,6 +24,7 @@
       HOTMAIL_PROVIDER,
       isMail2925LimitReachedError,
       isStopError,
+      isTabAlive,
       LUCKMAIL_PROVIDER,
       YYDS_MAIL_PROVIDER = 'yyds-mail',
       MAIL_2925_VERIFICATION_INTERVAL_MS,
@@ -32,6 +34,7 @@
       pollHotmailVerificationCode,
       pollLuckmailVerificationCode,
       pollYydsMailVerificationCode,
+      reuseOrCreateTab,
       sendToContentScript,
       sendToContentScriptResilient,
       sendToMailContentScriptResilient,
@@ -88,6 +91,55 @@
 
     function getVerificationCodeLabel(step) {
       return step === 4 ? '注册' : '登录';
+    }
+
+    function getYahooRejectedCodesFromState(step, state = {}) {
+      const rejectedCodes = [];
+      if (step === 8) {
+        const lastSignupCode = String(state?.lastSignupCode || '').trim();
+        if (lastSignupCode) {
+          rejectedCodes.push(lastSignupCode);
+        }
+      }
+      return rejectedCodes;
+    }
+
+    function inferMailProvider(mail = {}, state = {}) {
+      const explicitProvider = String(mail?.provider || '').trim().toLowerCase();
+      if (explicitProvider) {
+        return explicitProvider;
+      }
+
+      const stateProvider = String(state?.mailProvider || '').trim().toLowerCase();
+      if (stateProvider) {
+        return stateProvider;
+      }
+
+      const source = String(mail?.source || '').trim().toLowerCase();
+      const injectSource = String(mail?.injectSource || '').trim().toLowerCase();
+      const label = String(mail?.label || '').trim().toLowerCase();
+      const url = String(mail?.url || '').trim().toLowerCase();
+      const combined = `${source} ${injectSource} ${label} ${url}`;
+
+      if (/yahoo/.test(combined)) return 'yahoo';
+      if (/2925/.test(combined)) return '2925';
+      if (/hotmail/.test(combined)) return HOTMAIL_PROVIDER;
+      if (/luckmail/.test(combined)) return LUCKMAIL_PROVIDER;
+      if (/cloudmail/.test(combined)) return CLOUD_MAIL_PROVIDER;
+      if (/yyds/.test(combined)) return YYDS_MAIL_PROVIDER;
+      if (/cloudflare/.test(combined)) return CLOUDFLARE_TEMP_EMAIL_PROVIDER;
+      return explicitProvider || stateProvider || '';
+    }
+
+    function withResolvedMailProvider(mail = {}, state = {}) {
+      const provider = inferMailProvider(mail, state);
+      if (!mail || typeof mail !== 'object') {
+        return { provider };
+      }
+      if (String(mail?.provider || '').trim().toLowerCase() === provider) {
+        return mail;
+      }
+      return { ...mail, provider };
     }
 
     function isIcloudMail(mail) {
@@ -429,6 +481,7 @@
       }
       const normalizedStep = Number(step) === 4 ? 4 : 8;
       const is2925Provider = state?.mailProvider === '2925';
+      const isYahooProvider = state?.mailProvider === 'yahoo';
       const mail2925MatchTargetEmail = is2925Provider
         && String(state?.mail2925Mode || '').trim().toLowerCase() === 'receive';
       return {
@@ -444,8 +497,9 @@
           : (String(state?.step8VerificationTargetEmail || '').trim() || state.email),
         targetEmailHints: [],
         mail2925MatchTargetEmail,
-        maxAttempts: is2925Provider ? MAIL_2925_VERIFICATION_MAX_ATTEMPTS : 5,
-        intervalMs: is2925Provider ? MAIL_2925_VERIFICATION_INTERVAL_MS : 3000,
+        maxAttempts: is2925Provider ? MAIL_2925_VERIFICATION_MAX_ATTEMPTS : (isYahooProvider ? 60 : 5),
+        intervalMs: is2925Provider ? MAIL_2925_VERIFICATION_INTERVAL_MS : (isYahooProvider ? 5000 : 3000),
+        keepRefreshingUntilCode: isYahooProvider,
         ...overrides,
       };
     }
@@ -677,7 +731,381 @@
       });
     }
 
+    function parseYahooReopenRequirement(error) {
+      const message = String(error?.message || error || '');
+      const match = message.match(/YAHOO_(?:INBOX|SETTINGS)_REOPEN_REQUIRED::(https?:\/\/\S+)/i);
+      return match ? match[1] : '';
+    }
+
+    function getYahooInboxUrl(mail) {
+      const fallbackUrl = 'https://mail.yahoo.com/n/inbox/all?listFilter=ALL_INBOX';
+      const candidateUrl = String(mail?.url || '').trim();
+
+      try {
+        const parsed = new URL(candidateUrl);
+        const isYahooInbox = /(^|\.)mail\.yahoo\.com$/i.test(parsed.hostname)
+          && /^\/n\/inbox\/all\/?$/i.test(parsed.pathname || '');
+        if (isYahooInbox) {
+          const accountIds = String(parsed.searchParams.get('accountIds') || '').trim();
+          return accountIds
+            ? `${fallbackUrl}&accountIds=${encodeURIComponent(accountIds)}`
+            : fallbackUrl;
+        }
+      } catch (_) {}
+
+      return fallbackUrl;
+    }
+
+    async function getYahooMailTabSnapshot(mail) {
+      const source = String(mail?.source || '').trim();
+      if (!source) {
+        return { source, tabId: null, alive: false };
+      }
+
+      let tabId = null;
+      if (typeof getTabId === 'function') {
+        try {
+          tabId = await getTabId(source);
+        } catch (_) {
+          tabId = null;
+        }
+      }
+
+      let alive = Number.isInteger(tabId);
+      if (typeof isTabAlive === 'function') {
+        try {
+          alive = await isTabAlive(source);
+        } catch (_) {
+          alive = Number.isInteger(tabId);
+        }
+      }
+
+      return {
+        source,
+        tabId: Number.isInteger(tabId) ? tabId : null,
+        alive: Boolean(alive),
+      };
+    }
+
+    async function assertYahooMailTabAvailable(step, mail, contextLabel = '收件箱重建后') {
+      let snapshot = null;
+      for (let attempt = 1; attempt <= 5; attempt += 1) {
+        snapshot = await getYahooMailTabSnapshot(mail);
+        if (snapshot.alive && Number.isInteger(snapshot.tabId)) {
+          return snapshot;
+        }
+        if (attempt < 5) {
+          await sleepWithStop(300);
+        }
+      }
+
+      const sourceLabel = snapshot?.source || String(mail?.source || '').trim() || 'yahoo-mail';
+      throw new Error(`步骤 ${step}：Yahoo ${contextLabel}仍未能定位到可用标签页（source=${sourceLabel}，tabId=${snapshot?.tabId ?? 'null'}）。请停止当前流程后重试。`);
+    }
+
+    async function reopenYahooMailTabIfNeeded(step, mail, error) {
+      const reopenUrl = parseYahooReopenRequirement(error);
+      if (!reopenUrl || mail?.provider !== 'yahoo' || typeof reuseOrCreateTab !== 'function') {
+        return false;
+      }
+
+      const targetUrl = /\/n\/settings(?:\/2)?/i.test(reopenUrl)
+        ? reopenUrl
+        : getYahooInboxUrl(mail);
+
+      await addLog(`步骤 ${step}：Yahoo 页面要求重开，正在关闭旧标签并重新打开标准页面。`, 'warn');
+
+      try {
+        const snapshot = await getYahooMailTabSnapshot(mail);
+        if (snapshot.alive && Number.isInteger(snapshot.tabId)) {
+          await chrome.tabs.remove(snapshot.tabId).catch(() => {});
+          await sleepWithStop(400);
+        }
+      } catch (err) {
+        await addLog(`步骤 ${step}：检查 Yahoo 旧标签页失败，将继续创建新标签页：${err?.message || err}`, 'warn');
+      }
+
+      const newTabId = await reuseOrCreateTab(mail.source, targetUrl, {
+        inject: mail.inject,
+        injectSource: mail.injectSource,
+        navigateOnReuse: true,
+      });
+
+      if (!Number.isInteger(newTabId)) {
+        throw new Error('Yahoo：重开标签页失败，未能获取有效的标签页 ID。');
+      }
+
+      await sleepWithStop(2500);
+      await assertYahooMailTabAvailable(step, mail, '标签页重开后');
+
+      if (typeof ensureContentScriptReadyOnTab === 'function') {
+        try {
+          await ensureContentScriptReadyOnTab(mail.source, newTabId, {
+            inject: mail.inject,
+            injectSource: mail.injectSource,
+            timeoutMs: 30000,
+            retryDelayMs: 800,
+            logMessage: `步骤 ${step}：Yahoo 收件箱标签页重开后内容脚本仍在加载，正在等待就绪...`,
+          });
+        } catch (err) {
+          await addLog(`步骤 ${step}：Yahoo 内容脚本就绪检查失败，将继续尝试读取顶部邮件：${err?.message || err}`, 'warn');
+        }
+      }
+
+      return true;
+    }
+
+    async function ensureYahooInboxBeforePolling(step, mail, options = {}) {
+      const effectiveProvider = inferMailProvider(mail);
+      if (effectiveProvider !== 'yahoo') {
+        return false;
+      }
+
+      const mailSource = String(mail?.source || '').trim();
+      if (!mailSource) {
+        await addLog(`步骤 ${step}：当前未提供可复用的 Yahoo 邮箱标签页上下文，跳过强制切回标准收件箱。`, 'warn');
+        return false;
+      }
+
+      const targetUrl = getYahooInboxUrl(mail);
+      const waitMs = Math.max(0, Number(options.waitMs) || 1800);
+      const logMessage = options.logMessage === undefined
+        ? `步骤 ${step}：轮询 Yahoo 前先强制回到标准收件箱页。`
+        : String(options.logMessage || '').trim();
+      const normalizedMail = {
+        ...mail,
+        url: targetUrl,
+        navigateOnReuse: true,
+      };
+      const snapshotBefore = await getYahooMailTabSnapshot(normalizedMail);
+      const hasReusableTab = snapshotBefore.alive && Number.isInteger(snapshotBefore.tabId);
+
+      if (hasReusableTab && typeof chrome?.tabs?.get === 'function') {
+        try {
+          const currentTab = await chrome.tabs.get(snapshotBefore.tabId);
+          const currentUrl = String(currentTab?.url || '').trim();
+          if (currentUrl && currentUrl.includes('/n/inbox')) {
+            if (waitMs > 0) {
+              await sleepWithStop(waitMs);
+            }
+            return true;
+          }
+        } catch (err) {
+          await addLog(`步骤 ${step}：检查 Yahoo 标签页当前 URL 失败，将继续强制导航：${err?.message || err}`, 'warn');
+        }
+      }
+
+      if (typeof reuseOrCreateTab === 'function') {
+        if (logMessage) {
+          await addLog(logMessage, options.logLevel || 'info');
+        }
+        await reuseOrCreateTab(normalizedMail.source, targetUrl, {
+          inject: normalizedMail.inject,
+          injectSource: normalizedMail.injectSource,
+          reloadIfSameUrl: true,
+          navigateOnReuse: true,
+        });
+        await assertYahooMailTabAvailable(step, normalizedMail, hasReusableTab ? '收件箱刷新后' : '收件箱标签页重建后');
+        if (waitMs > 0) {
+          await sleepWithStop(waitMs);
+        }
+        if (mail && typeof mail === 'object' && mail.url !== targetUrl) {
+          mail.url = targetUrl;
+        }
+        return true;
+      }
+
+      const mailTabId = hasReusableTab ? snapshotBefore.tabId : null;
+      if (!Number.isInteger(mailTabId) || !chrome?.tabs?.update) {
+        throw new Error(`步骤 ${step}：当前没有可用的 Yahoo 标签页可供导航。请停止当前流程后重试。`);
+      }
+
+      await chrome.tabs.update(mailTabId, { url: targetUrl, active: true }).catch(() => {});
+      if (waitMs > 0) {
+        await sleepWithStop(waitMs);
+      }
+      if (mail && typeof mail === 'object' && mail.url !== targetUrl) {
+        mail.url = targetUrl;
+      }
+      return true;
+    }
+
+    async function pollYahooVerificationCodeWithForegroundRefresh(step, state, mail, pollOverrides = {}) {
+      mail = withResolvedMailProvider(mail, state);
+      const stateKey = getVerificationCodeStateKey(step);
+      const rejectedCodes = new Set();
+      if (state[stateKey] && pollOverrides?.seedRejectedCodesFromState !== false) {
+        rejectedCodes.add(state[stateKey]);
+      }
+      for (const code of getYahooRejectedCodesFromState(step, state)) {
+        if (code) rejectedCodes.add(code);
+      }
+      for (const code of (pollOverrides.excludeCodes || [])) {
+        if (code) rejectedCodes.add(code);
+      }
+
+      const refreshIntervalMs = Math.max(1000, Number(pollOverrides.intervalMs) || 5000);
+      const maxPageRefreshes = Math.max(1, Math.floor(Number(pollOverrides.maxAttempts) || 60));
+      const refreshesBeforeResend = Math.max(1, Math.floor(Number(pollOverrides.refreshesBeforeResend) || 5));
+      const payloadOverrides = { ...pollOverrides };
+      delete payloadOverrides.excludeCodes;
+      delete payloadOverrides.intervalMs;
+      delete payloadOverrides.maxAttempts;
+      delete payloadOverrides.refreshesBeforeResend;
+      delete payloadOverrides.resendIntervalMs;
+      delete payloadOverrides.lastResendAt;
+      delete payloadOverrides.maxResendRequests;
+      delete payloadOverrides.onResendRequestedAt;
+      delete payloadOverrides.keepRefreshingUntilCode;
+      delete payloadOverrides.filterAfterTimestamp;
+      delete payloadOverrides.seedRejectedCodesFromState;
+
+      let totalPageRefreshes = 0;
+      let resendCycle = 0;
+      let lastError = null;
+      let lastResendAt = Number(pollOverrides.lastResendAt) || 0;
+      let lastObservedTopMessageFingerprint = String(
+        pollOverrides.previousTopMessageFingerprint || state.lastYahooTopMessageFingerprint || ''
+      ).trim();
+      const previousAcceptedEmailTimestamp = Math.max(0, Number(
+        pollOverrides.previousAcceptedEmailTimestamp || state.lastEmailTimestamp || 0
+      ) || 0);
+
+      await addLog(
+        `步骤 ${step}：Yahoo 专用取码流程已启动：先重发验证码，再切回收件箱顶部邮件检查，每 ${Math.round(refreshIntervalMs / 1000)} 秒刷新一次。`,
+        'warn'
+      );
+
+      while (totalPageRefreshes < maxPageRefreshes) {
+        throwIfStopped();
+        resendCycle += 1;
+        lastResendAt = await requestVerificationCodeResend(step, {
+          ...pollOverrides,
+          allowMissingSignupTab: true,
+        });
+
+        await ensureYahooInboxBeforePolling(step, mail, {
+          logMessage: `步骤 ${step}：已跳转到 Yahoo 收件箱页面，开始检查最顶部验证码邮件。`,
+          logLevel: 'warn',
+          waitMs: 2500,
+        });
+
+        let refreshesThisCycle = 0;
+        const maxCycleRefreshes = Math.min(refreshesBeforeResend, maxPageRefreshes - totalPageRefreshes);
+        while (refreshesThisCycle < maxCycleRefreshes && totalPageRefreshes < maxPageRefreshes) {
+          throwIfStopped();
+          const payload = getVerificationPollPayload(step, state, {
+            ...payloadOverrides,
+            excludeCodes: [...rejectedCodes],
+            intervalMs: refreshIntervalMs,
+            maxAttempts: 1,
+            keepRefreshingUntilCode: false,
+            yahooTopRowOnly: true,
+            filterAfterTimestamp: 0,
+            requestedAt: lastResendAt,
+            previousTopMessageFingerprint: lastObservedTopMessageFingerprint,
+            previousAcceptedEmailTimestamp,
+            yahooFreshnessSkewMs: Math.max(refreshIntervalMs * 2, 180000),
+          });
+
+          const timedPoll = await applyMailPollingTimeBudget(
+            step,
+            payload,
+            { ...pollOverrides, disableTimeBudgetCap: Boolean(pollOverrides.disableTimeBudgetCap) },
+            `检查 Yahoo 收件箱顶部${getVerificationCodeLabel(step)}验证码邮件`
+          );
+
+          let result;
+          try {
+            result = await sendToMailContentScriptResilient(
+              mail,
+              {
+                type: 'YAHOO_CHECK_TOP_MESSAGE',
+                step,
+                source: 'background',
+                payload: {
+                  ...timedPoll.payload,
+                  intervalMs: refreshIntervalMs,
+                  maxAttempts: 1,
+                  keepRefreshingUntilCode: false,
+                  yahooTopRowOnly: true,
+                  filterAfterTimestamp: 0,
+                },
+              },
+              {
+                timeoutMs: Math.min(timedPoll.timeoutMs, 30000),
+                maxRecoveryAttempts: 2,
+                responseTimeoutMs: Math.min(timedPoll.responseTimeoutMs, 30000),
+                logStep: activeVerificationLogStep,
+                logStepKey: step === 4 ? 'fetch-signup-code' : 'fetch-login-code',
+              }
+            );
+          } catch (err) {
+            if (await reopenYahooMailTabIfNeeded(step, mail, err)) {
+              await addLog(`步骤 ${step}：Yahoo 标签页已重开，继续检查顶部邮件。`, 'warn');
+              continue;
+            }
+            throw err;
+          }
+
+          if (result?.error) {
+            const resultError = new Error(result.error);
+            if (await reopenYahooMailTabIfNeeded(step, mail, resultError)) {
+              await addLog(`步骤 ${step}：Yahoo 顶部检查要求重开收件箱，已处理并继续。`, 'warn');
+              continue;
+            }
+            throw resultError;
+          }
+
+          if (result?.topMessageFingerprint !== undefined) {
+            lastObservedTopMessageFingerprint = String(result.topMessageFingerprint || '').trim();
+          }
+
+          if (result?.code && !rejectedCodes.has(result.code)) {
+            if (result.freshnessMatched) {
+              await addLog(`步骤 ${step}：Yahoo 顶部邮件命中${getVerificationCodeLabel(step)}验证码 ${result.code}`, 'warn');
+              return {
+                ...result,
+                lastResendAt,
+                remainingResendRequests: 0,
+                totalPageRefreshes,
+              };
+            }
+            await addLog(`步骤 ${step}：Yahoo 顶部邮件发现验证码 ${result.code}，但不是本轮新验证码，继续等待。`, 'warn');
+          }
+
+          lastError = new Error(result?.reason || `步骤 ${step}：Yahoo 顶部邮件未读取到新的验证码。`);
+          refreshesThisCycle += 1;
+          totalPageRefreshes += 1;
+
+          if (refreshesThisCycle < maxCycleRefreshes && totalPageRefreshes < maxPageRefreshes) {
+            await addLog(
+              `步骤 ${step}：Yahoo 顶部邮件未命中，${Math.round(refreshIntervalMs / 1000)} 秒后刷新收件箱继续检查（${totalPageRefreshes}/${maxPageRefreshes}）。`,
+              'warn'
+            );
+            await sleepWithStop(refreshIntervalMs);
+            await ensureYahooInboxBeforePolling(step, mail, {
+              logMessage: `步骤 ${step}：正在刷新 Yahoo 收件箱并重新检查顶部邮件。`,
+              logLevel: 'warn',
+              waitMs: 2500,
+            });
+          }
+        }
+
+        if (refreshesThisCycle >= maxCycleRefreshes) {
+          await addLog(`步骤 ${step}：Yahoo 连续 ${refreshesThisCycle} 次前台刷新仍未命中，返回认证页重新获取验证码。`, 'warn');
+        }
+      }
+
+      throw lastError || new Error(`步骤 ${step}：Yahoo 前台刷新 ${maxPageRefreshes} 次后仍未获取到新的${getVerificationCodeLabel(step)}验证码。`);
+    }
+
     async function pollFreshVerificationCodeWithResendInterval(step, state, mail, pollOverrides = {}) {
+      mail = withResolvedMailProvider(mail, state);
+      if (mail?.provider === 'yahoo') {
+        throw new Error(`步骤 ${step}：Yahoo 已禁用普通定时邮箱轮询，仅允许专用前台刷新取码流程。`);
+      }
+
       const stateKey = getVerificationCodeStateKey(step);
       const rejectedCodes = new Set();
       if (state[stateKey]) {
@@ -944,6 +1372,7 @@
     }
 
     async function pollFreshVerificationCode(step, state, mail, pollOverrides = {}) {
+      mail = withResolvedMailProvider(mail, state);
       const {
         onResendRequestedAt,
         maxRounds: _ignoredMaxRounds,
@@ -993,6 +1422,16 @@
           ...cleanPollOverrides,
         }, cleanPollOverrides, `轮询${getVerificationCodeLabel(step)}验证码邮箱`);
         return pollYydsMailVerificationCode(step, state, timedPoll.payload);
+      }
+      if (mail.provider === 'yahoo') {
+        const refreshesBeforeResend = Math.max(1, Number(pollOverrides.refreshesBeforeResend) || 5);
+        const refreshIntervalSeconds = Math.max(1, Math.round((Number(pollOverrides.intervalMs) || 5000) / 1000));
+        const maxRefreshAttempts = Math.max(1, Number(pollOverrides.maxAttempts) || 60);
+        await addLog(
+          `步骤 ${step}：本次将走 Yahoo 专用前台刷新取码逻辑：先重发，再跳转收件箱，只检查顶部邮件，每 ${refreshIntervalSeconds} 秒刷新一次，连续 ${refreshesBeforeResend} 次未命中就回认证页重新获取验证码，总刷新上限 ${maxRefreshAttempts} 次。`,
+          'warn'
+        );
+        return pollYahooVerificationCodeWithForegroundRefresh(step, state, mail, pollOverrides);
       }
 
       if (Number(pollOverrides.resendIntervalMs) > 0) {
@@ -1268,6 +1707,7 @@
     }
 
     async function resolveVerificationStep(step, state, mail, options = {}) {
+      mail = withResolvedMailProvider(mail, state);
       const completionStep = getCompletionStep(step, options);
       activeVerificationLogStep = completionStep;
       const completionNodeId = await getNodeIdForStep(completionStep);
@@ -1280,8 +1720,13 @@
         ? options.beforeSubmit
         : null;
       const ignorePersistedLastCode = Boolean(hotmailPollConfig?.ignorePersistedLastCode);
-      if (state[stateKey] && !ignorePersistedLastCode) {
+      if (state[stateKey] && !ignorePersistedLastCode && mail?.provider !== 'yahoo') {
         rejectedCodes.add(state[stateKey]);
+      }
+      if (mail?.provider === 'yahoo') {
+        for (const code of getYahooRejectedCodesFromState(step, state)) {
+          if (code) rejectedCodes.add(code);
+        }
       }
 
       let nextFilterAfterTimestamp = options.filterAfterTimestamp ?? null;
@@ -1318,7 +1763,11 @@
 
       await clear2925MailboxBeforePolling(step, mail, options);
 
-      if (requestFreshCodeFirst) {
+      if (requestFreshCodeFirst && mail?.provider === 'yahoo') {
+        await addLog(`步骤 ${step}：Yahoo 专用取码流程会在主循环内先重发验证码，跳过进入主循环前的额外预发。`, 'warn');
+      }
+
+      if (requestFreshCodeFirst && mail?.provider !== 'yahoo') {
         if (remainingAutomaticResendCount <= 0) {
           await addLog(`步骤 ${step}：当前自动重新发送验证码次数为 0，将直接使用当前时间窗口轮询邮箱。`, 'info');
         } else {
@@ -1367,7 +1816,20 @@
             resendIntervalMs,
             lastResendAt,
             onResendRequestedAt: updateFilterAfterTimestampForVerificationStep,
+            seedRejectedCodesFromState: !Boolean(mail?.provider === 'yahoo'),
           };
+          if (Number(options.intervalMs) > 0) {
+            pollOptions.intervalMs = Number(options.intervalMs);
+          }
+          if (Number(options.maxAttempts) > 0) {
+            pollOptions.maxAttempts = Number(options.maxAttempts);
+          }
+          if (Number(options.refreshesBeforeResend) > 0) {
+            pollOptions.refreshesBeforeResend = Number(options.refreshesBeforeResend);
+          }
+          if (options.keepRefreshingUntilCode !== undefined) {
+            pollOptions.keepRefreshingUntilCode = Boolean(options.keepRefreshingUntilCode);
+          }
           if (nextFilterAfterTimestamp !== null && nextFilterAfterTimestamp !== undefined) {
             pollOptions.filterAfterTimestamp = nextFilterAfterTimestamp;
           }
@@ -1420,6 +1882,9 @@
           await setState({
             lastEmailTimestamp: result.emailTimestamp,
             [stateKey]: result.code,
+            ...(mail?.provider === 'yahoo'
+              ? { lastYahooTopMessageFingerprint: result.topMessageFingerprint || null }
+              : {}),
           });
 
           if (!completionNodeId) {

--- a/background/verification-flow.js
+++ b/background/verification-flow.js
@@ -105,41 +105,18 @@
     }
 
     function inferMailProvider(mail = {}, state = {}) {
-      const explicitProvider = String(mail?.provider || '').trim().toLowerCase();
-      if (explicitProvider) {
-        return explicitProvider;
+      if (typeof globalThis?.MailProviderUtils?.inferMailProvider === 'function') {
+        return globalThis.MailProviderUtils.inferMailProvider(mail, state);
       }
-
-      const stateProvider = String(state?.mailProvider || '').trim().toLowerCase();
-      if (stateProvider) {
-        return stateProvider;
-      }
-
-      const source = String(mail?.source || '').trim().toLowerCase();
-      const injectSource = String(mail?.injectSource || '').trim().toLowerCase();
-      const label = String(mail?.label || '').trim().toLowerCase();
-      const url = String(mail?.url || '').trim().toLowerCase();
-      const combined = `${source} ${injectSource} ${label} ${url}`;
-
-      if (/yahoo/.test(combined)) return 'yahoo';
-      if (/2925/.test(combined)) return '2925';
-      if (/hotmail/.test(combined)) return HOTMAIL_PROVIDER;
-      if (/luckmail/.test(combined)) return LUCKMAIL_PROVIDER;
-      if (/cloudmail/.test(combined)) return CLOUD_MAIL_PROVIDER;
-      if (/yyds/.test(combined)) return YYDS_MAIL_PROVIDER;
-      if (/cloudflare/.test(combined)) return CLOUDFLARE_TEMP_EMAIL_PROVIDER;
-      return explicitProvider || stateProvider || '';
+      return String(mail?.provider || state?.mailProvider || '').trim().toLowerCase();
     }
 
     function withResolvedMailProvider(mail = {}, state = {}) {
+      if (typeof globalThis?.MailProviderUtils?.withResolvedMailProvider === 'function') {
+        return globalThis.MailProviderUtils.withResolvedMailProvider(mail, state);
+      }
       const provider = inferMailProvider(mail, state);
-      if (!mail || typeof mail !== 'object') {
-        return { provider };
-      }
-      if (String(mail?.provider || '').trim().toLowerCase() === provider) {
-        return mail;
-      }
-      return { ...mail, provider };
+      return mail && typeof mail === 'object' ? { ...mail, provider } : { provider };
     }
 
     function isIcloudMail(mail) {

--- a/content/kiro/register-page.js
+++ b/content/kiro/register-page.js
@@ -3,6 +3,7 @@ console.log('[MultiPage:kiro-register-page] Content script loaded on', location.
 const KIRO_REGISTER_PAGE_LISTENER_SENTINEL = 'data-multipage-kiro-register-page-listener';
 const DEFAULT_KIRO_PAGE_LOAD_TIMEOUT_MS = globalThis.MultiPageKiroTimeouts?.DEFAULT_KIRO_PAGE_LOAD_TIMEOUT_MS || (3 * 60 * 1000);
 const KIRO_CONTINUE_TEXT_PATTERN = /continue|继续/i;
+const KIRO_RESEND_VERIFICATION_CODE_PATTERN = /重新发送(?:验证码)?|再次发送(?:验证码)?|重发(?:验证码)?|未收到(?:验证码|邮件)?|resend(?:\s+(?:code|email))?|send\s+(?:a\s+)?new\s+code|send\s+(?:it\s+)?again|request\s+(?:a\s+)?new\s+code|didn'?t\s+receive|did\s+not\s+receive/i;
 const KIRO_BUILDER_ID_TEXT_PATTERN = /aws\s*builder\s*id|builder\s*id/i;
 const KIRO_CONFIRM_CONTINUE_TEXT_PATTERN = /confirm and continue|确认并继续/i;
 const KIRO_ALLOW_ACCESS_TEXT_PATTERN = /allow access|允许访问/i;
@@ -47,7 +48,7 @@ const KIRO_CONFIRM_PASSWORD_TEXT_PATTERN = /confirm\s*password|re[-\s]*enter\s*p
 const KIRO_PRIMARY_PASSWORD_HINT_PATTERN = /enter\s*password|create\s*password|new\s*password|\u8f93\u5165.*\u5bc6\u7801|\u521b\u5efa.*\u5bc6\u7801|^\s*\u5bc6\u7801\s*$/i;
 const KIRO_SIGN_IN_TEXT_PATTERN = /sign\s*in\s*with\s*your\s*aws\s*builder\s*id|aws\s*builder\s*id\s*sign\s*in/i;
 const KIRO_CODE_INVALID_TEXT_PATTERN = /code\s*(?:is\s*)?invalid|invalid\s*code|\u4ee3\u7801\u65e0\u6548|\u9a8c\u8bc1\u7801\u65e0\u6548/i;
-const KIRO_RESEND_CODE_TEXT_PATTERN = /resend|send\s*again|\u91cd\u65b0\u53d1\u9001/i;
+const KIRO_RESEND_CODE_TEXT_PATTERN = KIRO_RESEND_VERIFICATION_CODE_PATTERN;
 
 function isVisibleKiroElement(element) {
   if (!element) return false;
@@ -166,6 +167,12 @@ function getElementActionText(element) {
     .trim();
 }
 
+function isKiroActionEnabled(element) {
+  return Boolean(element)
+    && !element.disabled
+    && element.getAttribute('aria-disabled') !== 'true';
+}
+
 function findActionButton(options = {}) {
   const {
     preferredSelectors = [],
@@ -175,13 +182,13 @@ function findActionButton(options = {}) {
 
   for (const selector of preferredSelectors) {
     const preferred = findFirstVisible(selector);
-    if (preferred && !preferred.disabled && preferred.getAttribute('aria-disabled') !== 'true') {
+    if (preferred && isKiroActionEnabled(preferred)) {
       return preferred;
     }
   }
 
   const candidates = collectVisibleElements('button, [role="button"], input[type="submit"], input[type="button"]')
-    .filter((element) => !element.disabled && element.getAttribute('aria-disabled') !== 'true');
+    .filter((element) => isKiroActionEnabled(element));
 
   const prioritized = formOwner
     ? candidates.filter((element) => (element.form || element.closest?.('form') || null) === formOwner)
@@ -386,12 +393,27 @@ function findOtpVerifyButton(otpInput = null) {
   });
 }
 
-function findOtpResendButton(otpInput = null) {
+function findOtpResendButton(otpInputOrOptions = null) {
+  const options = otpInputOrOptions instanceof HTMLElement ? {} : (otpInputOrOptions || {});
+  const otpInput = otpInputOrOptions instanceof HTMLElement
+    ? otpInputOrOptions
+    : (options.otpInput instanceof HTMLElement ? options.otpInput : null);
   const form = otpInput?.form || otpInput?.closest?.('form') || null;
-  return findActionButton({
-    textPattern: KIRO_RESEND_CODE_TEXT_PATTERN,
-    formOwner: form,
+  const allowDisabled = Boolean(options.allowDisabled);
+  const candidates = collectVisibleElements(
+    'button, a, [role="button"], [role="link"], input[type="submit"], input[type="button"]'
+  );
+  const matches = candidates.filter((element) => {
+    if (!allowDisabled && !isKiroActionEnabled(element)) {
+      return false;
+    }
+    const text = getElementActionText(element);
+    return text && KIRO_RESEND_CODE_TEXT_PATTERN.test(text);
   });
+  const sameFormMatches = form
+    ? matches.filter((element) => (element.form || element.closest?.('form') || null) === form)
+    : [];
+  return sameFormMatches[0] || matches[0] || null;
 }
 
 function findPasswordContinueButton(passwordInput = null) {
@@ -838,6 +860,41 @@ async function submitKiroVerificationCode(payload = {}) {
   };
 }
 
+async function resendKiroVerificationCode(payload = {}) {
+  const readyState = await ensureKiroRegisterPageState({
+    targetStates: ['register_otp_page'],
+    timeoutMs: payload?.timeoutMs || DEFAULT_KIRO_PAGE_LOAD_TIMEOUT_MS,
+    retryDelayMs: payload?.retryDelayMs || 250,
+  });
+
+  const timeoutMs = Math.max(1000, Math.floor(Number(payload?.timeoutMs) || 30000));
+  const retryDelayMs = Math.max(100, Math.floor(Number(payload?.retryDelayMs) || 250));
+  const start = Date.now();
+  let resendButton = null;
+
+  while (Date.now() - start < timeoutMs) {
+    throwIfStopped();
+    resendButton = findOtpResendButton({
+      otpInput: readyState.otpInput,
+      allowDisabled: true,
+    });
+    if (resendButton && isKiroActionEnabled(resendButton)) {
+      const actionText = getElementActionText(resendButton);
+      await sleep(200);
+      simulateClick(resendButton);
+      return {
+        resent: true,
+        state: 'verification_resend_requested',
+        actionText,
+        url: location.href,
+      };
+    }
+    await sleep(retryDelayMs);
+  }
+
+  throw new Error('Kiro 验证码页未找到可用的重新发送验证码按钮。');
+}
+
 async function submitKiroPassword(payload = {}) {
   const password = String(payload?.password || '');
   if (!password) {
@@ -946,6 +1003,8 @@ async function handleKiroRegisterCommand(message) {
       return ensureKiroRegisterPageState(message.payload || {});
     case 'ENSURE_KIRO_STATE_CHANGE':
       return waitForKiroRegisterStateChange(message.payload || {});
+    case 'KIRO_RESEND_VERIFICATION_CODE':
+      return resendKiroVerificationCode(message.payload || {});
     case 'EXECUTE_NODE': {
       const nodeId = String(message.nodeId || message.payload?.nodeId || '').trim();
       if (nodeId === 'kiro-open-register-page') {
@@ -980,6 +1039,7 @@ if (document.documentElement.getAttribute(KIRO_REGISTER_PAGE_LISTENER_SENTINEL) 
       message.type === 'ENSURE_KIRO_PAGE_STATE'
       || message.type === 'ENSURE_KIRO_STATE_CHANGE'
       || message.type === 'GET_KIRO_REGISTER_PAGE_STATE'
+      || message.type === 'KIRO_RESEND_VERIFICATION_CODE'
       || message.type === 'EXECUTE_NODE'
     ) {
       resetStopState();

--- a/content/kiro/register-page.js
+++ b/content/kiro/register-page.js
@@ -394,10 +394,11 @@ function findOtpVerifyButton(otpInput = null) {
 }
 
 function findOtpResendButton(otpInputOrOptions = null) {
-  const options = otpInputOrOptions instanceof HTMLElement ? {} : (otpInputOrOptions || {});
-  const otpInput = otpInputOrOptions instanceof HTMLElement
+  const isElement = typeof HTMLElement !== 'undefined' && otpInputOrOptions instanceof HTMLElement;
+  const options = isElement ? {} : (otpInputOrOptions || {});
+  const otpInput = isElement
     ? otpInputOrOptions
-    : (options.otpInput instanceof HTMLElement ? options.otpInput : null);
+    : (typeof HTMLElement !== 'undefined' && options.otpInput instanceof HTMLElement ? options.otpInput : null);
   const form = otpInput?.form || otpInput?.closest?.('form') || null;
   const allowDisabled = Boolean(options.allowDisabled);
   const candidates = collectVisibleElements(

--- a/content/yahoo-mail.js
+++ b/content/yahoo-mail.js
@@ -1,0 +1,2683 @@
+const YAHOO_MAIL_PREFIX = '[MultiPage:yahoo-mail]';
+const YAHOO_INBOX_URL = 'https://mail.yahoo.com/n/inbox/all?listFilter=ALL_INBOX';
+const YAHOO_SETTINGS_URL = 'https://mail.yahoo.com/n/settings/2';
+const YAHOO_ROW_SCAN_LIMIT = 80;
+console.log(YAHOO_MAIL_PREFIX, 'Content script loaded on', location.href);
+
+// 监听后台发来的邮件轮询和临时别名创建请求。
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message.type === 'POLL_EMAIL') {
+    if (Number(message.step) === 4 || Number(message.step) === 8) {
+      const error = `YAHOO_LEGACY_POLLING_DISABLED::步骤 ${message.step} 已禁用旧版 POLL_EMAIL 轮询，只允许 YAHOO_CHECK_TOP_MESSAGE 专用顶部邮件检查。`;
+      log(`Yahoo：${error}`, 'warn');
+      sendResponse({ error });
+      return true;
+    }
+
+    resetStopState();
+    handlePollEmail(message.step, message.payload || {}).then(sendResponse).catch((err) => {
+      if (isStopError(err)) {
+        sendResponse({ stopped: true, error: err.message });
+        return;
+      }
+      sendResponse({ error: err.message });
+    });
+    return true;
+  }
+
+  if (message.type === 'YAHOO_CHECK_TOP_MESSAGE') {
+    resetStopState();
+    handleCheckTopMessage(message.step, message.payload || {}).then(sendResponse).catch((err) => {
+      if (isStopError(err)) {
+        sendResponse({ stopped: true, error: err.message });
+        return;
+      }
+      sendResponse({ error: err.message });
+    });
+    return true;
+  }
+
+  if (message.type === 'YAHOO_READ_CURRENT_MESSAGE_CODE') {
+    resetStopState();
+    handleReadCurrentMessageCode(message.step, message.payload || {}).then(sendResponse).catch((err) => {
+      if (isStopError(err)) {
+        sendResponse({ stopped: true, error: err.message });
+        return;
+      }
+      sendResponse({ error: err.message });
+    });
+    return true;
+  }
+
+  if (message.type === 'YAHOO_OPEN_TOP_MESSAGE') {
+    resetStopState();
+    handleOpenTopMessage(message.step, message.payload || {}).then(sendResponse).catch((err) => {
+      if (isStopError(err)) {
+        sendResponse({ stopped: true, error: err.message });
+        return;
+      }
+      sendResponse({ error: err.message });
+    });
+    return true;
+  }
+
+  if (message.type === 'YAHOO_CREATE_TEMP_ALIAS') {
+    resetStopState();
+    handleCreateYahooTempAlias(message.payload || {}).then(sendResponse).catch((err) => {
+      if (isStopError(err)) {
+        sendResponse({ stopped: true, error: err.message });
+        return;
+      }
+      sendResponse({ error: err.message });
+    });
+    return true;
+  }
+
+  if (message.type === 'YAHOO_LOGIN_WITH_CREDENTIALS') {
+    resetStopState();
+    handleYahooLoginWithCredentials(message.payload || {}).then(sendResponse).catch((err) => {
+      if (isStopError(err)) {
+        sendResponse({ stopped: true, error: err.message });
+        return;
+      }
+      sendResponse({ error: err.message });
+    });
+    return true;
+  }
+});
+
+// 规范化文本，压缩连续空白并去掉首尾空格。
+function normalizeText(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+// 规范化文本后统一转成小写，方便做模糊匹配。
+function normalizeLowerText(value) {
+  return normalizeText(value).toLowerCase();
+}
+
+function joinUniqueTextParts(parts = []) {
+  const seen = new Set();
+  return normalizeText(parts
+    .map((part) => normalizeText(part))
+    .filter(Boolean)
+    .filter((part) => {
+      if (seen.has(part)) return false;
+      seen.add(part);
+      return true;
+    })
+    .join(' '));
+}
+
+// 从邮件或页面文本中提取 6 位验证码。
+function extractVerificationCode(text) {
+  const source = String(text || '');
+  const matchCn = source.match(/(?:代码为|验证码[^0-9]*?)[\s：:]*(\d{6})/i);
+  if (matchCn) return matchCn[1];
+  const matchEn = source.match(/(?:your\s+chatgpt\s+code\s+is|verification\s+code|code(?:\s+is)?)[^0-9]{0,16}(\d{6})/i);
+  if (matchEn) return matchEn[1];
+  const matchPlain = source.match(/\b(\d{6})\b/);
+  return matchPlain ? matchPlain[1] : null;
+}
+
+function extractVerificationCodeWithPatterns(text, payload = {}) {
+  const source = String(text || '');
+  const patterns = Array.isArray(payload?.codePatterns) ? payload.codePatterns : [];
+
+  for (const pattern of patterns) {
+    try {
+      const regex = pattern instanceof RegExp
+        ? pattern
+        : new RegExp(String(pattern?.source || pattern || ''), String(pattern?.flags || 'i'));
+      const match = source.match(regex);
+      const code = match?.[1] || match?.[0];
+      const normalizedCode = String(code || '').match(/\b(\d{6})\b/)?.[1] || '';
+      if (normalizedCode) return normalizedCode;
+    } catch {}
+  }
+
+  return extractVerificationCode(source);
+}
+
+// 判断节点是否真实可见且占据页面空间。
+function isVisibleElement(node) {
+  if (!(node instanceof HTMLElement)) return false;
+  const style = getComputedStyle(node);
+  if (style.display === 'none' || style.visibility === 'hidden') return false;
+  const rect = node.getBoundingClientRect();
+  return rect.width > 0 && rect.height > 0;
+}
+
+function isElementInViewport(node) {
+  if (!(node instanceof HTMLElement) || !isVisibleElement(node)) return false;
+  const rect = node.getBoundingClientRect();
+  const viewportWidth = Number(window.innerWidth) || document.documentElement?.clientWidth || 0;
+  const viewportHeight = Number(window.innerHeight) || document.documentElement?.clientHeight || 0;
+  if (!viewportWidth || !viewportHeight) return true;
+  return rect.bottom > 0
+    && rect.right > 0
+    && rect.top < viewportHeight
+    && rect.left < viewportWidth;
+}
+
+// 根据当前 URL 和页面文案判断是否像 Yahoo 未登录状态。
+function looksLikeYahooLoggedOut() {
+  const url = String(location.href || '').trim();
+
+  if (/login\.yahoo\.com/i.test(url)) {
+    return true;
+  }
+
+  if (/\/account\//i.test(url) && !/mail\.yahoo\.com/i.test(url)) {
+    return true;
+  }
+
+  if (isYahooInboxPage(url) || isYahooSettingsPage(url)) {
+    return false;
+  }
+
+  const mailboxIndicators = [
+    '[data-test-id="message-list"]',
+    '[data-test-id="virtual-list"]',
+    '[role="main"]',
+    'main',
+    'a[href*="/n/inbox"]',
+    'a[href*="/d/folders"]',
+    'a[href*="/b/folders"]',
+    'a[href*="/n/settings"]',
+  ];
+
+  if (mailboxIndicators.some((selector) => document.querySelector(selector))) {
+    return false;
+  }
+
+  const bodyText = normalizeLowerText(document.body?.innerText || '');
+  return /sign in to yahoo mail|yahoo mail sign in|登录 yahoo|登入 yahoo/.test(bodyText);
+}
+
+// 校验当前是否已登录 Yahoo Mail，不满足时直接抛错。
+function ensureYahooLoggedIn(actionLabel = 'Yahoo 邮箱操作') {
+  const url = String(location.href || '').trim();
+  const hasMessageList = Boolean(document.querySelector('[data-test-id="message-list"]'));
+  const hasMain = Boolean(document.querySelector('main'));
+
+  if (looksLikeYahooLoggedOut()) {
+    const bodySample = normalizeLowerText(document.body?.innerText || '').slice(0, 200);
+    log(`Yahoo：登录态检测失败 url=${url} hasMessageList=${hasMessageList} hasMain=${hasMain} bodySample=${bodySample}`, 'warn');
+    throw new Error(`${actionLabel}失败：当前未登录 Yahoo Mail，请先手动登录后重试。`);
+  }
+
+  log(`Yahoo：登录态检测通过 url=${url} hasMessageList=${hasMessageList} hasMain=${hasMain}`, 'info');
+}
+
+function isYahooLoginPage(url = location.href) {
+  try {
+    const parsed = new URL(String(url || ''), location.origin);
+    return /(^|\.)login\.yahoo\.com$/i.test(parsed.hostname || '')
+      || /(^|\.)guce\.yahoo\.com$/i.test(parsed.hostname || '');
+  } catch {
+    return /login\.yahoo\.com|guce\.yahoo\.com/i.test(String(url || ''));
+  }
+}
+
+function findYahooLoginEmailInput() {
+  return Array.from(document.querySelectorAll([
+    'input#login-username',
+    'input[name="username"]',
+    'input[name="login"]',
+    'input[type="email"]',
+    'input[autocomplete="username"]',
+  ].join(','))).find((node) => node instanceof HTMLInputElement && isVisibleElement(node)) || null;
+}
+
+function findYahooLoginPasswordInput() {
+  return Array.from(document.querySelectorAll([
+    'input#login-passwd',
+    'input[name="password"]',
+    'input[type="password"]',
+    'input[autocomplete="current-password"]',
+  ].join(','))).find((node) => node instanceof HTMLInputElement && isVisibleElement(node)) || null;
+}
+
+function findYahooLoginSubmitButton() {
+  const selectors = [
+    'button#login-signin',
+    'input#login-signin',
+    'button[name="signin"]',
+    'input[name="signin"]',
+    'button[type="submit"]',
+    'input[type="submit"]',
+  ];
+  return Array.from(document.querySelectorAll(selectors.join(',')))
+    .find((node) => node instanceof HTMLElement && isVisibleElement(node) && !node.disabled) || null;
+}
+
+async function waitForYahooLoginPasswordInput(timeout = 15000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeout) {
+    throwIfStopped();
+    const input = findYahooLoginPasswordInput();
+    if (input) return input;
+    await sleep(250);
+  }
+  return findYahooLoginPasswordInput();
+}
+
+async function clickYahooLoginButton(label) {
+  const button = findYahooLoginSubmitButton();
+  if (!button) {
+    const activeInput = document.activeElement;
+    if (activeInput instanceof HTMLElement) {
+      activeInput.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key: 'Enter', code: 'Enter' }));
+      activeInput.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true, cancelable: true, key: 'Enter', code: 'Enter' }));
+      return true;
+    }
+    return false;
+  }
+  try {
+    button.scrollIntoView?.({ block: 'center', inline: 'center' });
+  } catch {}
+  await sleep(120);
+  const rect = button.getBoundingClientRect();
+  const x = Math.round(rect.left + Math.max(4, Math.min(rect.width / 2, rect.width - 4)));
+  const y = Math.round(rect.top + Math.max(4, Math.min(rect.height / 2, rect.height - 4)));
+  dispatchClickSequence(button, x, y);
+  log(`Yahoo：已点击${label}`, 'info');
+  return true;
+}
+
+async function handleYahooLoginWithCredentials(payload = {}) {
+  if (!isYahooLoginPage()) {
+    return { ok: true, skipped: true, reason: 'not_yahoo_login_page', url: location.href };
+  }
+
+  const email = String(payload.email || '').trim();
+  const password = String(payload.password || '');
+  if (!email || !password) {
+    return { ok: true, skipped: true, reason: 'missing_credentials' };
+  }
+
+  let passwordInput = findYahooLoginPasswordInput();
+  if (!passwordInput) {
+    const emailInput = findYahooLoginEmailInput();
+    if (!emailInput) {
+      throw new Error('Yahoo 登录页未找到邮箱输入框。');
+    }
+    fillInput(emailInput, email);
+    log(`Yahoo：已填写登录邮箱 ${email}，准备进入密码页。`, 'info');
+    await sleep(180);
+    await clickYahooLoginButton('Yahoo 登录下一步按钮');
+    passwordInput = await waitForYahooLoginPasswordInput();
+  }
+
+  if (!passwordInput) {
+    throw new Error('Yahoo 登录页未进入密码输入步骤。');
+  }
+
+  fillInput(passwordInput, password);
+  log('Yahoo：已填写登录密码，准备提交。', 'info');
+  await sleep(180);
+  await clickYahooLoginButton('Yahoo 登录提交按钮');
+  return { ok: true, submitted: true };
+}
+
+// 判断指定地址是否属于 Yahoo 收件箱页面。
+function isYahooInboxPage(url = location.href) {
+  const value = String(url || '').trim();
+
+  try {
+    const parsed = new URL(value, location.origin);
+    const isYahooMailHost = /(^|\.)mail\.yahoo\.com$/i.test(parsed.hostname);
+    const isInboxPath = /^\/(?:n|d|b)\/(?:inbox|folders(?:\/\d+)?)/i.test(parsed.pathname || '');
+    if (isYahooMailHost && isInboxPath) {
+      return true;
+    }
+  } catch {}
+
+  if (/\/(?:n|d|b)\/(?:inbox|folders(?:\/\d+)?)(?:[/?#].*)?$/i.test(value)) {
+    return true;
+  }
+
+  if (document.querySelector('[data-test-id="message-list"], [data-test-id="virtual-list"]')) {
+    return true;
+  }
+
+  return false;
+}
+
+// 根据页面文本判断是否像 Yahoo 设置页 DOM。
+function looksLikeYahooSettingsDom(root = document) {
+  const text = normalizeLowerText(root?.body?.innerText || root?.body?.textContent || root?.innerText || root?.textContent || '');
+  return /一次性电子邮件地址|disposable email addresses|disposable email address|disposable address/.test(text)
+    || /mailboxes|邮箱列表|auto-forwarding|自动转发/.test(text);
+}
+
+// 判断指定地址或 DOM 是否属于 Yahoo 设置页。
+function isYahooSettingsPage(url = location.href) {
+  const value = String(url || '').trim();
+  if (/https:\/\/mail\.yahoo\.com\/(?:n|d|b)\/settings(?:\/2)?(?:[/?#].*)?$/i.test(value)) {
+    return true;
+  }
+  if (/\/(?:n|d|b)\/settings(?:\/2)?(?:[/?#].*)?$/i.test(value)) {
+    return true;
+  }
+  if (/\/settings(?:\/2)?(?:[/?#].*)?$/i.test(value)) {
+    return true;
+  }
+  return looksLikeYahooSettingsDom(document);
+}
+
+// 规范化 Yahoo URL，去掉 hash 便于比较。
+function normalizeComparableYahooUrl(url) {
+  try {
+    const value = new URL(String(url || ''), location.origin);
+    value.hash = '';
+    return value.toString();
+  } catch {
+    return String(url || '').trim();
+  }
+}
+
+// 查找当前页面可用的 Yahoo“收件箱”入口，优先复用站内导航而不是直接要求后台重开。
+function findYahooInboxLink() {
+  const directSelectors = [
+    'a[data-test-folder-name="Inbox"]',
+    'a[href*="/n/inbox"]',
+    'a[href*="/d/folders"]',
+    'a[href*="/b/folders"]',
+    'button[aria-label*="Inbox"]',
+    'button[aria-label*="收件箱"]',
+    '[role="button"][aria-label*="Inbox"]',
+    '[role="button"][aria-label*="收件箱"]',
+  ];
+
+  for (const selector of directSelectors) {
+    const matched = Array.from(document.querySelectorAll(selector)).find((node) => isVisibleElement(node));
+    if (matched) {
+      return matched;
+    }
+  }
+
+  return Array.from(document.querySelectorAll('a[href], button, [role="button"]')).find((node) => {
+    if (!(node instanceof HTMLElement) || !isVisibleElement(node)) return false;
+    const href = String(node.getAttribute?.('href') || '').trim();
+    const text = normalizeLowerText(node.getAttribute?.('aria-label') || node.textContent || node.title || '');
+    return /\/n\/inbox/i.test(href) || /^(inbox|收件箱)$/.test(text) || /收件箱|inbox/.test(text);
+  }) || null;
+}
+
+// 等待 Yahoo 收件箱列表真正可见，避免只是 URL 改了但列表尚未 ready。
+async function waitForYahooInboxReady(timeout = 10000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeout) {
+    throwIfStopped();
+    if (isYahooInboxPage(location.href) && isYahooInboxListVisible()) {
+      return true;
+    }
+    await sleep(250);
+  }
+  return isYahooInboxPage(location.href) && isYahooInboxListVisible();
+}
+
+// 确保当前处在 Yahoo 收件箱页；优先在当前页内自愈跳转到收件箱，失败后再交由后台重开。
+async function ensureOnYahooInbox() {
+  ensureYahooLoggedIn('读取 Yahoo 邮件');
+  const currentUrl = normalizeComparableYahooUrl(location.href);
+  const targetUrl = normalizeComparableYahooUrl(YAHOO_INBOX_URL);
+
+  if (isYahooInboxPage(currentUrl) && isYahooInboxListVisible()) {
+    return;
+  }
+
+  log(`Yahoo：当前未处于可读取的收件箱列表，先尝试在当前页内切回收件箱 current=${currentUrl} target=${targetUrl}`, 'warn');
+
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    throwIfStopped();
+
+    const inboxLink = findYahooInboxLink();
+    if (inboxLink) {
+      const rect = inboxLink.getBoundingClientRect();
+      const clickX = Math.round(rect.left + Math.max(6, Math.min(rect.width / 2, Math.max(rect.width - 6, 6))));
+      const clickY = Math.round(rect.top + Math.max(6, Math.min(rect.height / 2, Math.max(rect.height - 6, 6))));
+      log(`Yahoo：第 ${attempt} 次尝试点击站内”收件箱”入口回到 inbox tag=${inboxLink.tagName || 'unknown'} pos=${clickX},${clickY}`, 'info');
+      try {
+        dispatchHoverSequence(inboxLink, clickX, clickY);
+        await sleep(120);
+        dispatchClickSequence(inboxLink, clickX, clickY);
+        if (typeof inboxLink.click === 'function') inboxLink.click();
+      } catch (err) {
+        log(`Yahoo：收件箱链接点击失败 attempt=${attempt} error=${err?.message || String(err)}`, 'warn');
+      }
+      await sleep(1200);
+      if (await waitForYahooInboxReady(5000)) {
+        log(`Yahoo：已在当前页内成功切回收件箱，第 ${attempt} 次尝试完成`, 'ok');
+        return;
+      }
+    }
+
+    if (isYahooInboxPage(location.href)) {
+      const refreshed = await refreshYahooInboxList(attempt);
+      await sleep(1000);
+      if (refreshed && await waitForYahooInboxReady(4000)) {
+        log(`Yahoo：当前已位于收件箱 URL，经过第 ${attempt} 次页内刷新后列表已可读`, 'ok');
+        return;
+      }
+    }
+  }
+
+  log(`Yahoo：当前不在目标收件箱页，且页内自愈失败，交由后台重开标签页 current=${normalizeComparableYahooUrl(location.href)} target=${targetUrl}`, 'warn');
+  throw new Error(`YAHOO_INBOX_REOPEN_REQUIRED::${YAHOO_INBOX_URL}`);
+}
+
+// 确保当前处在 Yahoo 设置页，不在则尝试从站内入口切过去。
+async function ensureOnYahooSettings() {
+  ensureYahooLoggedIn('创建 Yahoo 临时邮箱');
+  if (isYahooSettingsPage(location.href)) {
+    log(`Yahoo：已位于设置页 href=${location.href}`, 'info');
+    return;
+  }
+
+  log(`Yahoo：当前不在设置页，尝试使用站内入口切换 href=${location.href}`, 'warn');
+
+  const settingsLink = Array.from(document.querySelectorAll('a[href], button, [role="button"]')).find((node) => {
+    const href = node.getAttribute?.('href') || '';
+    const text = normalizeLowerText(node.getAttribute?.('aria-label') || node.textContent || node.title || '');
+    return /\/settings(?:\/2)?(?:[/?#].*)?$/i.test(href)
+      || /settings/.test(text);
+  });
+
+  if (settingsLink) {
+    try {
+      settingsLink.click?.();
+    } catch (err) {
+      log(`Yahoo：设置链接点击失败 error=${err?.message || String(err)}`, 'warn');
+    }
+    await sleep(1200);
+    if (isYahooSettingsPage(location.href)) {
+      log(`Yahoo：点击设置入口后已进入设置页 href=${location.href}`, 'info');
+      return;
+    }
+  }
+
+  throw new Error(`YAHOO_SETTINGS_REOPEN_REQUIRED::${YAHOO_SETTINGS_URL}`);
+}
+
+// 等待给定选择器中任意一个在页面上变得可见。
+async function waitForAnySelector(selectors, timeout = 10000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeout) {
+    throwIfStopped();
+    for (const selector of selectors) {
+      const node = document.querySelector(selector);
+      if (node && isVisibleElement(node)) {
+        return node;
+      }
+    }
+    await sleep(200);
+  }
+  throw new Error(`等待 Yahoo 页面元素超时：${selectors.join(' | ')}`);
+}
+
+// 判断节点是否像 Yahoo 收件箱中的邮件行。
+function isLikelyYahooMessageRow(node) {
+  if (!(node instanceof HTMLElement) || !isElementInViewport(node)) return false;
+  const text = getYahooRowFullText(node);
+  if (!text || text.length < 12) return false;
+
+  const className = String(node.className || '');
+  if (/\bH_A\b/.test(className) && /\bhd_n\b/.test(className) && /\bp_a\b/.test(className) && /\bL_0\b/.test(className) && /\bR_0\b/.test(className)) {
+    return true;
+  }
+
+  const hasCheckbox = Boolean(node.querySelector('input[type="checkbox"], [role="checkbox"], [data-test-id="checkbox"]'));
+  const hasTime = Boolean(node.querySelector('time, [datetime]')) || /\b\d{1,2}:\d{2}\s?(?:am|pm)\b/i.test(text) || /\b\d{1,2}:\d{2}\b/.test(text);
+  const hasMailKeyword = /openai|no-?reply@|signin\.aws|amazon\s+web\s+services|aws|构建者|chatgpt|verification|verify|验证码|安全码|临时/i.test(text) || /@/.test(text) || /\b\d{6}\b/.test(text);
+  const hasSender = /OpenAI|ChatGPT|no-?reply|signin\.aws|Amazon Web Services/i.test(text);
+
+  return hasMailKeyword && (hasCheckbox || hasTime || hasSender);
+}
+
+function getYahooMessageQueryRoots() {
+  const roots = [
+    document.querySelector('[data-test-id="message-list"]'),
+    document.querySelector('[data-test-id="virtual-list"]'),
+    document.querySelector('#mail-app-component'),
+    document.querySelector('main [role="list"]'),
+    document.querySelector('main ul'),
+    document.querySelector('main ol'),
+    document.querySelector('main'),
+    document,
+  ];
+  return roots.filter((root, index, array) => root && array.indexOf(root) === index);
+}
+
+function collectLimitedNodes(root, selector, limit = YAHOO_ROW_SCAN_LIMIT) {
+  if (!root || typeof root.querySelectorAll !== 'function') {
+    return [];
+  }
+  const nodes = [];
+  for (const node of root.querySelectorAll(selector)) {
+    nodes.push(node);
+    if (nodes.length >= limit) {
+      break;
+    }
+  }
+  return nodes;
+}
+
+// 收集并排序当前页面上的 Yahoo 邮件行。
+function getMessageRows() {
+  const roots = getYahooMessageQueryRoots();
+  const exactRows = roots.flatMap((root) => collectLimitedNodes(root, 'li.H_A.hd_n.p_a.L_0.R_0'))
+    .filter((node) => isLikelyYahooMessageRow(node))
+    .filter((node, index, arr) => arr.indexOf(node) === index)
+    .sort((left, right) => {
+      const leftTop = parseFloat(String(left.style?.top || '').replace('px', ''));
+      const rightTop = parseFloat(String(right.style?.top || '').replace('px', ''));
+      const safeLeftTop = Number.isFinite(leftTop) ? leftTop : left.getBoundingClientRect().top;
+      const safeRightTop = Number.isFinite(rightTop) ? rightTop : right.getBoundingClientRect().top;
+      if (Math.abs(safeLeftTop - safeRightTop) > 1) return safeLeftTop - safeRightTop;
+      const leftRect = left.getBoundingClientRect();
+      const rightRect = right.getBoundingClientRect();
+      return leftRect.left - rightRect.left;
+    });
+  if (exactRows.length) return exactRows;
+
+  const selectors = [
+    '[data-test-id="message-list-item"]',
+    '[data-test-id*="message-list-item"]',
+    '[data-test-id="message-list"] [role="row"]',
+    '[data-test-id="message-list"] li',
+    '[data-test-id="message-list"] > div',
+    '[data-test-id="virtual-list"] [role="row"]',
+    '[data-test-id="virtual-list"] li',
+    'div[role="row"]',
+    'ul[role="list"] li',
+    'main li',
+    'table tr',
+  ];
+
+  for (const selector of selectors) {
+    const rows = roots.flatMap((root) => collectLimitedNodes(root, selector))
+      .filter((node) => isLikelyYahooMessageRow(node))
+      .filter((node, index, arr) => arr.indexOf(node) === index)
+      .sort((left, right) => {
+        const leftRect = left.getBoundingClientRect();
+        const rightRect = right.getBoundingClientRect();
+        if (Math.abs(leftRect.top - rightRect.top) > 4) return leftRect.top - rightRect.top;
+        return leftRect.left - rightRect.left;
+      });
+    if (rows.length) {
+      return rows;
+    }
+  }
+
+  return [];
+}
+
+function isKiroYahooTopMessagePayload(payload = {}) {
+  if (String(payload?.flowId || '').trim().toLowerCase() === 'kiro') {
+    return true;
+  }
+  const filters = [
+    ...(Array.isArray(payload?.senderFilters) ? payload.senderFilters : []),
+    ...(Array.isArray(payload?.subjectFilters) ? payload.subjectFilters : []),
+    ...(Array.isArray(payload?.requiredKeywords) ? payload.requiredKeywords : []),
+  ].map(normalizeLowerText).join(' ');
+  return /signin\.aws|aws builder id|构建者|kiro/.test(filters);
+}
+
+function getFastVisibleYahooMessageRows(limit = 12) {
+  const selectors = [
+    'li[data-test-id="message-list-item"]',
+    '[data-test-id="message-list"] li[data-test-id="message-list-item"]',
+    '[data-test-id="virtual-list"] li[data-test-id="message-list-item"]',
+    'li.H_A.hd_n.p_a.L_0.R_0',
+  ];
+  const rows = [];
+  for (const selector of selectors) {
+    for (const row of document.querySelectorAll(selector)) {
+      if (!(row instanceof HTMLElement)) continue;
+      if (!isElementInViewport(row)) continue;
+      if (rows.includes(row)) continue;
+      rows.push(row);
+      if (rows.length >= limit) break;
+    }
+    if (rows.length >= limit) break;
+  }
+  return rows.sort((left, right) => {
+    const leftRect = left.getBoundingClientRect();
+    const rightRect = right.getBoundingClientRect();
+    if (Math.abs(leftRect.top - rightRect.top) > 4) return leftRect.top - rightRect.top;
+    return leftRect.left - rightRect.left;
+  });
+}
+
+function rowLooksLikeKiroAwsMessage(text = '') {
+  const lower = normalizeLowerText(text);
+  return /no-?reply@signin\.aws|signin\.aws|amazon web services|aws/.test(lower)
+    && /构建者|builder id|verification|验证码|code/.test(lower);
+}
+
+function buildYahooNoCodeTopRowResult(row, rowText, reason, topRowTimestamp = 0) {
+  return {
+    ok: false,
+    code: null,
+    reason,
+    preview: rowText.slice(0, 200),
+    emailTimestamp: topRowTimestamp || Date.now(),
+    topMessageFingerprint: buildYahooTopMessageFingerprint(row, rowText, null, topRowTimestamp || Date.now()),
+  };
+}
+
+function handleKiroYahooTopMessageFastPath(step, payload = {}) {
+  const rows = getFastVisibleYahooMessageRows(12);
+  log(`Yahoo：Kiro 快速顶部邮件扫描 rows=${rows.length}`, 'warn');
+  if (!rows.length) {
+    return {
+      ok: false,
+      code: null,
+      reason: 'Kiro 快速扫描未找到可见 Yahoo 邮件行',
+      preview: '',
+      emailTimestamp: Date.now(),
+      topMessageFingerprint: '',
+    };
+  }
+
+  const topRow = rows[0];
+  const rowText = getYahooRowFullText(topRow);
+  const topRowTimestamp = getRowTimestamp(topRow) || Date.now();
+  if (!rowText) {
+    return buildYahooNoCodeTopRowResult(topRow, '', 'Kiro 快速扫描顶部邮件没有可读取文本', topRowTimestamp);
+  }
+
+  const filterMatched = rowMatchesFilters(rowText, payload) || rowLooksLikeKiroAwsMessage(rowText);
+  if (!filterMatched) {
+    return buildYahooNoCodeTopRowResult(topRow, rowText, 'Kiro 快速扫描顶部邮件未命中 AWS/Kiro 过滤条件', topRowTimestamp);
+  }
+
+  const code = extractVerificationCodeWithPatterns(rowText, payload);
+  if (!code) {
+    return buildYahooNoCodeTopRowResult(topRow, rowText, 'Kiro 快速扫描顶部 AWS/Kiro 邮件中未提取到验证码', topRowTimestamp);
+  }
+
+  const rowCode = { code, text: rowText, source: 'fast-row-snippet' };
+  const freshness = evaluateYahooTopMessageFreshness(topRow, rowText, rowCode, topRowTimestamp, payload, true);
+  if (!freshness.freshnessMatched) {
+    log(`Yahoo：Kiro 快速扫描验证码 ${code} 缺少新鲜度证据：${freshness.freshnessReason}`, 'warn');
+    return {
+      ok: false,
+      code: null,
+      reason: `顶部验证码存在，但缺少本轮新邮件证据：${freshness.freshnessReason}`,
+      preview: rowText.slice(0, 200),
+      emailTimestamp: topRowTimestamp,
+      topMessageFingerprint: freshness.topMessageFingerprint,
+    };
+  }
+
+  log(`Yahoo：Kiro 快速扫描已从顶部邮件行提取验证码 ${code} preview=${rowText.slice(0, 180)}`, 'warn');
+  return {
+    ok: true,
+    code,
+    emailTimestamp: topRowTimestamp,
+    preview: rowText.slice(0, 200),
+    topMessageFingerprint: freshness.topMessageFingerprint,
+    freshnessMatched: freshness.freshnessMatched,
+    freshnessReason: freshness.freshnessReason,
+  };
+}
+
+// 取出最靠前或时间最靠上的候选邮件行。
+function getLatestYahooCodeRow() {
+  const rows = getMessageRows();
+  if (!rows.length) return null;
+
+  return findTopMessageRow(rows);
+}
+
+// 判断当前是否已经展示了收件箱列表。
+function isYahooInboxListVisible() {
+  const listRoot = document.querySelector('[data-test-id="message-list"], [data-test-id="virtual-list"], main [role="list"], main ul, main ol, #mail-app-component');
+  if (listRoot && isVisibleElement(listRoot)) {
+    return true;
+  }
+  return getYahooMessageQueryRoots().some((root) => collectLimitedNodes(root, 'li.H_A.hd_n.p_a.L_0.R_0, [data-test-id="message-list-item"], [data-test-id*="message-list-item"], [data-test-id="message-list"] [role="row"], [data-test-id="virtual-list"] [role="row"], div[role="row"], table tr', 8)
+    .some((node) => isLikelyYahooMessageRow(node)));
+}
+
+// 尝试通过刷新按钮或收件箱入口拉取最新邮件列表。
+async function refreshYahooInboxList(attempt) {
+  try {
+    const refreshBtnCandidates = Array.from(document.querySelectorAll('button, [role="button"], span, div')).filter((node) => {
+      if (!(node instanceof HTMLElement) || !isVisibleElement(node)) return false;
+      const text = normalizeLowerText(node.getAttribute?.('aria-label') || node.textContent || node.title || '');
+      return /refresh|check for new|new mail|更新|刷新|检查新邮件/.test(text);
+    });
+
+    const refreshBtn = refreshBtnCandidates[0]
+      || document.querySelector('button[data-test-id="icon-btn-refresh"]')
+      || document.querySelector('button[aria-label*="Refresh"], button[title*="Refresh"], button[aria-label*="刷新"], button[title*="刷新"]');
+
+    if (refreshBtn instanceof HTMLElement && isVisibleElement(refreshBtn)) {
+      log(`Yahoo：尝试点击刷新按钮拉取新邮件（第 ${attempt} 次）...`, 'info');
+      simulateClick(refreshBtn);
+      await sleep(1000);
+      if (isYahooInboxListVisible()) return true;
+    }
+
+    const inboxLinks = Array.from(document.querySelectorAll('a[data-test-folder-name="Inbox"], a[href*="/n/inbox"], a[href*="/d/folders"], a[href*="/b/folders"], button[aria-label*="Inbox"], button[aria-label*="收件箱"]'))
+      .filter((node) => node instanceof HTMLElement && isVisibleElement(node));
+    const inboxBtn = inboxLinks[0] || null;
+
+    if (inboxBtn) {
+      const rect = inboxBtn.getBoundingClientRect();
+      const clickX = Math.round(rect.left + Math.min(Math.max(rect.width / 2, 5), Math.max(rect.width - 5, 5)));
+      const clickY = Math.round(rect.top + Math.min(Math.max(rect.height / 2, 5), Math.max(rect.height - 5, 5)));
+      log(`Yahoo：尝试点击收件箱按钮刷新列表（第 ${attempt} 次）...`, 'info');
+      dispatchHoverSequence(inboxBtn, clickX, clickY);
+      await sleep(120);
+      dispatchClickSequence(inboxBtn, clickX, clickY);
+      try {
+        if (typeof inboxBtn.click === 'function') inboxBtn.click();
+      } catch (err) {
+        log(`Yahoo：收件箱按钮点击失败 error=${err?.message || String(err)}`, 'warn');
+      }
+      await sleep(1000);
+      if (isYahooInboxListVisible()) return true;
+    }
+  } catch (error) {
+    log(`Yahoo：尝试刷新收件箱时发生异常忽略：${error?.message || error}`, 'warn');
+  }
+
+  return isYahooInboxListVisible();
+}
+
+// 直接从邮件行文本里提取 6 位数字验证码。
+function extractSixDigitCodeFromLatestRow(row) {
+  if (!(row instanceof HTMLElement)) return null;
+
+  const text = getYahooRowFullText(row);
+
+  const match = text.match(/\b(\d{6})\b/);
+  if (!match) return null;
+
+  return {
+    code: match[1],
+    text,
+    source: 'row-text',
+  };
+}
+
+function getYahooRowFullText(row) {
+  if (!(row instanceof HTMLElement)) return '';
+  const explicitTextNodes = Array.from(row.querySelectorAll([
+    '[id^="email-sender-"]',
+    '[id^="email-subject-snippet-"]',
+    '[id^="email-subject-"]',
+    '[id^="email-snippet-"]',
+    '[id^="email-date-"]',
+    '[title]',
+  ].join(','))).map((node) => [
+    node.getAttribute?.('aria-label'),
+    node.getAttribute?.('title'),
+    node.innerText,
+    node.textContent,
+  ].filter(Boolean).join(' '));
+
+  return joinUniqueTextParts([
+    row.getAttribute('aria-label'),
+    row.getAttribute('title'),
+    row.innerText,
+    row.textContent,
+    ...explicitTextNodes,
+  ]);
+}
+
+// 获取邮件行的可读文本。
+function getRowText(row) {
+  return getYahooRowFullText(row);
+}
+
+// 找出列表中最靠上的可见邮件行。
+function findTopMessageRow(rows = []) {
+  return (Array.isArray(rows) ? rows : [])
+    .filter((row) => row instanceof HTMLElement && isElementInViewport(row))
+    .sort((left, right) => {
+      const leftRect = left.getBoundingClientRect();
+      const rightRect = right.getBoundingClientRect();
+      if (Math.abs(leftRect.top - rightRect.top) > 4) return leftRect.top - rightRect.top;
+      return leftRect.left - rightRect.left;
+    })[0] || null;
+}
+
+// 尝试把 Yahoo 邮件时间文本解析成时间戳。
+function parseYahooMailboxTimestampCandidate(value) {
+  const text = normalizeText(value);
+  if (!text) return null;
+
+  const relativeCnMatch = text.match(/(\d{1,3})\s*(秒|分钟|分|小时|天)前/);
+  if (relativeCnMatch) {
+    const amount = Number(relativeCnMatch[1]);
+    const unit = relativeCnMatch[2] || '';
+    const unitMs = /秒/.test(unit)
+      ? 1000
+      : (/分|分钟/.test(unit)
+        ? 60 * 1000
+        : (/小时/.test(unit)
+          ? 60 * 60 * 1000
+          : 24 * 60 * 60 * 1000));
+    return Date.now() - (amount * unitMs);
+  }
+
+  const relativeEnMatch = text.match(/(\d{1,3})\s*(second|sec|minute|min|hour|hr|day)s?\s*ago/i);
+  if (relativeEnMatch) {
+    const amount = Number(relativeEnMatch[1]);
+    const unit = normalizeLowerText(relativeEnMatch[2] || '');
+    const unitMs = /second|sec/.test(unit)
+      ? 1000
+      : (/minute|min/.test(unit)
+        ? 60 * 1000
+        : (/hour|hr/.test(unit)
+          ? 60 * 60 * 1000
+          : 24 * 60 * 60 * 1000));
+    return Date.now() - (amount * unitMs);
+  }
+
+  if (/^(just now|刚刚|刚才)$/i.test(text)) {
+    return Date.now();
+  }
+
+  const directParsed = Date.parse(text);
+  if (Number.isFinite(directParsed)) {
+    return directParsed;
+  }
+
+  const localizedDateTimeMatch = text.match(/(\d{1,2})月(\d{1,2})日(?:\s*(上午|下午))?\s*(\d{1,2}):(\d{2})/);
+  if (localizedDateTimeMatch) {
+    const now = new Date();
+    let hour = Number(localizedDateTimeMatch[4]);
+    const minute = Number(localizedDateTimeMatch[5]);
+    const meridiem = localizedDateTimeMatch[3] || '';
+    if (meridiem === '下午' && hour < 12) hour += 12;
+    if (meridiem === '上午' && hour === 12) hour = 0;
+    const parsed = new Date(now.getFullYear(), Number(localizedDateTimeMatch[1]) - 1, Number(localizedDateTimeMatch[2]), hour, minute, 0, 0).getTime();
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  const timeMatch = text.match(/(?:(今天|today|昨天|yesterday)\s*)?(?:(上午|下午)\s*)?(\d{1,2}):(\d{2})(?:\s*(am|pm))?/i);
+  if (timeMatch) {
+    let hour = Number(timeMatch[3]);
+    const minute = Number(timeMatch[4]);
+    const dayToken = normalizeLowerText(timeMatch[1] || '');
+    const meridiemCn = timeMatch[2] || '';
+    const meridiemEn = normalizeLowerText(timeMatch[5] || '');
+    if ((meridiemCn === '下午' || meridiemEn === 'pm') && hour < 12) hour += 12;
+    if ((meridiemCn === '上午' || meridiemEn === 'am') && hour === 12) hour = 0;
+    const now = new Date();
+    if (dayToken === '昨天' || dayToken === 'yesterday') {
+      now.setDate(now.getDate() - 1);
+    }
+    now.setHours(hour, minute, 0, 0);
+    return now.getTime();
+  }
+
+  return null;
+}
+
+// 从邮件行的多个时间候选字段里提取时间戳。
+function getRowTimestamp(row) {
+  const timeNode = row.querySelector('time, [datetime], [title]');
+  const candidates = [
+    timeNode?.getAttribute?.('datetime'),
+    timeNode?.getAttribute?.('title'),
+    timeNode?.textContent,
+    row.getAttribute?.('aria-label'),
+    row.innerText,
+    row.textContent,
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    const parsed = parseYahooMailboxTimestampCandidate(candidate);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+
+  return 0;
+}
+
+// 判断邮件文本是否命中发件人或主题过滤条件。
+function rowMatchesFilters(text, payload) {
+  const lower = normalizeLowerText(text);
+  const senderFilters = (payload.senderFilters || []).map(normalizeLowerText).filter(Boolean);
+  const subjectFilters = (payload.subjectFilters || []).map(normalizeLowerText).filter(Boolean);
+  const senderMatch = senderFilters.length === 0 ? true : senderFilters.some((item) => lower.includes(item));
+  const subjectMatch = subjectFilters.length === 0 ? true : subjectFilters.some((item) => lower.includes(item));
+  return senderMatch || subjectMatch;
+}
+
+// 预编译正则表达式以提升性能
+const YAHOO_FINGERPRINT_PATTERNS = [
+  /\b\d{1,3}\s*(?:seconds?|secs?|minutes?|mins?|hours?|hrs?|days?)\s+ago\b/gi,
+  /\b(?:just now|today|yesterday)\b/gi,
+  /\d{1,3}\s*(?:秒|分钟|分|小时|天)前/g,
+  /(?:今天|昨天)\s*/g,
+  /(?:上午|下午)?\s*\d{1,2}:\d{2}(?:\s*(?:am|pm))?/gi,
+  /\s+/g
+];
+
+function normalizeYahooFingerprintText(value) {
+  let text = normalizeText(String(value || ''));
+
+  // 使用预编译的正则表达式批量替换
+  for (const pattern of YAHOO_FINGERPRINT_PATTERNS) {
+    text = text.replace(pattern, ' ');
+  }
+
+  return text.trim().slice(0, 240);
+}
+
+function buildYahooTopMessageFingerprint(row, rowText, rowCode, rowTimestamp) {
+  if (!(row instanceof HTMLElement)) {
+    return '';
+  }
+
+  const normalizedRowText = normalizeYahooFingerprintText(rowText);
+  const identityParts = [
+    row.getAttribute('data-id'),
+    row.getAttribute('data-test-id'),
+    row.getAttribute('id'),
+    row.dataset?.testid,
+    row.dataset?.id,
+    row.querySelector('a[href]')?.getAttribute('href'),
+    row.querySelector('time, [datetime]')?.getAttribute('datetime'),
+    rowCode?.code || '',
+    normalizedRowText,
+  ].map((item) => normalizeText(item)).filter(Boolean);
+
+  return identityParts.join(' | ');
+}
+
+function evaluateYahooTopMessageFreshness(row, rowText, rowCode, rowTimestamp, payload = {}, filterMatched = false) {
+  const topMessageFingerprint = buildYahooTopMessageFingerprint(row, rowText, rowCode, rowTimestamp);
+  const previousTopMessageFingerprint = normalizeText(payload.previousTopMessageFingerprint || '');
+  const previousAcceptedEmailTimestamp = Math.max(0, Number(payload.previousAcceptedEmailTimestamp || 0) || 0);
+  const requestedAt = Math.max(0, Number(payload.requestedAt || 0) || 0);
+  const freshnessSkewMs = Math.max(60000, Number(payload.yahooFreshnessSkewMs || 180000) || 180000);
+  const topRowCodeFallbackMatched = Boolean(payload.yahooTopRowOnly && rowCode?.code);
+
+  const fingerprintChanged = Boolean(previousTopMessageFingerprint)
+    && Boolean(topMessageFingerprint)
+    && topMessageFingerprint !== previousTopMessageFingerprint;
+  const timestampNotOlderThanRequest = requestedAt > 0
+    && rowTimestamp > 0
+    && rowTimestamp >= requestedAt - freshnessSkewMs;
+  const timestampAdvancedBeyondPreviousSuccess = previousAcceptedEmailTimestamp > 0
+    && rowTimestamp > 0
+    && rowTimestamp > previousAcceptedEmailTimestamp;
+  const bootstrapFallbackAllowed = !previousTopMessageFingerprint
+    && previousAcceptedEmailTimestamp <= 0
+    && requestedAt > 0
+    && Boolean(payload.yahooTopRowOnly)
+    && Boolean(rowCode?.code)
+    && (Boolean(filterMatched) || topRowCodeFallbackMatched);
+
+  let freshnessMatched = false;
+  let freshnessReason = '未获得本轮新邮件证据';
+
+  if (timestampNotOlderThanRequest) {
+    freshnessMatched = true;
+    freshnessReason = `邮件时间接近本轮重发时间 (${rowTimestamp} >= ${requestedAt} - ${freshnessSkewMs})`;
+  } else if (timestampAdvancedBeyondPreviousSuccess) {
+    freshnessMatched = true;
+    freshnessReason = `邮件时间晚于上次已接受邮件 (${rowTimestamp} > ${previousAcceptedEmailTimestamp})`;
+  } else if (fingerprintChanged) {
+    freshnessMatched = true;
+    freshnessReason = '顶部邮件指纹相较上一轮观察已发生变化';
+  } else if (bootstrapFallbackAllowed) {
+    freshnessMatched = true;
+    freshnessReason = '缺少历史基线，当前顶部验证码邮件按首次候选放行';
+  }
+
+  return {
+    topMessageFingerprint,
+    freshnessMatched,
+    freshnessReason,
+    previousTopMessageFingerprint,
+    previousAcceptedEmailTimestamp,
+    requestedAt,
+    freshnessSkewMs,
+    topRowCodeFallbackMatched,
+    fingerprintChanged,
+    timestampNotOlderThanRequest,
+    timestampAdvancedBeyondPreviousSuccess,
+    bootstrapFallbackAllowed,
+  };
+}
+
+function findYahooMessageOpenTarget(row) {
+  if (!(row instanceof HTMLElement)) return null;
+  const selectors = [
+    '[data-test-id="message-list-item"]',
+    '[data-test-id*="message-list-item"]',
+    '[data-test-id*="subject"]',
+    '[data-test-id*="snippet"]',
+    'a[href*="/d/"]',
+    '[role="link"]',
+  ];
+  for (const selector of selectors) {
+    const target = row.matches?.(selector) ? row : row.querySelector(selector);
+    if (target instanceof HTMLElement && isElementInViewport(target)) {
+      return target;
+    }
+  }
+  return row;
+}
+
+function getYahooMessageOpenClickPoint(row, target = null) {
+  const rowRect = row?.getBoundingClientRect?.() || { left: 0, top: 0, width: 0, height: 0 };
+  const targetRect = target?.getBoundingClientRect?.() || rowRect;
+  const usableRect = targetRect.width > 40 && targetRect.height > 8 ? targetRect : rowRect;
+  const relativeSafeX = Math.max(140, Math.min(usableRect.width * 0.42, usableRect.width - 80));
+  const x = Math.round(usableRect.left + Math.max(8, relativeSafeX));
+  const y = Math.round(usableRect.top + Math.max(6, Math.min(usableRect.height / 2, usableRect.height - 6)));
+  return { x, y };
+}
+
+function dispatchYahooMessageOpenSequence(target, x, y) {
+  const hit = document.elementFromPoint?.(x, y);
+  const clickTarget = hit?.closest?.('[data-test-id*="message-list-item"], [role="link"], a, span, div')
+    || hit
+    || target;
+  const finalTarget = clickTarget instanceof HTMLElement ? clickTarget : target;
+
+  dispatchHoverSequence(finalTarget, x, y);
+  dispatchClickSequence(finalTarget, x, y);
+  try {
+    finalTarget.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, cancelable: true, clientX: x, clientY: y }));
+  } catch {}
+  try {
+    finalTarget.focus?.();
+    finalTarget.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key: 'Enter', code: 'Enter' }));
+    finalTarget.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true, cancelable: true, key: 'Enter', code: 'Enter' }));
+  } catch {}
+  try { if (typeof finalTarget.click === 'function') finalTarget.click(); } catch {}
+}
+
+async function waitForYahooMessageDetailText(rowText = '', payload = {}, timeoutMs = 6500) {
+  const startedAt = Date.now();
+  let latestText = '';
+  while (Date.now() - startedAt < timeoutMs) {
+    throwIfStopped();
+    latestText = normalizeText(document.body?.innerText || document.body?.textContent || '');
+    const combinedText = normalizeText([rowText, latestText].filter(Boolean).join(' '));
+    if (extractVerificationCodeWithPatterns(combinedText, payload)) {
+      return latestText;
+    }
+    await sleep(350);
+  }
+  return latestText;
+}
+
+async function clickYahooMessageOpenTarget(target, row, label = 'primary') {
+  const { x: clickX, y: clickY } = getYahooMessageOpenClickPoint(row, target);
+  log(`Yahoo：尝试打开顶部邮件详情 click=${label} target=${target?.tagName || 'unknown'} point=${clickX},${clickY}`, 'info');
+  dispatchYahooMessageOpenSequence(target, clickX, clickY);
+  await sleep(120);
+}
+
+function scheduleYahooMessageOpenTarget(target, row, label = 'scheduled') {
+  if (!(target instanceof HTMLElement)) return false;
+  const { x: clickX, y: clickY } = getYahooMessageOpenClickPoint(row, target);
+  log(`Yahoo：准备异步打开顶部邮件详情 click=${label} target=${target?.tagName || 'unknown'} point=${clickX},${clickY}`, 'info');
+  setTimeout(() => {
+    try {
+      dispatchYahooMessageOpenSequence(target, clickX, clickY);
+    } catch (error) {
+      log(`Yahoo：异步打开顶部邮件详情失败 error=${error?.message || String(error)}`, 'warn');
+    }
+  }, 30);
+  return true;
+}
+
+// 点击邮件行并读取正文文本。
+async function openRowAndReadText(row, rowText = '', payload = {}) {
+  const link = findYahooMessageOpenTarget(row);
+  if (!(link instanceof HTMLElement)) {
+    return normalizeText(document.body?.innerText || document.body?.textContent || '');
+  }
+
+  await clickYahooMessageOpenTarget(link, row, 'subject');
+  let detailText = await waitForYahooMessageDetailText(rowText, payload, 3000);
+  if (extractVerificationCodeWithPatterns(normalizeText([rowText, detailText].join(' ')), payload)) {
+    return detailText;
+  }
+
+  if (isYahooInboxListVisible()) {
+    log('Yahoo：第一次点击后仍停留在收件箱列表，改用邮件行安全区域重试打开详情。', 'warn');
+    await clickYahooMessageOpenTarget(row, row, 'row-safe-area');
+  }
+
+  detailText = await waitForYahooMessageDetailText(rowText, payload, 6500);
+  return detailText;
+}
+
+async function openTopRowAndReadVerificationCode(row, rowText, payload = {}) {
+  log('Yahoo：顶部目标邮件行未直接露出验证码，正在点进邮件详情读取正文。', 'warn');
+  if (payload?.deferDetailReadAfterOpen !== false) {
+    return {
+      code: null,
+      text: rowText,
+      source: 'message-detail-required',
+      needsOpenDetails: true,
+      needsDetailRead: true,
+    };
+  }
+
+  const detailText = await openRowAndReadText(row, rowText, payload);
+  const combinedText = normalizeText([rowText, detailText].filter(Boolean).join(' '));
+  const code = extractVerificationCodeWithPatterns(combinedText, payload);
+  if (!code) {
+    log(`Yahoo：邮件详情正文仍未提取到验证码 preview=${combinedText.slice(0, 240)}`, 'warn');
+    return null;
+  }
+
+  log(`Yahoo：已从邮件详情正文提取验证码 ${code}`, 'warn');
+  return {
+    code,
+    text: combinedText,
+    source: 'message-detail',
+  };
+}
+
+async function handleReadCurrentMessageCode(step, payload = {}) {
+  ensureYahooLoggedIn('读取 Yahoo 邮件正文');
+  const text = await waitForYahooMessageDetailText('', payload, 12000);
+  const code = extractVerificationCodeWithPatterns(text, payload);
+  if (!code) {
+    log(`Yahoo：步骤 ${step} 当前邮件详情页未提取到验证码 preview=${text.slice(0, 240)}`, 'warn');
+    return {
+      ok: false,
+      code: null,
+      reason: '当前邮件详情页未提取到验证码',
+      preview: text.slice(0, 200),
+      emailTimestamp: Date.now(),
+    };
+  }
+
+  log(`Yahoo：步骤 ${step} 已从当前邮件详情页提取验证码 ${code}`, 'warn');
+  return {
+    ok: true,
+    code,
+    emailTimestamp: Date.now(),
+    preview: text.slice(0, 200),
+    freshnessMatched: true,
+    freshnessReason: '已打开顶部邮件详情并读取正文',
+  };
+}
+
+async function handleOpenTopMessage(step, payload = {}) {
+  await ensureOnYahooInbox();
+  const rows = getMessageRows();
+  const topRow = getLatestYahooCodeRow() || findTopMessageRow(rows);
+  if (!topRow) {
+    return {
+      ok: false,
+      detailOpened: false,
+      reason: '未找到可打开的 Yahoo 顶部邮件行',
+    };
+  }
+  const rowText = getRowText(topRow);
+  const filterMatched = rowMatchesFilters(rowText, payload);
+  if (!filterMatched && !payload?.forceOpenTopMessage) {
+    return {
+      ok: false,
+      detailOpened: false,
+      reason: '顶部邮件未命中过滤条件，未打开详情',
+      preview: rowText.slice(0, 200),
+    };
+  }
+  const target = findYahooMessageOpenTarget(topRow);
+  const scheduled = scheduleYahooMessageOpenTarget(target, topRow, 'open-command');
+  return {
+    ok: scheduled,
+    detailOpened: scheduled,
+    preview: rowText.slice(0, 200),
+    emailTimestamp: getRowTimestamp(topRow) || Date.now(),
+    topMessageFingerprint: buildYahooTopMessageFingerprint(topRow, rowText, null, getRowTimestamp(topRow) || Date.now()),
+  };
+}
+
+// 从邮件行中的 lq_x 结构里提取验证码。
+function getLatestLqxCodeFromRow(row) {
+  if (!(row instanceof HTMLElement)) return null;
+  const nodes = Array.from(row.querySelectorAll('.lq_x')).filter((node) => isVisibleElement(node));
+  if (!nodes.length) return null;
+
+  const latestNode = nodes.sort((left, right) => {
+    const leftRect = left.getBoundingClientRect();
+    const rightRect = right.getBoundingClientRect();
+    if (Math.abs(leftRect.top - rightRect.top) > 6) return leftRect.top - rightRect.top;
+    return leftRect.left - rightRect.left;
+  })[0] || null;
+
+  if (!latestNode) return null;
+
+  const text = normalizeText(latestNode.innerText || latestNode.textContent || latestNode.getAttribute?.('aria-label') || '');
+  const code = extractVerificationCode(text);
+  return code ? { code, text, source: 'lq_x' } : null;
+}
+
+// 从邮件行内的可见文本片段里提取验证码。
+function getTopRowInlineCode(row) {
+  if (!(row instanceof HTMLElement)) return null;
+
+  const fullText = getYahooRowFullText(row);
+  const fullTextCode = extractVerificationCode(fullText);
+  if (fullTextCode) {
+    return { code: fullTextCode, text: fullText, source: 'full-row-text' };
+  }
+
+  const candidates = Array.from(row.querySelectorAll('span, div, a')).filter((node) => {
+    if (!(node instanceof HTMLElement) || !isVisibleElement(node)) return false;
+    const text = normalizeText(node.innerText || node.textContent || node.getAttribute?.('aria-label') || '');
+    return /\b\d{6}\b/.test(text) || /verification|验证码|临时验证码|code|继续/.test(text);
+  }).map((node) => {
+    const text = normalizeText(node.innerText || node.textContent || node.getAttribute?.('aria-label') || '');
+    const code = extractVerificationCode(text);
+    const rect = node.getBoundingClientRect();
+    const score = (code ? 100 : 0)
+      + (/verification|验证码|临时验证码|code/.test(text) ? 20 : 0)
+      + (/openai|noreply@|chatgpt/.test(text) ? 5 : 0)
+      - Math.round(rect.left / 100)
+      - Math.round(rect.top / 50);
+    return { node, text, code, score, rect };
+  }).filter((item) => item.code);
+
+  if (!candidates.length) return null;
+
+  const best = candidates.sort((left, right) => right.score - left.score || left.rect.top - right.rect.top || left.rect.left - right.rect.left)[0];
+  return best ? { code: best.code, text: best.text, source: 'inline-row' } : null;
+}
+
+// 从邮件详情页尽量返回到收件箱列表视图。
+async function returnToYahooInboxListFromMessageView() {
+  if (isYahooInboxListVisible()) {
+    return true;
+  }
+
+  const backCandidates = [
+    'button[aria-label^="Back to"]',
+    'button[title^="Back to"]',
+    'button[aria-label*="返回"]',
+    'button[title*="返回"]',
+    'a[aria-label*="Inbox"]',
+    'a[title*="Inbox"]',
+    'a[href*="/n/inbox"]',
+    'a[href*="/d/folders"]',
+    'a[href*="/b/folders"]',
+    'button[aria-label*="Inbox"]',
+    'button[aria-label*="收件箱"]',
+  ];
+
+  for (const selector of backCandidates) {
+    const btn = document.querySelector(selector);
+    if (!(btn instanceof HTMLElement) || !isVisibleElement(btn)) continue;
+    log(`Yahoo：尝试返回收件箱 selector=${selector}`, 'info');
+    simulateClick(btn);
+    await sleep(1500);
+    if (isYahooInboxListVisible()) {
+      return true;
+    }
+  }
+
+  if (history.length > 1) {
+    try {
+      log('Yahoo：未找到明确返回按钮，尝试 history.back() 返回收件箱', 'warn');
+      history.back();
+      await sleep(2000);
+      if (isYahooInboxListVisible()) {
+        return true;
+      }
+    } catch (err) {
+      log(`Yahoo：history.back() 失败 error=${err?.message || String(err)}`, 'warn');
+    }
+  }
+
+  return false;
+}
+
+// 在两次轮询之间做一次软等待，并记录原因。
+async function addSoftInboxPollDelay(intervalMs, attempt, maxAttempts, reason = '') {
+  const seconds = Math.max(1, Math.round(intervalMs / 1000));
+  log(`Yahoo：第 ${attempt}/${maxAttempts} 次检查未命中验证码，等待 ${seconds} 秒后再次读取当前收件箱。${reason ? `原因：${reason}` : ''}`, 'info');
+  await sleep(intervalMs);
+}
+
+// 刷新收件箱前先保证还停留在正确页面。
+async function refreshInbox(attempt) {
+  ensureYahooLoggedIn('刷新 Yahoo 邮箱');
+  const currentUrl = normalizeComparableYahooUrl(location.href);
+
+  if (!isYahooInboxPage(currentUrl)) {
+    log(`Yahoo：当前页不属于 all 收件箱路径，要求后台先回到 ${YAHOO_INBOX_URL} 再刷新。href=${location.href}`, 'warn');
+    throw new Error(`YAHOO_INBOX_REOPEN_REQUIRED::${YAHOO_INBOX_URL}`);
+  }
+
+  if (!isYahooInboxListVisible()) {
+    const returned = await returnToYahooInboxListFromMessageView();
+    if (!returned) {
+      log(`Yahoo：当前不在可刷新的收件箱列表视图，要求后台先回到 ${YAHOO_INBOX_URL} 再刷新。href=${location.href}`, 'warn');
+      throw new Error(`YAHOO_INBOX_REOPEN_REQUIRED::${YAHOO_INBOX_URL}`);
+    }
+  }
+
+  await refreshYahooInboxList(attempt);
+  await sleep(800);
+}
+
+async function handleCheckTopMessage(step, payload) {
+  log(`Yahoo：handleCheckTopMessage start step=${step} href=${location.href} excludedCodes=${(payload.excludeCodes || []).join(',') || '(none)'}`, 'warn');
+  if (isKiroYahooTopMessagePayload(payload)) {
+    return handleKiroYahooTopMessageFastPath(step, payload);
+  }
+  return handlePollEmail(step, {
+    ...payload,
+    yahooTopRowOnly: true,
+    keepRefreshingUntilCode: false,
+    maxAttempts: 1,
+  });
+}
+
+// 轮询 Yahoo 收件箱，并只读取最顶部那封邮件中的验证码。
+async function handlePollEmail(step, payload) {
+  await ensureOnYahooInbox();
+  await waitForAnySelector([
+    '[data-test-id="message-list"]',
+    'main',
+  ], 15000);
+  ensureYahooLoggedIn('读取 Yahoo 邮件');
+
+  const excludedCodeSet = new Set((payload.excludeCodes || []).map((item) => String(item || '').trim()).filter(Boolean));
+  log(`Yahoo：handlePollEmail start step=${step} href=${location.href} yahooTopRowOnly=${Boolean(payload.yahooTopRowOnly)} excludedCodes=${[...excludedCodeSet].join(',') || '(none)'}`, 'warn');
+  const rows = getMessageRows();
+  log(`Yahoo：当前可见邮件行数量 rows=${rows.length}`, 'info');
+  const topRow = getLatestYahooCodeRow() || findTopMessageRow(rows);
+
+  if (!topRow) {
+    log(`Yahoo：步骤 ${step} 未找到可见的收件箱顶部邮件行。`, 'warn');
+    return {
+      ok: false,
+      code: null,
+      reason: '未找到收件箱顶部邮件行',
+      preview: '',
+      emailTimestamp: Date.now(),
+    };
+  }
+
+  const rowText = getRowText(topRow);
+  const topRowTimestamp = getRowTimestamp(topRow) || Date.now();
+  log(`Yahoo：顶部邮件摘要=${rowText.slice(0, 200) || '(empty)'} timestamp=${topRowTimestamp}`, 'warn');
+  if (!rowText) {
+    log(`Yahoo：步骤 ${step} 的顶部邮件行没有可读取文本。`, 'warn');
+    return {
+      ok: false,
+      code: null,
+      reason: '收件箱顶部邮件没有可读取文本',
+      preview: '',
+      emailTimestamp: getRowTimestamp(topRow) || Date.now(),
+      topMessageFingerprint: '',
+    };
+  }
+
+  let rowCode = getLatestLqxCodeFromRow(topRow)
+    || getTopRowInlineCode(topRow)
+    || extractSixDigitCodeFromLatestRow(topRow);
+  const filterMatched = rowMatchesFilters(rowText, payload);
+  const topRowCodeFallbackMatched = Boolean(payload.yahooTopRowOnly && rowCode?.code);
+
+  if (!filterMatched && !topRowCodeFallbackMatched) {
+    log(`Yahoo：步骤 ${step} 的顶部邮件既未命中过滤条件，也未直接提取到验证码。`, 'warn');
+    return {
+      ok: false,
+      code: null,
+      reason: '当前收件箱顶部邮件既未命中过滤条件，也未直接提取到验证码',
+      preview: rowText.slice(0, 200),
+      emailTimestamp: getRowTimestamp(topRow) || Date.now(),
+      topMessageFingerprint: buildYahooTopMessageFingerprint(topRow, rowText, null, topRowTimestamp),
+    };
+  }
+
+  if (!rowCode?.code) {
+    if (filterMatched) {
+      rowCode = await openTopRowAndReadVerificationCode(topRow, rowText, payload);
+    }
+  }
+
+  if (!rowCode?.code) {
+    log(`Yahoo：步骤 ${step} 的顶部目标邮件中还没有读到 6 位验证码。`, 'warn');
+    if (rowCode?.needsDetailRead) {
+      return {
+        ok: false,
+        code: null,
+        needsOpenDetails: Boolean(rowCode?.needsOpenDetails),
+        needsDetailRead: true,
+        reason: '顶部目标邮件需要打开详情读取正文',
+        preview: rowText.slice(0, 200),
+        emailTimestamp: getRowTimestamp(topRow) || Date.now(),
+        topMessageFingerprint: buildYahooTopMessageFingerprint(topRow, rowText, null, topRowTimestamp),
+      };
+    }
+    return {
+      ok: false,
+      code: null,
+      reason: '收件箱顶部目标邮件中未提取到验证码',
+      preview: rowText.slice(0, 200),
+      emailTimestamp: getRowTimestamp(topRow) || Date.now(),
+      topMessageFingerprint: buildYahooTopMessageFingerprint(topRow, rowText, null, topRowTimestamp),
+    };
+  }
+
+  if (!filterMatched && topRowCodeFallbackMatched) {
+    log(`Yahoo：步骤 ${step} 的顶部邮件未命中过滤条件，但已在顶部行直接提取到验证码 ${rowCode.code}，按顶部验证码兜底候选继续判定。`, 'warn');
+  }
+
+  const freshness = evaluateYahooTopMessageFreshness(topRow, rowText, rowCode, topRowTimestamp, payload, filterMatched);
+  if (!freshness.freshnessMatched) {
+    log(`Yahoo：步骤 ${step} 的顶部验证码 ${rowCode.code} 缺少本轮新鲜度证据。reason=${freshness.freshnessReason} fingerprintChanged=${freshness.fingerprintChanged} previousTopFingerprint=${freshness.previousTopMessageFingerprint || '(none)'} requestedAt=${freshness.requestedAt} previousAcceptedEmailTimestamp=${freshness.previousAcceptedEmailTimestamp}`, 'warn');
+    return {
+      ok: false,
+      code: null,
+      reason: `顶部验证码存在，但缺少本轮新邮件证据：${freshness.freshnessReason}`,
+      preview: rowCode.text ? rowCode.text.slice(0, 200) : rowText.slice(0, 200),
+      emailTimestamp: getRowTimestamp(topRow) || Date.now(),
+      topMessageFingerprint: freshness.topMessageFingerprint,
+    };
+  }
+
+  if (excludedCodeSet.has(rowCode.code)) {
+    log(`Yahoo：步骤 ${step} 的顶部验证码 ${rowCode.code} 已被排除。`, 'warn');
+    return {
+      ok: false,
+      code: null,
+      reason: `收件箱顶部验证码 ${rowCode.code} 已被排除`,
+      preview: rowCode.text ? rowCode.text.slice(0, 200) : rowText.slice(0, 200),
+      emailTimestamp: getRowTimestamp(topRow) || Date.now(),
+      topMessageFingerprint: freshness.topMessageFingerprint,
+    };
+  }
+
+  const emailTimestamp = getRowTimestamp(topRow) || Date.now();
+  log(`Yahoo：已从收件箱顶部邮件命中验证码 code=${rowCode.code} timestamp=${new Date(emailTimestamp).toISOString()} freshness=${freshness.freshnessReason} preview=${String(rowCode.text || rowText).slice(0, 180)}`, 'warn');
+  return {
+    ok: true,
+    code: rowCode.code,
+    emailTimestamp,
+    preview: (rowCode.text || rowText).slice(0, 200),
+    topMessageFingerprint: freshness.topMessageFingerprint,
+    freshnessMatched: freshness.freshnessMatched,
+    freshnessReason: freshness.freshnessReason,
+  };
+}
+
+// 给一次性邮箱设置区域打分，帮助定位正确的卡片容器。
+function scoreDisposableAliasSection(node) {
+  if (!(node instanceof HTMLElement)) return -Infinity;
+  const text = normalizeLowerText(node.innerText || node.textContent || '');
+  if (!/一次性电子邮件地址|disposable email addresses|disposable email address|disposable address/.test(text)) {
+    return -Infinity;
+  }
+
+  const rect = node.getBoundingClientRect();
+  if (rect.width < 260 || rect.height < 80) return -Infinity;
+
+  let score = 0;
+  if (/protect your privacy|最多\s*3\s*个免费|during your free trial|protect your real email address|alias email addresses/.test(text)) score += 8;
+  if (/添加|add/.test(text)) score += 3;
+  if (/@yahoo\.com/.test(text)) score += 3;
+  if (/mailbox list|邮箱列表/.test(text)) score -= 8;
+  if (/send-only email address|仅发送电子邮件地址/.test(text)) score -= 8;
+  if (/auto-forwarding|自动转发/.test(text)) score -= 5;
+  if (/mailboxes/.test(text)) score -= 6;
+  score -= (rect.width * rect.height) / 200000;
+  return score;
+}
+
+// 找到 Yahoo 一次性邮箱设置区域的主容器。
+function findDisposableAliasSection() {
+  const heading = Array.from(document.querySelectorAll('h1, h2, h3, h4, div, span')).find((node) => {
+    const text = normalizeLowerText(node.innerText || node.textContent || '');
+    return node instanceof HTMLElement && /一次性电子邮件地址|disposable email addresses|disposable email address|disposable address/.test(text);
+  });
+
+  const candidates = [];
+  if (heading) {
+    let current = heading.parentElement;
+    while (current && current !== document.body) {
+      candidates.push(current);
+      current = current.parentElement;
+    }
+  }
+
+  candidates.push(...Array.from(document.querySelectorAll('section, div, main, article')));
+
+  return candidates
+    .filter((node, index, arr) => node instanceof HTMLElement && arr.indexOf(node) === index)
+    .map((node) => ({ node, score: scoreDisposableAliasSection(node) }))
+    .filter((item) => Number.isFinite(item.score) && item.score > -Infinity)
+    .sort((left, right) => right.score - left.score)[0]?.node || null;
+}
+
+async function focusDisposableAliasSection() {
+  for (let attempt = 1; attempt <= 4; attempt += 1) {
+    try {
+      window.scrollTo({ left: 0, behavior: 'instant' });
+      document.scrollingElement?.scrollTo?.({ left: 0, behavior: 'instant' });
+    } catch {
+      window.scrollTo(0, window.scrollY || 0);
+    }
+
+    const section = findDisposableAliasSection();
+    const heading = findYahooDisposableSectionHeading();
+    const target = heading || section;
+
+    if (target instanceof HTMLElement) {
+      try {
+        target.scrollIntoView?.({ block: 'center', inline: 'center' });
+      } catch {}
+      await sleep(500);
+      const refreshedSection = findDisposableAliasSection();
+      const addButton = findYahooDisposableAddButton();
+      if (addButton) {
+        log(`Yahoo：已定位 Disposable email addresses 区域并找到 Add 按钮（attempt=${attempt}）`, 'info');
+        return { section: refreshedSection || section, addButton };
+      }
+      log(`Yahoo：已滚动到 Disposable email addresses 区域，但暂未找到 Add 按钮（attempt=${attempt}）`, 'warn');
+    }
+
+    try {
+      window.scrollBy({ top: attempt % 2 ? 420 : -240, left: -1200, behavior: 'instant' });
+    } catch {
+      window.scrollBy(-1200, attempt % 2 ? 420 : -240);
+    }
+    await sleep(450);
+  }
+
+  return {
+    section: findDisposableAliasSection(),
+    addButton: findYahooDisposableAddButton(),
+  };
+}
+
+// 在祖先链里找最贴近的一次性邮箱卡片。
+function findTightAliasCard(node) {
+  if (!(node instanceof HTMLElement)) return null;
+  const chain = [];
+  let current = node;
+  while (current && current !== document.body) {
+    if (isVisibleElement(current)) {
+      const rect = current.getBoundingClientRect();
+      const text = normalizeLowerText(current.innerText || current.textContent || '');
+      if (rect.width >= 220 && rect.height >= 40 && rect.height <= 120 && /@yahoo\.com/.test(text)) {
+        chain.push(current);
+      }
+    }
+    current = current.parentElement;
+  }
+  return chain.sort((left, right) => {
+    const leftRect = left.getBoundingClientRect();
+    const rightRect = right.getBoundingClientRect();
+    const leftScore = Math.abs(leftRect.height - 64) + Math.abs(leftRect.width - 420) / 10;
+    const rightScore = Math.abs(rightRect.height - 64) + Math.abs(rightRect.width - 420) / 10;
+    return leftScore - rightScore;
+  })[0] || node;
+}
+
+// 等待一次性邮箱列表稳定后再继续操作。
+async function waitForAliasListStable(timeoutMs = 2500) {
+  const startedAt = Date.now();
+  let lastSignature = '';
+  let stableRounds = 0;
+  while (Date.now() - startedAt < timeoutMs) {
+    const aliases = collectAliasItems().map((node) => extractAliasEmailFromItem(node)).filter(Boolean);
+    const signature = aliases.join('|');
+    if (signature && signature === lastSignature) {
+      stableRounds += 1;
+      if (stableRounds >= 3) return aliases;
+    } else {
+      stableRounds = 0;
+      lastSignature = signature;
+    }
+    await sleep(180);
+  }
+  return collectAliasItems().map((node) => extractAliasEmailFromItem(node)).filter(Boolean);
+}
+
+// 收集当前页面可见的一次性邮箱条目。
+function collectAliasItems() {
+  const section = findDisposableAliasSection();
+  const scope = section || document;
+  const allEmailTexts = normalizeLowerText(scope.innerText || scope.textContent || '').match(/[a-z0-9._%+-]+@yahoo\.com/g) || [];
+  log(`Yahoo：旧邮箱扫描区域命中 ${allEmailTexts.length} 个邮箱文本`, 'info');
+
+  const unique = [];
+  const seen = new Set();
+
+  const emailNodes = Array.from(scope.querySelectorAll('*')).filter((node) => {
+    if (!(node instanceof HTMLElement) || !isVisibleElement(node)) return false;
+    const text = normalizeLowerText((node.innerText || node.textContent || '').replace(/\s+/g, ''));
+    if (!/^[a-z0-9._%+-]+@yahoo\.com$/.test(text)) return false;
+
+    let current = node.parentElement;
+    while (current && current !== scope) {
+      const currentText = normalizeLowerText(current.innerText || current.textContent || '');
+      if (/mailbox list|邮箱列表|send-only email address|仅发送电子邮件地址/.test(currentText)
+        && !/一次性电子邮件地址|disposable email addresses|disposable email address|disposable address/.test(currentText)) {
+        return false;
+      }
+      current = current.parentElement;
+    }
+    return true;
+  });
+
+  for (const node of emailNodes) {
+    const email = extractAliasEmailFromItem(node);
+    if (!email || seen.has(email)) continue;
+    const card = findTightAliasCard(node);
+    seen.add(email);
+    unique.push(card || node);
+  }
+
+  if (!unique.length) {
+    const blockCandidates = Array.from(scope.querySelectorAll('button, [role="button"], li, div, article, section')).filter((node) => {
+      if (!isVisibleElement(node)) return false;
+      const text = normalizeLowerText(node.innerText || node.textContent || '');
+      if (!/@yahoo\.com/.test(text)) return false;
+      if (/添加一次性电子邮件地址|add disposable|说明|描述|姓名|关键词|自动转发|移除地址|remove address|编辑|edit|取消|节省|保存|升级|you've reached|达到极限/.test(text)) return false;
+      const rect = node.getBoundingClientRect();
+      return rect.width > 220 && rect.height >= 40;
+    });
+
+    for (const node of blockCandidates) {
+      const email = extractAliasEmailFromItem(node);
+      if (!email || seen.has(email)) continue;
+      seen.add(email);
+      unique.push(node);
+    }
+  }
+
+  log(`Yahoo：当前检测到 ${unique.length} 个旧一次性邮箱`, 'info');
+  return unique;
+}
+
+// 按邮箱地址查找对应的一次性邮箱条目。
+function findAliasItemByEmail(email = '') {
+  const normalizedEmail = normalizeLowerText(email).replace(/\s+/g, '');
+  if (!normalizedEmail) return null;
+  const section = findDisposableAliasSection();
+  const scope = section || document;
+
+  const exactNode = Array.from(scope.querySelectorAll('*')).find((node) => {
+    if (!(node instanceof HTMLElement) || !isVisibleElement(node)) return false;
+    return normalizeLowerText((node.innerText || node.textContent || '').replace(/\s+/g, '')) === normalizedEmail;
+  });
+  if (exactNode) {
+    return findTightAliasCard(exactNode) || exactNode;
+  }
+
+  return collectAliasItems().find((node) => extractAliasEmailFromItem(node) === normalizedEmail) || null;
+}
+
+// 从条目文本中抽取一次性邮箱地址。
+function extractAliasEmailFromItem(item) {
+  const text = normalizeText(item.innerText || item.textContent || '');
+  const match = text.match(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i);
+  return match ? match[0].toLowerCase() : '';
+}
+
+// 派发一组悬停事件，模拟鼠标移入目标元素。
+function dispatchHoverSequence(target, x, y) {
+  if (!target) return;
+  target.dispatchEvent(new MouseEvent('pointerover', { bubbles: true, cancelable: true, clientX: x, clientY: y }));
+  target.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, cancelable: true, clientX: x, clientY: y }));
+  target.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true, cancelable: true, clientX: x, clientY: y }));
+  target.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, cancelable: true, clientX: x, clientY: y }));
+}
+
+// 派发一组点击事件，尽量模拟真实鼠标点击。
+function dispatchClickSequence(target, x, y) {
+  if (!target) return false;
+  dispatchHoverSequence(target, x, y);
+  target.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, cancelable: true, clientX: x, clientY: y }));
+  target.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true, clientX: x, clientY: y }));
+  target.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, cancelable: true, clientX: x, clientY: y }));
+  target.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true, clientX: x, clientY: y }));
+  target.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: x, clientY: y }));
+  if (typeof target.click === 'function') {
+    try { target.click(); } catch {}
+  }
+  return true;
+}
+
+// 从编辑面板文本里提取邮箱地址。
+function extractEditorPanelEmail(panel) {
+  if (!panel) return '';
+  const text = normalizeText(panel.innerText || panel.textContent || '');
+  const match = text.match(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i);
+  return match ? match[0].toLowerCase() : '';
+}
+
+// 定位指定一次性邮箱的编辑面板。
+function findAliasEditorPanel(email = '') {
+  const normalizedEmail = normalizeLowerText(email).replace(/\s+/g, '');
+  const panels = Array.from(document.querySelectorAll('section, div, aside, article')).filter((node) => {
+    if (!isVisibleElement(node)) return false;
+    const text = normalizeLowerText(node.innerText || node.textContent || '');
+    const compactText = text.replace(/\s+/g, '');
+    if (!/编辑|edit/.test(text)) return false;
+    if (!/移除地址|remove address|姓名|描述|取消|节省|保存/.test(text)) return false;
+    if (!normalizedEmail) return true;
+    return compactText.includes(normalizedEmail);
+  });
+  return panels.sort((left, right) => {
+    const leftRect = left.getBoundingClientRect();
+    const rightRect = right.getBoundingClientRect();
+    return rightRect.left - leftRect.left;
+  })[0] || null;
+}
+
+// 在悬停后的条目中寻找隐藏的删除按钮。
+function findHoveredAliasDeleteButton(item) {
+  const itemRect = item.getBoundingClientRect();
+  const localCandidates = Array.from(item.querySelectorAll('button, [role="button"], span, div, svg')).map((node) => {
+    const host = node instanceof SVGElement ? node.parentElement : node;
+    return host;
+  }).filter((node) => node && isVisibleElement(node));
+
+  const localMatch = localCandidates.find((node) => {
+    const text = normalizeLowerText(node.getAttribute?.('aria-label') || node.textContent || node.title || '');
+    const rect = node.getBoundingClientRect();
+    return rect.left >= itemRect.left + itemRect.width * 0.78
+      && rect.right <= itemRect.right + 20
+      && rect.width > 0
+      && rect.height > 0
+      && rect.width <= 44
+      && rect.height <= 44
+      && (/删除|移除|remove|delete|×|x/.test(text) || rect.width === rect.height);
+  });
+  if (localMatch) return localMatch;
+
+  const globalCandidates = Array.from(document.querySelectorAll('button, [role="button"], span, div, svg')).map((node) => {
+    const host = node instanceof SVGElement ? node.parentElement : node;
+    return host;
+  }).filter((node) => node && isVisibleElement(node));
+
+  return globalCandidates.find((node) => {
+    const text = normalizeLowerText(node.getAttribute?.('aria-label') || node.textContent || node.title || '');
+    const rect = node.getBoundingClientRect();
+    const verticallyAligned = Math.abs((rect.top + rect.height / 2) - (itemRect.top + itemRect.height / 2)) <= Math.max(18, itemRect.height * 0.45);
+    return verticallyAligned
+      && rect.left >= itemRect.right - 60
+      && rect.left <= itemRect.right + 40
+      && rect.width > 0
+      && rect.height > 0
+      && rect.width <= 44
+      && rect.height <= 44
+      && (/删除|移除|remove|delete|×|x/.test(text) || rect.width === rect.height);
+  }) || null;
+}
+
+// 在编辑面板内寻找“移除地址”按钮。
+function findRemoveAddressButton(panel) {
+  const scope = panel || document;
+  const textNodes = Array.from(scope.querySelectorAll('button, [role="button"], a, span, div')).filter((node) => {
+    const text = normalizeLowerText(node.getAttribute?.('aria-label') || node.textContent || node.title || '');
+    return isVisibleElement(node) && /^(移除地址|remove address|删除地址|remove)$/.test(text);
+  });
+  if (textNodes.length) {
+    return textNodes.sort((left, right) => {
+      const leftRect = left.getBoundingClientRect();
+      const rightRect = right.getBoundingClientRect();
+      return (rightRect.width * rightRect.height) - (leftRect.width * leftRect.height);
+    })[0] || null;
+  }
+
+  const fuzzy = Array.from(scope.querySelectorAll('button, [role="button"], a, span, div')).filter((node) => {
+    const text = normalizeLowerText(node.getAttribute?.('aria-label') || node.textContent || node.title || '');
+    return isVisibleElement(node) && /移除地址|remove address|删除地址|remove/.test(text) && !/cancel|取消/.test(text);
+  });
+  return fuzzy.sort((left, right) => {
+    const leftRect = left.getBoundingClientRect();
+    const rightRect = right.getBoundingClientRect();
+    return (rightRect.width * rightRect.height) - (leftRect.width * leftRect.height);
+  })[0] || null;
+}
+
+// 找到节点中心点附近真正可点击的命中目标。
+function findClickableTargetAtCenter(node) {
+  if (!node || typeof node.getBoundingClientRect !== 'function') {
+    return null;
+  }
+  const rect = node.getBoundingClientRect();
+  const points = [
+    { x: Math.round(rect.left + rect.width / 2), y: Math.round(rect.top + rect.height / 2) },
+    { x: Math.round(rect.left + rect.width * 0.3), y: Math.round(rect.top + rect.height / 2) },
+    { x: Math.round(rect.left + rect.width * 0.7), y: Math.round(rect.top + rect.height / 2) },
+  ];
+
+  for (const point of points) {
+    const hit = document.elementFromPoint(point.x, point.y);
+    const clickable = hit?.closest?.('button, [role="button"], a, span, div') || hit;
+    if (clickable && isVisibleElement(clickable)) {
+      return { target: clickable, x: point.x, y: point.y };
+    }
+  }
+  return null;
+}
+
+// 选择某个一次性邮箱条目并打开其编辑面板。
+async function selectAliasItemForEditing(item, email = '') {
+  const normalizedEmail = normalizeLowerText(email).replace(/\s+/g, '');
+
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    await waitForAliasListStable(1800);
+    const freshItem = findAliasItemByEmail(email) || item;
+    freshItem.scrollIntoView?.({ block: 'center', inline: 'nearest' });
+    await sleep(320);
+
+    const directEmailNode = Array.from(freshItem.querySelectorAll('*')).find((node) => {
+      if (!(node instanceof HTMLElement) || !isVisibleElement(node)) return false;
+      return normalizeLowerText((node.innerText || node.textContent || '').replace(/\s+/g, '')) === normalizedEmail;
+    }) || (normalizeLowerText((freshItem.innerText || freshItem.textContent || '').replace(/\s+/g, '')) === normalizedEmail ? freshItem : null);
+
+    const targetNode = findTightAliasCard(directEmailNode || freshItem) || directEmailNode || freshItem;
+    const rect = targetNode.getBoundingClientRect();
+    const hoverX = Math.round(rect.left + Math.max(28, Math.min(90, rect.width * 0.18)));
+    const hoverY = Math.round(rect.top + rect.height / 2);
+    dispatchHoverSequence(targetNode, hoverX, hoverY);
+    log(`Yahoo：已悬停旧一次性邮箱 ${email || '(unknown)'} (attempt ${attempt + 1})`, 'info');
+    await sleep(550);
+
+    const clickPoints = [
+      [Math.round(rect.left + Math.max(36, Math.min(96, rect.width * 0.20))), Math.round(rect.top + rect.height / 2)],
+      [Math.round(rect.left + rect.width / 2), Math.round(rect.top + rect.height / 2)],
+      [Math.round(rect.left + Math.max(48, Math.min(140, rect.width * 0.28))), Math.round(rect.top + rect.height / 2)],
+    ];
+
+    for (const [clickX, clickY] of clickPoints) {
+      dispatchClickSequence(targetNode, clickX, clickY);
+      try { if (typeof targetNode.click === 'function') targetNode.click(); } catch {}
+      log(`Yahoo：已点击旧一次性邮箱卡片主体 ${email || '(unknown)'} point=${clickX},${clickY} (attempt ${attempt + 1})`, 'info');
+
+      let lastPanelEmail = '';
+      for (let i = 0; i < 10; i += 1) {
+        await sleep(220);
+        const panel = findAliasEditorPanel(email) || findAliasEditorPanel('');
+        if (!panel) continue;
+        const panelEmail = extractEditorPanelEmail(panel);
+        if (panelEmail && panelEmail !== lastPanelEmail) {
+          lastPanelEmail = panelEmail;
+          log(`Yahoo：已打开编辑面板，面板邮箱=${panelEmail}`, 'info');
+        }
+        if (!normalizedEmail || panelEmail.replace(/\s+/g, '') === normalizedEmail) {
+          return panel;
+        }
+      }
+    }
+  }
+
+  const snippets = Array.from(document.querySelectorAll('section, div, aside, article'))
+    .filter((node) => isVisibleElement(node))
+    .map((node) => normalizeText(node.innerText || node.textContent || ''))
+    .filter((text) => /编辑|edit|移除地址|remove address/.test(text))
+    .slice(0, 3)
+    .join(' || ');
+  log(`Yahoo：编辑面板候选片段=${snippets || '(none)'}`, 'warn');
+  return null;
+}
+
+// 按文本模式筛选可能的对话框候选项。
+function getDialogCandidates(pattern) {
+  return Array.from(document.querySelectorAll('[role="dialog"], dialog, [aria-modal="true"], div')).filter((node) => {
+    if (!isVisibleElement(node)) return false;
+    const text = normalizeLowerText(node.innerText || node.textContent || '');
+    if (!pattern.test(text)) return false;
+    const rect = node.getBoundingClientRect();
+    const style = getComputedStyle(node);
+    return rect.width >= 260
+      && rect.height >= 120
+      && rect.left >= 0
+      && rect.top >= 0
+      && rect.left + rect.width <= window.innerWidth + 20
+      && rect.top + rect.height <= window.innerHeight + 20
+      && (style.position === 'fixed' || style.position === 'absolute');
+  }).sort((left, right) => {
+    const leftRect = left.getBoundingClientRect();
+    const rightRect = right.getBoundingClientRect();
+    return (leftRect.width * leftRect.height) - (rightRect.width * rightRect.height);
+  });
+}
+
+// 直接按文本模式取第一个匹配到的对话框。
+function findDialogByText(pattern) {
+  return getDialogCandidates(pattern)[0] || null;
+}
+
+// 查找“达到极限”之类的提示弹窗。
+function findVisibleDialog() {
+  return findDialogByText(/你已经达到极限了|达到极限|limit|upgrade|升级/);
+}
+
+function getYahooClickableText(node) {
+  if (!node) return '';
+  return normalizeLowerText([
+    node.getAttribute?.('aria-label') || '',
+    node.getAttribute?.('title') || '',
+    node.getAttribute?.('data-test-id') || '',
+    node.getAttribute?.('data-test') || '',
+    node.getAttribute?.('id') || '',
+    node.textContent || '',
+  ].join(' '));
+}
+
+function isLikelyYahooDisposableAddText(text, options = {}) {
+  const normalized = normalizeLowerText(text);
+  const allowShort = Boolean(options.allowShort);
+  if (!normalized) return false;
+  if (allowShort && /^(添加|新增|新建|创建|add|new|create|\+)$/.test(normalized)) {
+    return true;
+  }
+  return /(添加|新增|新建|创建).{0,16}(一次性|临时|分身|电子邮件地址|电子邮箱|邮箱|地址)/.test(normalized)
+    || /(一次性|临时|分身|电子邮件地址|电子邮箱|邮箱|地址).{0,16}(添加|新增|新建|创建)/.test(normalized)
+    || /(add|new|create).{0,24}(disposable|alias|address|email)/.test(normalized)
+    || /(disposable|alias).{0,24}(add|new|create)/.test(normalized);
+}
+
+function isUsableYahooButtonCandidate(node) {
+  if (!(node instanceof HTMLElement) || !isVisibleElement(node)) return false;
+  if (node.disabled || node.getAttribute?.('aria-disabled') === 'true') return false;
+  const rect = node.getBoundingClientRect();
+  return rect.width >= 24 && rect.height >= 20 && rect.width <= 380 && rect.height <= 100;
+}
+
+function collectYahooVisibleButtonLabels(root = document, limit = 12) {
+  return Array.from(root.querySelectorAll('button, [role="button"], a, span, div'))
+    .filter((node) => isUsableYahooButtonCandidate(node))
+    .map((node) => getYahooClickableText(node))
+    .filter(Boolean)
+    .filter((text, index, arr) => arr.indexOf(text) === index)
+    .slice(0, limit);
+}
+
+function getYahooDialogText(dialog) {
+  return normalizeText(dialog?.innerText || dialog?.textContent || '').slice(0, 220);
+}
+
+function buildYahooAliasCreateDiagnostics() {
+  let aliases = [];
+  try {
+    aliases = collectAliasItems().map(extractAliasEmailFromItem).filter(Boolean);
+  } catch {}
+
+  const section = findDisposableAliasSection();
+  const limitDialog = findVisibleDialog();
+  const buttonLabels = collectYahooVisibleButtonLabels(section || document, 10);
+  const pageText = normalizeText(document.body?.innerText || document.body?.textContent || '').slice(0, 280);
+  const limitHint = limitDialog
+    ? `检测到 Yahoo 限制弹窗：“${getYahooDialogText(limitDialog)}”。`
+    : '';
+  const aliasHint = aliases.length >= 3
+    ? `当前页面已识别 ${aliases.length} 个旧别名；已按当前配置不自动清理旧别名。`
+    : `当前页面已识别 ${aliases.length} 个旧别名。`;
+  return [
+    `url=${location.href}`,
+    `section=${section ? 'yes' : 'no'}`,
+    aliasHint,
+    limitHint,
+    `可见按钮=${buttonLabels.join(' / ') || '(none)'}`,
+    `页面片段=${pageText || '(empty)'}`,
+  ].filter(Boolean).join('；');
+}
+
+// 查找一次性邮箱删除确认弹窗。
+function findDeleteConfirmDialog() {
+  const candidates = getDialogCandidates(/删除.*@yahoo\.com|这将从您的一次性电子邮件地址列表中删除|remove.*@yahoo\.com|delete.*@yahoo\.com/);
+  return candidates.find((node) => {
+    const text = normalizeLowerText(node.innerText || node.textContent || '');
+    return /取消|cancel/.test(text) && /删除|remove|delete/.test(text);
+  }) || candidates[0] || null;
+}
+
+// 如果出现“达到极限”提示弹窗就尝试关闭。
+async function closeLimitDialogIfPresent() {
+  const dialog = findVisibleDialog();
+  if (!dialog) {
+    return false;
+  }
+
+  log('Yahoo：检测到“达到极限”弹窗，正在尝试关闭...', 'warn');
+
+  const closeButton = Array.from(dialog.querySelectorAll('button, [role="button"], span, div')).find((node) => {
+    const text = normalizeLowerText(node.getAttribute?.('aria-label') || node.textContent || node.title || '');
+    return isVisibleElement(node) && (/close|关闭|×|x/.test(text));
+  });
+
+  if (closeButton) {
+    simulateClick(closeButton);
+    await sleep(800);
+    return true;
+  }
+
+  const clickableNodes = Array.from(dialog.querySelectorAll('button, [role="button"], span, div, svg')).filter((node) => {
+    const host = node instanceof SVGElement ? node.parentElement : node;
+    if (!host || !isVisibleElement(host)) return false;
+    const rect = host.getBoundingClientRect();
+    const dialogRect = dialog.getBoundingClientRect();
+    return rect.width > 0
+      && rect.height > 0
+      && rect.width <= 40
+      && rect.height <= 40
+      && rect.top <= dialogRect.top + 60
+      && rect.left >= dialogRect.left + dialogRect.width * 0.7;
+  });
+
+  const fallbackClose = clickableNodes[0] instanceof SVGElement ? clickableNodes[0].parentElement : clickableNodes[0];
+  if (fallbackClose) {
+    simulateClick(fallbackClose);
+    await sleep(800);
+    return true;
+  }
+
+  return false;
+}
+
+// 在删除确认弹窗中定位确认删除按钮。
+function findDeleteConfirmButton(dialog) {
+  if (!dialog) return null;
+
+  const exactCandidates = Array.from(dialog.querySelectorAll('button, [role="button"], span, div')).filter((node) => {
+    const text = normalizeLowerText(node.getAttribute?.('aria-label') || node.textContent || node.title || '');
+    return isVisibleElement(node) && /^(删除|delete|remove)$/.test(text);
+  });
+  if (exactCandidates.length) {
+    return exactCandidates.sort((left, right) => {
+      const leftRect = left.getBoundingClientRect();
+      const rightRect = right.getBoundingClientRect();
+      return (rightRect.width * rightRect.height) - (leftRect.width * leftRect.height);
+    })[0] || null;
+  }
+
+  const buttonCandidates = Array.from(dialog.querySelectorAll('button, [role="button"]')).filter((node) => {
+    if (!isVisibleElement(node)) return false;
+    const text = normalizeLowerText(node.getAttribute?.('aria-label') || node.textContent || node.title || '');
+    if (/取消|cancel|关闭|close/.test(text)) return false;
+    const rect = node.getBoundingClientRect();
+    const dialogRect = dialog.getBoundingClientRect();
+    return rect.width >= 60
+      && rect.height >= 32
+      && rect.top >= dialogRect.top + dialogRect.height * 0.45
+      && rect.left >= dialogRect.left + dialogRect.width * 0.45;
+  });
+  if (buttonCandidates.length) {
+    return buttonCandidates.sort((left, right) => {
+      const leftRect = left.getBoundingClientRect();
+      const rightRect = right.getBoundingClientRect();
+      if (Math.abs(rightRect.top - leftRect.top) > 8) return rightRect.top - leftRect.top;
+      return rightRect.left - leftRect.left;
+    })[0] || null;
+  }
+
+  const genericCandidates = Array.from(dialog.querySelectorAll('span, div')).filter((node) => {
+    if (!isVisibleElement(node)) return false;
+    const text = normalizeLowerText(node.getAttribute?.('aria-label') || node.textContent || node.title || '');
+    if (/取消|cancel|关闭|close/.test(text)) return false;
+    const rect = node.getBoundingClientRect();
+    const dialogRect = dialog.getBoundingClientRect();
+    return rect.width >= 60
+      && rect.height >= 24
+      && rect.top >= dialogRect.top + dialogRect.height * 0.45
+      && rect.left >= dialogRect.left + dialogRect.width * 0.45
+      && /删除|delete|remove/.test(text);
+  });
+  return genericCandidates.sort((left, right) => {
+    const leftRect = left.getBoundingClientRect();
+    const rightRect = right.getBoundingClientRect();
+    if (Math.abs(rightRect.top - leftRect.top) > 8) return rightRect.top - leftRect.top;
+    return rightRect.left - leftRect.left;
+  })[0] || null;
+}
+
+// 如果删除确认弹窗出现，就点击确认按钮完成删除。
+async function confirmDeleteDialogIfPresent(email = '') {
+  const normalizedEmail = normalizeLowerText(email);
+  let dialog = null;
+  for (let i = 0; i < 20 && !dialog; i += 1) {
+    const candidate = findDeleteConfirmDialog();
+    const dialogEmail = extractEditorPanelEmail(candidate || null);
+    if (candidate && (!normalizedEmail || !dialogEmail || dialogEmail === normalizedEmail)) {
+      dialog = candidate;
+      break;
+    }
+    await sleep(200);
+  }
+
+  if (!dialog) {
+    log(`Yahoo：未检测到 ${email || '(unknown)'} 的删除确认弹窗`, 'warn');
+    return false;
+  }
+
+  const dialogEmail = extractEditorPanelEmail(dialog || null);
+  log(`Yahoo：已检测到 ${email || '(unknown)'} 的删除确认弹窗 dialogEmail=${dialogEmail || '(unknown)'}`, 'info');
+
+  const confirmButton = findDeleteConfirmButton(dialog);
+  if (!confirmButton) {
+    log(`Yahoo：未找到 ${email || '(unknown)'} 删除确认按钮`, 'warn');
+    return false;
+  }
+
+  const rect = confirmButton.getBoundingClientRect();
+  const x = Math.round(rect.left + rect.width / 2);
+  const y = Math.round(rect.top + rect.height / 2);
+  dispatchHoverSequence(confirmButton, x, y);
+  await sleep(120);
+  dispatchClickSequence(confirmButton, x, y);
+  try {
+    if (typeof confirmButton.click === 'function') confirmButton.click();
+  } catch {}
+  log(`Yahoo：已确认删除 ${email || '(unknown)'} target=${confirmButton.tagName || 'unknown'} rect=${Math.round(rect.width)}x${Math.round(rect.height)}`, 'info');
+  await sleep(2200);
+  return true;
+}
+
+// 删除单个一次性邮箱条目，优先走行内删除，失败再走编辑面板。
+async function clickDeleteForAliasItem(item) {
+  const email = extractAliasEmailFromItem(item);
+  log(`Yahoo：准备删除旧一次性邮箱 ${email || '(unknown)'}`, 'info');
+
+  const freshItem = findAliasItemByEmail(email) || item;
+  freshItem.scrollIntoView?.({ block: 'center', inline: 'nearest' });
+  await sleep(260);
+
+  const hoverTarget = findTightAliasCard(freshItem) || freshItem;
+  const hoverRect = hoverTarget.getBoundingClientRect();
+  const hoverX = Math.round(hoverRect.left + Math.max(32, Math.min(88, hoverRect.width * 0.18)));
+  const hoverY = Math.round(hoverRect.top + hoverRect.height / 2);
+  dispatchHoverSequence(hoverTarget, hoverX, hoverY);
+  await sleep(520);
+
+  let inlineDelete = findHoveredAliasDeleteButton(hoverTarget) || findHoveredAliasDeleteButton(freshItem);
+  if (inlineDelete) {
+    const deleteRect = inlineDelete.getBoundingClientRect();
+    const deleteX = Math.round(deleteRect.left + deleteRect.width / 2);
+    const deleteY = Math.round(deleteRect.top + deleteRect.height / 2);
+    const deleteText = normalizeLowerText(inlineDelete.getAttribute?.('aria-label') || inlineDelete.textContent || inlineDelete.title || '') || '(empty)';
+    log(`Yahoo：已命中行内删除按钮 text=${deleteText} target=${inlineDelete.tagName || 'unknown'} rect=${Math.round(deleteRect.width)}x${Math.round(deleteRect.height)}`, 'info');
+    dispatchHoverSequence(inlineDelete, deleteX, deleteY);
+    await sleep(120);
+    dispatchClickSequence(inlineDelete, deleteX, deleteY);
+    try { if (typeof inlineDelete.click === 'function') inlineDelete.click(); } catch {}
+    await sleep(900);
+
+    const confirmedInline = await confirmDeleteDialogIfPresent(email);
+    if (confirmedInline) {
+      await closeLimitDialogIfPresent();
+      return true;
+    }
+    log(`Yahoo：行内删除按钮点击后未出现 ${email || '(unknown)'} 的确认弹窗，回退编辑面板方案`, 'warn');
+  }
+
+  const editorPanel = await selectAliasItemForEditing(freshItem, email);
+  if (!editorPanel) {
+    log(`Yahoo：未能打开 ${email || '(unknown)'} 的编辑面板`, 'warn');
+    return false;
+  }
+  log(`Yahoo：已打开 ${email || '(unknown)'} 的编辑面板`, 'info');
+
+  const removeButton = findRemoveAddressButton(editorPanel);
+  if (!removeButton) {
+    log(`Yahoo：未找到 ${email || '(unknown)'} 的“移除地址”按钮`, 'warn');
+    return false;
+  }
+
+  removeButton.scrollIntoView?.({ block: 'center', inline: 'nearest' });
+  await sleep(300);
+
+  const removeTarget = removeButton.closest?.('button, [role="button"], a, div') || removeButton;
+  const hit = findClickableTargetAtCenter(removeTarget) || findClickableTargetAtCenter(removeButton);
+  const rect = (hit?.target || removeTarget).getBoundingClientRect();
+  const x = hit?.x ?? Math.round(rect.left + rect.width / 2);
+  const y = hit?.y ?? Math.round(rect.top + rect.height / 2);
+  const clickTarget = hit?.target || removeTarget;
+  const labelText = normalizeLowerText(removeButton.getAttribute?.('aria-label') || removeButton.textContent || removeButton.title || '') || '(empty)';
+  log(`Yahoo：已命中“移除地址”按钮 text=${labelText} target=${clickTarget.tagName || 'unknown'} rect=${Math.round(rect.width)}x${Math.round(rect.height)}`, 'info');
+
+  dispatchHoverSequence(clickTarget, x, y);
+  await sleep(180);
+  dispatchClickSequence(clickTarget, x, y);
+  try {
+    if (typeof clickTarget.click === 'function') clickTarget.click();
+    else if (typeof removeTarget.click === 'function') removeTarget.click();
+  } catch {}
+
+  await sleep(1000);
+
+  const confirmed = await confirmDeleteDialogIfPresent(email);
+  if (!confirmed) {
+    log(`Yahoo：点击“移除地址”后未出现 ${email || '(unknown)'} 的确认弹窗`, 'warn');
+    return false;
+  }
+  await closeLimitDialogIfPresent();
+  return true;
+}
+
+// 逐个删除旧的一次性邮箱，直到不再需要清理为止。
+async function deleteAllOldAliases() {
+  const deleted = [];
+  for (let round = 0; round < 10; round += 1) {
+    throwIfStopped();
+    await waitForAliasListStable(2200);
+    const aliases = collectAliasItems();
+    log(`Yahoo：当前检测到 ${aliases.length} 个旧一次性邮箱`, 'info');
+    if (!aliases.length) {
+      break;
+    }
+
+    if (aliases.length < 3) {
+      log(`Yahoo：当前仅剩 ${aliases.length} 个旧一次性邮箱，未达到上限，跳过后续删除并直接进入创建`, 'warn');
+      break;
+    }
+
+    const item = aliases[0];
+    const email = extractAliasEmailFromItem(item);
+    const freshItem = findAliasItemByEmail(email) || item;
+    const beforeCount = aliases.length;
+    const ok = await clickDeleteForAliasItem(freshItem);
+    if (!ok) {
+      log(`Yahoo：未能命中 ${email || '(unknown)'} 的删除按钮`, 'warn');
+      break;
+    }
+
+    let removed = false;
+    for (let waitRound = 0; waitRound < 15; waitRound += 1) {
+      await sleep(500);
+      const currentAliases = collectAliasItems().map(extractAliasEmailFromItem).filter(Boolean);
+      if (!currentAliases.includes(email) || currentAliases.length < beforeCount) {
+        removed = true;
+        log(`Yahoo：旧一次性邮箱已删除 ${email || '(unknown)'}`, 'ok');
+        break;
+      }
+    }
+
+    if (removed && email) {
+      deleted.push(email);
+    } else {
+      log(`Yahoo：等待删除 ${email || '(unknown)'} 生效超时`, 'warn');
+      break;
+    }
+  }
+  return deleted;
+}
+
+// 生成一个默认的一次性邮箱前缀。
+function generateAliasPrefix(length = 10) {
+  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  let output = '';
+  for (let i = 0; i < length; i += 1) {
+    output += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return output;
+}
+
+// 在指定范围内按文本匹配查找可见按钮。
+function findYahooButtonByText(patterns = [], root = document) {
+  return Array.from(root.querySelectorAll('button, [role="button"], a, span')).find((node) => {
+    const text = normalizeLowerText(node.getAttribute?.('aria-label') || node.textContent || node.title || '');
+    return patterns.some((pattern) => pattern.test(text)) && isVisibleElement(node);
+  }) || null;
+}
+
+// 查找 Yahoo 创建一次性邮箱的右侧面板。
+function findYahooCreatePanel() {
+  const panels = Array.from(document.querySelectorAll('section, div, aside, article, [role="dialog"], dialog')).filter((node) => {
+    if (!isVisibleElement(node)) return false;
+    const text = normalizeLowerText(node.innerText || node.textContent || '');
+    const rect = node.getBoundingClientRect();
+    if (rect.width < 260 || rect.height < 180) return false;
+    if (rect.left < window.innerWidth * 0.45) return false;
+    if (!/添加一次性电子邮件地址|add disposable address|add disposable email address|创建一次性电子邮件地址|create disposable|name your address|choose.*address|keyword|关键词/.test(text)) {
+      return false;
+    }
+    if (!/关键词|keyword|姓名|描述|save|保存|节省|cancel|取消|description|name|address/.test(text)) {
+      return false;
+    }
+    return true;
+  });
+  return panels.sort((left, right) => {
+    const leftRect = left.getBoundingClientRect();
+    const rightRect = right.getBoundingClientRect();
+    if (Math.abs(rightRect.left - leftRect.left) > 20) return rightRect.left - leftRect.left;
+    return (rightRect.width * rightRect.height) - (leftRect.width * leftRect.height);
+  })[0] || null;
+}
+
+// 查找创建面板里的一次性邮箱输入框。
+function findYahooAliasInput() {
+  const panel = findYahooCreatePanel();
+  const scopes = [panel, document].filter(Boolean);
+
+  for (const scope of scopes) {
+    const inputs = Array.from(scope.querySelectorAll('input, textarea, [contenteditable="true"], [role="textbox"]'));
+
+    const semanticMatch = inputs.find((node) => {
+      const host = node instanceof HTMLElement ? node : null;
+      if (!host || !isVisibleElement(host)) return false;
+      if (host instanceof HTMLInputElement || host instanceof HTMLTextAreaElement) {
+        if (host.disabled || host.readOnly) return false;
+      }
+      const text = normalizeLowerText([
+        host.getAttribute?.('placeholder') || '',
+        host.getAttribute?.('aria-label') || '',
+        host.getAttribute?.('name') || '',
+        host.getAttribute?.('id') || '',
+        host.getAttribute?.('data-test-id') || '',
+        host.getAttribute?.('data-test') || '',
+        host.labels?.[0]?.textContent || '',
+        host.parentElement?.innerText || '',
+        host.closest('div,section,form,[role="dialog"]')?.innerText || '',
+      ].join(' '));
+      return /关键词|keyword|alias|address|name your address|create your address|choose.*address/.test(text);
+    });
+    if (semanticMatch) return semanticMatch;
+
+    const sizedMatch = inputs.find((node) => {
+      const host = node instanceof HTMLElement ? node : null;
+      if (!host || !isVisibleElement(host)) return false;
+      if (host instanceof HTMLInputElement || host instanceof HTMLTextAreaElement) {
+        if (host.disabled || host.readOnly) return false;
+      }
+      const rect = host.getBoundingClientRect();
+      const type = normalizeLowerText(host.getAttribute?.('type') || '');
+      if (/hidden|checkbox|radio|submit|button/.test(type)) return false;
+      return rect.width >= 120 && rect.height >= 24;
+    });
+    if (sizedMatch) return sizedMatch;
+  }
+
+  return null;
+}
+
+// 查找一次性邮箱设置区域的标题节点。
+function findYahooDisposableSectionHeading() {
+  const candidates = Array.from(document.querySelectorAll('h1, h2, h3, h4, div, span')).filter((node) => {
+    if (!(node instanceof HTMLElement)) return false;
+    const text = normalizeLowerText(node.innerText || node.textContent || '');
+    return /一次性电子邮件地址|disposable email addresses|disposable email address|disposable address/.test(text)
+      && !/@yahoo\.com/.test(text);
+  });
+  return candidates.sort((left, right) => {
+    const leftRect = left.getBoundingClientRect();
+    const rightRect = right.getBoundingClientRect();
+    return leftRect.top - rightRect.top;
+  })[0] || null;
+}
+
+// 查找新增一次性邮箱的“添加”按钮。
+function findYahooDisposableAddButton() {
+  const buttonSelectors = 'button, [role="button"], a, span, div';
+  const section = findDisposableAliasSection();
+
+  if (section) {
+    const sectionRect = section.getBoundingClientRect();
+    const scoped = Array.from(section.querySelectorAll(buttonSelectors)).filter((node) => {
+      if (!isUsableYahooButtonCandidate(node)) return false;
+      const text = getYahooClickableText(node);
+      if (!isLikelyYahooDisposableAddText(text, { allowShort: true })) return false;
+      const rect = node.getBoundingClientRect();
+      return rect.width >= 40
+        && rect.height >= 24
+        && rect.top >= sectionRect.top - 6
+        && rect.top <= sectionRect.top + 90
+        && rect.left >= sectionRect.left + sectionRect.width * 0.72;
+    });
+    if (scoped.length) {
+      return scoped.sort((left, right) => {
+        const leftRect = left.getBoundingClientRect();
+        const rightRect = right.getBoundingClientRect();
+        return Math.abs(leftRect.top - sectionRect.top) - Math.abs(rightRect.top - sectionRect.top)
+          || (rightRect.left - leftRect.left);
+      })[0];
+    }
+  }
+
+  const heading = findYahooDisposableSectionHeading();
+  if (heading) {
+    const headingRect = heading.getBoundingClientRect();
+    const nearHeading = Array.from(document.querySelectorAll(buttonSelectors)).filter((node) => {
+      if (!isUsableYahooButtonCandidate(node)) return false;
+      const text = getYahooClickableText(node);
+      if (!isLikelyYahooDisposableAddText(text, { allowShort: true })) return false;
+      const rect = node.getBoundingClientRect();
+      return rect.width >= 40
+        && rect.height >= 24
+        && Math.abs((rect.top + rect.height / 2) - (headingRect.top + headingRect.height / 2)) <= 28
+        && rect.left >= headingRect.left + Math.max(240, headingRect.width * 0.8);
+    });
+    if (nearHeading.length) {
+      return nearHeading.sort((left, right) => {
+        const leftRect = left.getBoundingClientRect();
+        const rightRect = right.getBoundingClientRect();
+        return Math.abs(leftRect.top - headingRect.top) - Math.abs(rightRect.top - headingRect.top)
+          || (rightRect.left - leftRect.left);
+      })[0];
+    }
+  }
+
+  const globalCandidates = Array.from(document.querySelectorAll(buttonSelectors)).filter((node) => {
+    if (!isUsableYahooButtonCandidate(node)) return false;
+    const text = getYahooClickableText(node);
+    return isLikelyYahooDisposableAddText(text);
+  });
+  return globalCandidates.sort((left, right) => {
+    const leftRect = left.getBoundingClientRect();
+    const rightRect = right.getBoundingClientRect();
+    return rightRect.top - leftRect.top || rightRect.left - leftRect.left;
+  })[0] || findYahooButtonByText([
+    /new\s+disposable\s+address/i,
+    /新建一次性电子邮件地址/i,
+    /新建一次性电子邮箱/i,
+    /新增一次性电子邮件地址/i,
+    /添加一次性电子邮件地址/i,
+    /一次性电子邮箱/i,
+    /一次性电子邮件地址/i,
+    /create/i,
+    /new/i,
+    /添加/i,
+    /创建/i,
+  ]);
+}
+
+function getDisposableAliasUsageCount() {
+  const section = findDisposableAliasSection();
+  const text = normalizeLowerText([
+    section?.innerText || section?.textContent || '',
+    document.body?.innerText || document.body?.textContent || '',
+  ].join(' '));
+  const match = text.match(/disposable email addresses[^0-9]{0,40}(\d+)\s+of\s+(\d+)/i)
+    || text.match(/一次性电子邮件地址[^0-9]{0,40}(\d+)\s*(?:of|\/)\s*(\d+)/i);
+  if (!match) return null;
+  return {
+    used: Number(match[1]),
+    limit: Number(match[2]),
+  };
+}
+
+function inferYahooAliasFromExistingAliases(prefix = '', aliases = []) {
+  const normalizedPrefix = normalizeLowerText(prefix).replace(/[^a-z0-9._%+-]/g, '');
+  if (!normalizedPrefix) return '';
+  const sample = (aliases || []).find((email) => /@yahoo\.com$/i.test(email) && email.includes('-'));
+  if (!sample) return '';
+  const local = sample.split('@')[0] || '';
+  const base = local.slice(0, local.lastIndexOf('-'));
+  return base ? `${base}-${normalizedPrefix}@yahoo.com` : '';
+}
+
+// 创建 Yahoo 临时邮箱，并返回新生成的地址。
+async function handleCreateYahooTempAlias(payload) {
+  log('Yahoo：已进入创建临时邮箱流程', 'info');
+  await ensureOnYahooSettings();
+  await waitForAnySelector(['main', 'form', 'button'], 15000);
+  ensureYahooLoggedIn('创建 Yahoo 临时邮箱');
+
+  await closeLimitDialogIfPresent();
+  log('Yahoo：跳过旧一次性邮箱清理，直接创建新邮箱', 'info');
+  await focusDisposableAliasSection();
+
+  const remainingAliases = collectAliasItems().map(extractAliasEmailFromItem).filter(Boolean);
+  const beforeUsage = getDisposableAliasUsageCount();
+  if (remainingAliases.length > 0) {
+    log(`Yahoo：当前已有 ${remainingAliases.length} 个一次性邮箱，将保留现有邮箱并继续直接创建新邮箱`, 'info');
+  }
+
+  const prefix = normalizeLowerText(payload.prefix || '') || generateAliasPrefix(10);
+  log(`Yahoo：准备创建新一次性邮箱，关键词=${prefix}`, 'info');
+
+  const addButton = findYahooDisposableAddButton();
+  if (!addButton) {
+    throw new Error(`创建 Yahoo 临时邮箱失败：未找到“新建一次性电子邮箱/地址”按钮，请确认 Yahoo 设置页已加载到一次性邮箱区域；${buildYahooAliasCreateDiagnostics()}`);
+  }
+
+  const addRect = addButton.getBoundingClientRect();
+  const addX = Math.round(addRect.left + addRect.width / 2);
+  const addY = Math.round(addRect.top + addRect.height / 2);
+  log(`Yahoo：已定位“添加”按钮 tag=${addButton.tagName || 'unknown'} rect=${Math.round(addRect.width)}x${Math.round(addRect.height)} pos=${addX},${addY}`, 'info');
+
+  let createPanel = null;
+  const clickTargets = [
+    addButton.closest?.('button, [role="button"], a, div') || addButton,
+    document.elementFromPoint(addX, addY)?.closest?.('button, [role="button"], a, div') || addButton,
+  ].filter(Boolean);
+
+  for (const target of clickTargets) {
+    dispatchHoverSequence(target, addX, addY);
+    await sleep(120);
+    dispatchClickSequence(target, addX, addY);
+    try { if (typeof target.click === 'function') target.click(); } catch {}
+    log(`Yahoo：已点击“添加”按钮 target=${target.tagName || 'unknown'}`, 'info');
+
+    for (let i = 0; i < 8 && !createPanel; i += 1) {
+      await sleep(250);
+      createPanel = findYahooCreatePanel();
+    }
+    if (createPanel) break;
+  }
+
+  if (!createPanel) {
+    const section = findDisposableAliasSection();
+    if (section) {
+      const sectionRect = section.getBoundingClientRect();
+      const fallbackX = Math.round(sectionRect.right - 32);
+      const fallbackY = Math.round(sectionRect.top + 34);
+      const fallbackTarget = document.elementFromPoint(fallbackX, fallbackY)?.closest?.('button, [role="button"], a, div');
+      if (fallbackTarget) {
+        dispatchHoverSequence(fallbackTarget, fallbackX, fallbackY);
+        await sleep(120);
+        dispatchClickSequence(fallbackTarget, fallbackX, fallbackY);
+        try { if (typeof fallbackTarget.click === 'function') fallbackTarget.click(); } catch {}
+        log(`Yahoo：已执行“添加”按钮兜底点击 target=${fallbackTarget.tagName || 'unknown'} pos=${fallbackX},${fallbackY}`, 'warn');
+        for (let i = 0; i < 8 && !createPanel; i += 1) {
+          await sleep(250);
+          createPanel = findYahooCreatePanel();
+        }
+      }
+    }
+  }
+  if (!createPanel) {
+    throw new Error('创建 Yahoo 临时邮箱失败：点击“添加”后未出现创建面板。');
+  }
+  log('Yahoo：已识别到右侧创建面板', 'info');
+
+  let input = findYahooAliasInput();
+  if (!input) {
+    for (let i = 0; i < 20 && !input; i += 1) {
+      await sleep(300);
+      input = findYahooAliasInput();
+    }
+  }
+  if (!input) {
+    const panelText = normalizeText((findYahooCreatePanel()?.innerText || findYahooCreatePanel()?.textContent || '')).slice(0, 500);
+    throw new Error(`创建 Yahoo 临时邮箱失败：未找到一次性邮箱输入框。创建面板片段：${panelText || '(empty)'}`);
+  }
+  fillInput(input, prefix);
+  try { input.focus?.(); } catch {}
+  if (input instanceof HTMLElement && input.getAttribute('contenteditable') === 'true') {
+    input.textContent = prefix;
+    input.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: prefix }));
+  }
+  log(`Yahoo：已填写关键词输入框 tag=${input.tagName || 'unknown'}`, 'info');
+  await sleep(500);
+
+  const saveButton = findYahooButtonByText([
+    /save/i,
+    /done/i,
+    /create/i,
+    /add/i,
+    /完成/i,
+    /保存/i,
+    /节省/i,
+    /创建/i,
+    /添加/i,
+  ], findYahooCreatePanel() || document);
+  if (!saveButton) {
+    throw new Error('创建 Yahoo 临时邮箱失败：未找到保存/创建按钮。');
+  }
+
+  simulateClick(saveButton);
+  log('Yahoo：已点击”节省/保存”按钮', 'info');
+  await sleep(1500);
+
+  // 等待创建面板消失
+  for (let i = 0; i < 20; i += 1) {
+    const panel = findYahooCreatePanel();
+    if (!panel) {
+      log('Yahoo：创建面板已关闭', 'info');
+      break;
+    }
+    await sleep(300);
+  }
+
+  await sleep(1000);
+  const limitDialogAfterSave = findVisibleDialog();
+  if (limitDialogAfterSave) {
+    const limitText = getYahooDialogText(limitDialogAfterSave);
+    await closeLimitDialogIfPresent();
+    throw new Error(`创建 Yahoo 临时邮箱失败：Yahoo 页面提示已达到一次性邮箱/别名上限；当前已按要求不自动清理旧别名，所以无法继续创建新别名。弹窗内容=${limitText || '(empty)'}`);
+  }
+
+  let afterUsage = null;
+  for (let attempt = 1; attempt <= 10; attempt += 1) {
+    afterUsage = getDisposableAliasUsageCount();
+    if (beforeUsage?.used >= 0 && afterUsage?.used > beforeUsage.used) {
+      break;
+    }
+    if (attempt < 10) {
+      log(`Yahoo：等待一次性邮箱数量增加（${attempt}/10）...`, 'info');
+      await sleep(600);
+    }
+  }
+
+  if (!(beforeUsage?.used >= 0 && afterUsage?.used > beforeUsage.used)) {
+    const beforeText = beforeUsage ? `${beforeUsage.used}/${beforeUsage.limit}` : 'unknown';
+    const afterText = afterUsage ? `${afterUsage.used}/${afterUsage.limit}` : 'unknown';
+    throw new Error(`创建 Yahoo 临时邮箱失败：保存后一次性邮箱数量未增加（before=${beforeText}, after=${afterText}）。`);
+  }
+
+  const createdAlias = inferYahooAliasFromExistingAliases(prefix, remainingAliases);
+  if (!createdAlias) {
+    throw new Error(`创建 Yahoo 临时邮箱失败：一次性邮箱数量已从 ${beforeUsage.used} 增至 ${afterUsage.used}，但无法从现有别名推断完整邮箱地址。`);
+  }
+
+  log(`Yahoo：一次性邮箱数量已从 ${beforeUsage.used} 增至 ${afterUsage.used}，按现有别名格式推断新别名 ${createdAlias}`, 'info');
+  return {
+    ok: true,
+    email: createdAlias,
+    deletedAliases: [],
+  };
+}

--- a/content/yahoo-mail.js
+++ b/content/yahoo-mail.js
@@ -1651,6 +1651,10 @@ async function waitForAliasListStable(timeoutMs = 2500) {
   return collectAliasItems().map((node) => extractAliasEmailFromItem(node)).filter(Boolean);
 }
 
+function getAliasTextCandidateNodes(scope) {
+  return Array.from(scope.querySelectorAll('a, span, div, li, p, button, [role="button"], [title], [aria-label]'));
+}
+
 // 收集当前页面可见的一次性邮箱条目。
 function collectAliasItems() {
   const section = findDisposableAliasSection();
@@ -1661,7 +1665,7 @@ function collectAliasItems() {
   const unique = [];
   const seen = new Set();
 
-  const emailNodes = Array.from(scope.querySelectorAll('*')).filter((node) => {
+  const emailNodes = getAliasTextCandidateNodes(scope).filter((node) => {
     if (!(node instanceof HTMLElement) || !isVisibleElement(node)) return false;
     const text = normalizeLowerText((node.innerText || node.textContent || '').replace(/\s+/g, ''));
     if (!/^[a-z0-9._%+-]+@yahoo\.com$/.test(text)) return false;
@@ -1715,7 +1719,7 @@ function findAliasItemByEmail(email = '') {
   const section = findDisposableAliasSection();
   const scope = section || document;
 
-  const exactNode = Array.from(scope.querySelectorAll('*')).find((node) => {
+  const exactNode = getAliasTextCandidateNodes(scope).find((node) => {
     if (!(node instanceof HTMLElement) || !isVisibleElement(node)) return false;
     return normalizeLowerText((node.innerText || node.textContent || '').replace(/\s+/g, '')) === normalizedEmail;
   });

--- a/flows/openai/mail-rules.js
+++ b/flows/openai/mail-rules.js
@@ -53,6 +53,10 @@
       return String(state?.mailProvider || '').trim().toLowerCase() === '2925';
     }
 
+    function isYahooProvider(state = {}) {
+      return String(state?.mailProvider || '').trim().toLowerCase() === 'yahoo';
+    }
+
     function shouldMatchMail2925TargetEmail(state = {}) {
       return isMail2925Provider(state)
         && String(state?.mail2925Mode || '').trim().toLowerCase() === 'receive';
@@ -78,10 +82,13 @@
       const nodeId = resolveVerificationNodeId(input);
       const normalizedStep = getVisibleStepForNode(nodeId, state);
       const mail2925Provider = isMail2925Provider(state);
+      const yahooProvider = isYahooProvider(state);
       const signupStep = nodeId === SIGNUP_CODE_NODE_ID;
       const targetEmail = signupStep
         ? state?.email
         : (String(state?.step8VerificationTargetEmail || '').trim() || state?.email);
+      const defaultMaxAttempts = yahooProvider ? 60 : 5;
+      const defaultIntervalMs = yahooProvider ? 5000 : 3000;
 
       return {
         flowId: 'openai',
@@ -105,8 +112,9 @@
         targetEmail,
         targetEmailHints: buildTargetEmailHints(targetEmail),
         mail2925MatchTargetEmail: shouldMatchMail2925TargetEmail(state),
-        maxAttempts: mail2925Provider ? MAIL_2925_VERIFICATION_MAX_ATTEMPTS : 5,
-        intervalMs: mail2925Provider ? MAIL_2925_VERIFICATION_INTERVAL_MS : 3000,
+        maxAttempts: mail2925Provider ? MAIL_2925_VERIFICATION_MAX_ATTEMPTS : defaultMaxAttempts,
+        intervalMs: mail2925Provider ? MAIL_2925_VERIFICATION_INTERVAL_MS : defaultIntervalMs,
+        ...(yahooProvider ? { keepRefreshingUntilCode: true } : {}),
       };
     }
 

--- a/mail-provider-utils.js
+++ b/mail-provider-utils.js
@@ -11,6 +11,7 @@
 })(typeof self !== 'undefined' ? self : globalThis, function createMailProviderUtils() {
   const HOTMAIL_PROVIDER = 'hotmail-api';
   const GMAIL_PROVIDER = 'gmail';
+  const YAHOO_PROVIDER = 'yahoo';
   const YYDS_MAIL_PROVIDER = 'yyds-mail';
   const NETEASE_LIST_PATH = '/js6/main.jsp?df=mail163_letter#module=mbox.ListModule%7C%7B%22fid%22%3A1%2C%22order%22%3A%22date%22%2C%22desc%22%3Atrue%7D';
   const ICLOUD_TARGET_MAILBOX_TYPE_INBOX = 'icloud-inbox';
@@ -27,6 +28,7 @@
     const normalized = String(value || '').trim().toLowerCase();
     switch (normalized) {
       case HOTMAIL_PROVIDER:
+      case YAHOO_PROVIDER:
       case YYDS_MAIL_PROVIDER:
       case '163':
       case '163-vip':
@@ -78,6 +80,17 @@
     if (provider === HOTMAIL_PROVIDER) {
       return { provider: HOTMAIL_PROVIDER, label: 'Hotmail（微软 Graph）' };
     }
+    if (provider === YAHOO_PROVIDER) {
+      return {
+        provider: YAHOO_PROVIDER,
+        source: 'yahoo-mail',
+        url: 'https://mail.yahoo.com/n/inbox/all?listFilter=ALL_INBOX',
+        label: 'Yahoo 邮箱',
+        navigateOnReuse: true,
+        inject: ['content/activation-utils.js', 'shared/source-registry.js', 'content/utils.js', 'content/yahoo-mail.js'],
+        injectSource: 'yahoo-mail',
+      };
+    }
     if (provider === YYDS_MAIL_PROVIDER) {
       return { provider: YYDS_MAIL_PROVIDER, label: 'YYDS Mail' };
     }
@@ -126,6 +139,7 @@
   return {
     GMAIL_PROVIDER,
     HOTMAIL_PROVIDER,
+    YAHOO_PROVIDER,
     YYDS_MAIL_PROVIDER,
     getIcloudForwardMailConfig,
     getIcloudForwardMailProviderOptions,

--- a/mail-provider-utils.js
+++ b/mail-provider-utils.js
@@ -13,6 +13,9 @@
   const GMAIL_PROVIDER = 'gmail';
   const YAHOO_PROVIDER = 'yahoo';
   const YYDS_MAIL_PROVIDER = 'yyds-mail';
+  const LUCKMAIL_PROVIDER = 'luckmail-api';
+  const CLOUDFLARE_TEMP_EMAIL_PROVIDER = 'cloudflare-temp-email';
+  const CLOUD_MAIL_PROVIDER = 'cloudmail';
   const NETEASE_LIST_PATH = '/js6/main.jsp?df=mail163_letter#module=mbox.ListModule%7C%7B%22fid%22%3A1%2C%22order%22%3A%22date%22%2C%22desc%22%3Atrue%7D';
   const ICLOUD_TARGET_MAILBOX_TYPE_INBOX = 'icloud-inbox';
   const ICLOUD_TARGET_MAILBOX_TYPE_FORWARD = 'forward-mailbox';
@@ -136,16 +139,62 @@
     return { source: 'qq-mail', url: 'https://wx.mail.qq.com/', label: 'QQ 邮箱' };
   }
 
+  function normalizeProviderToken(value = '') {
+    return String(value || '').trim().toLowerCase();
+  }
+
+  function inferMailProvider(mail = {}, state = {}) {
+    const explicitProvider = normalizeProviderToken(mail?.provider);
+    if (explicitProvider) {
+      return explicitProvider;
+    }
+
+    const stateProvider = normalizeProviderToken(state?.mailProvider);
+    if (stateProvider) {
+      return stateProvider;
+    }
+
+    const source = normalizeProviderToken(mail?.source);
+    const injectSource = normalizeProviderToken(mail?.injectSource);
+    const label = normalizeProviderToken(mail?.label);
+    const url = normalizeProviderToken(mail?.url);
+    const combined = `${source} ${injectSource} ${label} ${url}`;
+    if (/yahoo/.test(combined)) return YAHOO_PROVIDER;
+    if (/2925/.test(combined)) return '2925';
+    if (/hotmail/.test(combined)) return HOTMAIL_PROVIDER;
+    if (/luckmail/.test(combined)) return LUCKMAIL_PROVIDER;
+    if (/cloudmail/.test(combined)) return CLOUD_MAIL_PROVIDER;
+    if (/yyds/.test(combined)) return YYDS_MAIL_PROVIDER;
+    if (/cloudflare/.test(combined)) return CLOUDFLARE_TEMP_EMAIL_PROVIDER;
+    return explicitProvider || stateProvider || '';
+  }
+
+  function withResolvedMailProvider(mail = {}, state = {}) {
+    const provider = inferMailProvider(mail, state);
+    if (!mail || typeof mail !== 'object') {
+      return { provider };
+    }
+    if (normalizeProviderToken(mail.provider) === provider) {
+      return mail;
+    }
+    return { ...mail, provider };
+  }
+
   return {
+    CLOUDFLARE_TEMP_EMAIL_PROVIDER,
+    CLOUD_MAIL_PROVIDER,
     GMAIL_PROVIDER,
     HOTMAIL_PROVIDER,
+    LUCKMAIL_PROVIDER,
     YAHOO_PROVIDER,
     YYDS_MAIL_PROVIDER,
     getIcloudForwardMailConfig,
     getIcloudForwardMailProviderOptions,
     getMailProviderConfig,
+    inferMailProvider,
     normalizeIcloudForwardMailProvider,
     normalizeIcloudTargetMailboxType,
     normalizeMailProvider,
+    withResolvedMailProvider,
   };
 });

--- a/manifest.json
+++ b/manifest.json
@@ -106,7 +106,9 @@
     },
     {
       "matches": [
-        "https://mail.yahoo.com/*"
+        "https://mail.yahoo.com/*",
+        "https://login.yahoo.com/*",
+        "https://guce.yahoo.com/*"
       ],
       "js": [
         "content/activation-utils.js",

--- a/manifest.json
+++ b/manifest.json
@@ -106,6 +106,19 @@
     },
     {
       "matches": [
+        "https://mail.yahoo.com/*"
+      ],
+      "js": [
+        "content/activation-utils.js",
+        "shared/source-registry.js",
+        "content/utils.js",
+        "content/yahoo-mail.js"
+      ],
+      "all_frames": false,
+      "run_at": "document_idle"
+    },
+    {
+      "matches": [
         "https://duckduckgo.com/email/settings/autofill*"
       ],
       "js": [

--- a/shared/source-registry.js
+++ b/shared/source-registry.js
@@ -315,7 +315,9 @@
         case 'gmail-mail':
           return candidate.hostname === 'mail.google.com';
         case 'yahoo-mail':
-          return candidate.hostname === 'mail.yahoo.com';
+          return candidate.hostname === 'mail.yahoo.com'
+            || candidate.hostname === 'login.yahoo.com'
+            || candidate.hostname === 'guce.yahoo.com';
         case 'icloud-mail':
           return candidate.hostname === 'www.icloud.com'
             || candidate.hostname === 'www.icloud.com.cn';
@@ -375,7 +377,7 @@
       if (normalizedHostname === 'mail.qq.com' || normalizedHostname === 'wx.mail.qq.com') return 'qq-mail';
       if (is163MailHost(normalizedHostname)) return 'mail-163';
       if (normalizedHostname === 'mail.google.com') return 'gmail-mail';
-      if (normalizedHostname === 'mail.yahoo.com') return 'yahoo-mail';
+      if (normalizedHostname === 'mail.yahoo.com' || normalizedHostname === 'login.yahoo.com' || normalizedHostname === 'guce.yahoo.com') return 'yahoo-mail';
       if (normalizedHostname === 'www.icloud.com' || normalizedHostname === 'www.icloud.com.cn') return 'icloud-mail';
       if (normalizedUrl.includes('duckduckgo.com/email/settings/autofill')) return 'duck-mail';
       if (normalizedUrl.includes('2925.com')) return 'mail-2925';

--- a/shared/source-registry.js
+++ b/shared/source-registry.js
@@ -36,6 +36,15 @@
       driverId: 'content/gmail-mail',
       cleanupScopes: [],
     },
+    'yahoo-mail': {
+      flowId: null,
+      kind: 'mail-provider',
+      label: 'Yahoo 邮箱',
+      readyPolicy: 'top-frame-only',
+      family: 'yahoo-mail-family',
+      driverId: 'content/yahoo-mail',
+      cleanupScopes: [],
+    },
     'icloud-mail': {
       flowId: null,
       kind: 'mail-provider',
@@ -96,6 +105,10 @@
       sourceId: 'gmail-mail',
       commands: ['POLL_EMAIL'],
     },
+    'content/yahoo-mail': {
+      sourceId: 'yahoo-mail',
+      commands: ['POLL_EMAIL', 'YAHOO_CHECK_TOP_MESSAGE', 'YAHOO_OPEN_TOP_MESSAGE', 'YAHOO_READ_CURRENT_MESSAGE_CODE', 'YAHOO_CREATE_TEMP_ALIAS', 'YAHOO_LOGIN_WITH_CREDENTIALS'],
+    },
     'content/icloud-mail': {
       sourceId: 'icloud-mail',
       commands: ['POLL_EMAIL'],
@@ -120,6 +133,7 @@
     'qq-mail',
     'mail-163',
     'gmail-mail',
+    'yahoo-mail',
     'mail-2925',
     'inbucket-mail',
     'plus-checkout',
@@ -300,6 +314,8 @@
           return is163MailHost(candidate.hostname);
         case 'gmail-mail':
           return candidate.hostname === 'mail.google.com';
+        case 'yahoo-mail':
+          return candidate.hostname === 'mail.yahoo.com';
         case 'icloud-mail':
           return candidate.hostname === 'www.icloud.com'
             || candidate.hostname === 'www.icloud.com.cn';
@@ -359,6 +375,7 @@
       if (normalizedHostname === 'mail.qq.com' || normalizedHostname === 'wx.mail.qq.com') return 'qq-mail';
       if (is163MailHost(normalizedHostname)) return 'mail-163';
       if (normalizedHostname === 'mail.google.com') return 'gmail-mail';
+      if (normalizedHostname === 'mail.yahoo.com') return 'yahoo-mail';
       if (normalizedHostname === 'www.icloud.com' || normalizedHostname === 'www.icloud.com.cn') return 'icloud-mail';
       if (normalizedUrl.includes('duckduckgo.com/email/settings/autofill')) return 'duck-mail';
       if (normalizedUrl.includes('2925.com')) return 'mail-2925';

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -499,6 +499,7 @@
             <option value="luckmail-api">LuckMail（API 购邮）</option>
             <option value="yyds-mail">YYDS Mail</option>
             <option value="icloud">iCloud 邮箱</option>
+            <option value="yahoo">Yahoo 邮箱 (mail.yahoo.com) 请把默认邮箱页面设置为ALL</option>
             <option value="163">163 邮箱 (mail.163.com) 版本老旧，请自行维护使用</option>
             <option value="163-vip">163 VIP 邮箱 (vip.163.com) 版本老旧，请自行维护使用</option>
             <option value="126">126 邮箱 (mail.126.com) 版本老旧，请自行维护使用</option>
@@ -510,6 +511,20 @@
             <option value="cloudmail">Cloud Mail</option>
           </select>
           <button id="btn-mail-login" class="btn btn-outline btn-sm data-inline-btn" type="button" disabled>登录</button>
+        </div>
+      </div>
+      <div class="data-row" id="row-yahoo-mail-email" style="display:none;">
+        <span class="data-label">Yahoo账号</span>
+        <input type="text" id="input-yahoo-mail-email" class="data-input" placeholder="name@yahoo.com" />
+      </div>
+      <div class="data-row" id="row-yahoo-mail-password" style="display:none;">
+        <span class="data-label">Yahoo密码</span>
+        <div class="input-with-icon">
+          <input type="password" id="input-yahoo-mail-password" class="data-input data-input-with-icon"
+            placeholder="Yahoo 登录密码" />
+          <button id="btn-toggle-yahoo-mail-password" class="input-icon-btn" type="button"
+            data-password-toggle="input-yahoo-mail-password" data-show-label="显示 Yahoo 登录密码"
+            data-hide-label="隐藏 Yahoo 登录密码" aria-label="显示 Yahoo 登录密码" title="显示 Yahoo 登录密码"></button>
         </div>
       </div>
       <div class="data-row data-check-row" id="row-custom-mail-provider-pool" style="display:none;">
@@ -532,6 +547,7 @@
           <option value="custom-pool">自定义邮箱池</option>
           <option value="cloudflare">Cloudflare</option>
           <option value="icloud">iCloud 隐私邮箱</option>
+          <option value="yahoo">Yahoo 临时邮箱</option>
           <option value="cloudflare-temp-email">Cloudflare Temp Email（推荐）</option>
           <option value="cloudmail">Cloud Mail</option>
         </select>
@@ -1872,6 +1888,7 @@
   <script src="../phone-sms/providers/five-sim.js"></script>
   <script src="../phone-sms/providers/registry.js"></script>
   <script src="../icloud-utils.js"></script>
+  <script src="../yahoo-utils.js"></script>
   <script src="../mail-provider-utils.js"></script>
   <script src="../hotmail-utils.js"></script>
   <script src="../luckmail-utils.js"></script>

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -248,6 +248,10 @@ const rowGoPayPin = document.getElementById('row-gopay-pin');
 const inputGoPayPin = document.getElementById('input-gopay-pin');
 const selectMailProvider = document.getElementById('select-mail-provider');
 const btnMailLogin = document.getElementById('btn-mail-login');
+const rowYahooMailEmail = document.getElementById('row-yahoo-mail-email');
+const inputYahooMailEmail = document.getElementById('input-yahoo-mail-email');
+const rowYahooMailPassword = document.getElementById('row-yahoo-mail-password');
+const inputYahooMailPassword = document.getElementById('input-yahoo-mail-password');
 const rowCustomMailProviderPool = document.getElementById('row-custom-mail-provider-pool');
 const inputCustomMailProviderPool = document.getElementById('input-custom-mail-provider-pool');
 const rowMail2925Mode = document.getElementById('row-mail-2925-mode');
@@ -1058,6 +1062,8 @@ const HOTMAIL_SERVICE_MODE_LOCAL = 'local';
 const ICLOUD_PROVIDER = 'icloud';
 const GMAIL_PROVIDER = 'gmail';
 const GMAIL_ALIAS_GENERATOR = 'gmail-alias';
+const YAHOO_PROVIDER = window.YahooUtils?.YAHOO_PROVIDER || 'yahoo';
+const YAHOO_GENERATOR = window.YahooUtils?.YAHOO_GENERATOR || 'yahoo';
 const LUCKMAIL_PROVIDER = 'luckmail-api';
 const YYDS_MAIL_PROVIDER = 'yyds-mail';
 const CUSTOM_EMAIL_POOL_GENERATOR = 'custom-pool';
@@ -1673,6 +1679,11 @@ const MAIL_PROVIDER_LOGIN_CONFIGS = {
   [GMAIL_PROVIDER]: {
     label: 'Gmail 邮箱',
     url: 'https://mail.google.com/mail/u/0/#inbox',
+    buttonLabel: '登录',
+  },
+  [YAHOO_PROVIDER]: {
+    label: 'Yahoo 邮箱',
+    url: 'https://mail.yahoo.com/n/inbox/priority',
     buttonLabel: '登录',
   },
   '163': {
@@ -4750,6 +4761,12 @@ function collectSettingsPayload() {
     mail2925Mode: getSelectedMail2925Mode(),
     mail2925UseAccountPool,
     currentMail2925AccountId: String(latestState?.currentMail2925AccountId || '').trim(),
+    yahooMailEmail: typeof inputYahooMailEmail !== 'undefined' && inputYahooMailEmail
+      ? inputYahooMailEmail.value.trim()
+      : String(latestState?.yahooMailEmail || '').trim(),
+    yahooMailPassword: typeof inputYahooMailPassword !== 'undefined' && inputYahooMailPassword
+      ? inputYahooMailPassword.value
+      : String(latestState?.yahooMailPassword || ''),
     emailGenerator: selectEmailGenerator.value,
     customMailProviderPool: typeof normalizeCustomEmailPoolEntries === 'function'
       ? normalizeCustomEmailPoolEntries(inputCustomMailProviderPool?.value)
@@ -10866,8 +10883,14 @@ function applySettingsState(state) {
   const yydsMailProvider = typeof YYDS_MAIL_PROVIDER === 'string'
     ? YYDS_MAIL_PROVIDER
     : 'yyds-mail';
+  const yahooProvider = typeof YAHOO_PROVIDER === 'string'
+    ? YAHOO_PROVIDER
+    : 'yahoo';
+  const yahooGenerator = typeof YAHOO_GENERATOR === 'string'
+    ? YAHOO_GENERATOR
+    : 'yahoo';
   const restoredMailProvider = isCustomMailProvider(state?.mailProvider)
-    || [ICLOUD_PROVIDER, 'hotmail-api', GMAIL_PROVIDER, 'luckmail-api', yydsMailProvider, '163', '163-vip', '126', 'qq', 'inbucket', '2925', 'cloudflare-temp-email', 'cloudmail'].includes(String(state?.mailProvider || '').trim())
+    || [ICLOUD_PROVIDER, yahooProvider, 'hotmail-api', GMAIL_PROVIDER, 'luckmail-api', yydsMailProvider, '163', '163-vip', '126', 'qq', 'inbucket', '2925', 'cloudflare-temp-email', 'cloudmail'].includes(String(state?.mailProvider || '').trim())
     ? String(state?.mailProvider || '163').trim()
     : (String(state?.emailGenerator || '').trim().toLowerCase() === 'custom'
       || String(state?.emailGenerator || '').trim().toLowerCase() === 'manual'
@@ -10885,6 +10908,8 @@ function applySettingsState(state) {
       selectEmailGenerator.value = CUSTOM_EMAIL_POOL_GENERATOR;
     } else if (restoredEmailGenerator === 'icloud') {
       selectEmailGenerator.value = 'icloud';
+    } else if (restoredEmailGenerator === yahooGenerator) {
+      selectEmailGenerator.value = yahooGenerator;
     } else if (restoredEmailGenerator === 'cloudflare') {
       selectEmailGenerator.value = 'cloudflare';
     } else if (restoredEmailGenerator === 'cloudflare-temp-email') {
@@ -10923,6 +10948,12 @@ function applySettingsState(state) {
   }
   if (inputMail2925UseAccountPool) {
     inputMail2925UseAccountPool.checked = Boolean(state?.mail2925UseAccountPool);
+  }
+  if (inputYahooMailEmail) {
+    inputYahooMailEmail.value = state?.yahooMailEmail || '';
+  }
+  if (inputYahooMailPassword) {
+    inputYahooMailPassword.value = state?.yahooMailPassword || '';
   }
   setManagedAliasBaseEmailInputForProvider(restoredMailProvider, state);
   inputInbucketHost.value = state?.inbucketHost || '';
@@ -11917,6 +11948,13 @@ function isIcloudMailProvider(provider = selectMailProvider.value) {
   return String(provider || '').trim().toLowerCase() === ICLOUD_PROVIDER;
 }
 
+function isYahooMailProvider(provider = selectMailProvider.value) {
+  const yahooProvider = typeof YAHOO_PROVIDER === 'string'
+    ? YAHOO_PROVIDER
+    : 'yahoo';
+  return String(provider || '').trim().toLowerCase() === yahooProvider;
+}
+
 function normalizeLuckmailBaseUrl(value = '') {
   const trimmed = String(value || '').trim();
   if (!trimmed) {
@@ -11969,6 +12007,9 @@ function normalizeYydsMailBaseUrl(value = '') {
 
 function getSelectedEmailGenerator() {
   const generator = String(selectEmailGenerator.value || '').trim().toLowerCase();
+  const yahooGenerator = typeof YAHOO_GENERATOR === 'string'
+    ? YAHOO_GENERATOR
+    : 'yahoo';
   if (generator === 'custom' || generator === 'manual') {
     return 'custom';
   }
@@ -11981,6 +12022,9 @@ function getSelectedEmailGenerator() {
   if (generator === 'icloud') {
     return 'icloud';
   }
+  if (generator === yahooGenerator) {
+    return yahooGenerator;
+  }
   if (generator === 'cloudflare') return 'cloudflare';
   if (generator === 'cloudflare-temp-email') return 'cloudflare-temp-email';
   if (generator === 'cloudmail') return 'cloudmail';
@@ -11988,6 +12032,9 @@ function getSelectedEmailGenerator() {
 }
 
 function getEmailGeneratorUiCopy() {
+  const yahooGenerator = typeof YAHOO_GENERATOR === 'string'
+    ? YAHOO_GENERATOR
+    : 'yahoo';
   if (getSelectedEmailGenerator() === 'custom') {
     return getCustomMailProviderUiCopy();
   }
@@ -12013,6 +12060,14 @@ function getEmailGeneratorUiCopy() {
       placeholder: '点击获取 iCloud 隐私邮箱，或手动粘贴邮箱',
       successVerb: '获取',
       label: 'iCloud 隐私邮箱',
+    };
+  }
+  if (getSelectedEmailGenerator() === yahooGenerator) {
+    return {
+      buttonLabel: '创建别名',
+      placeholder: '点击创建 Yahoo 临时邮箱，或手动粘贴邮箱',
+      successVerb: '创建',
+      label: 'Yahoo 临时邮箱',
     };
   }
   if (getSelectedEmailGenerator() === 'cloudflare') {
@@ -12437,6 +12492,12 @@ function updateMailProviderUI() {
   const customEmailPoolGenerator = typeof CUSTOM_EMAIL_POOL_GENERATOR === 'string'
     ? CUSTOM_EMAIL_POOL_GENERATOR
     : 'custom-pool';
+  const yahooProvider = typeof YAHOO_PROVIDER === 'string'
+    ? YAHOO_PROVIDER
+    : 'yahoo';
+  const yahooGenerator = typeof YAHOO_GENERATOR === 'string'
+    ? YAHOO_GENERATOR
+    : 'yahoo';
   const gmailOnlyGenerators = new Set([gmailAliasGenerator, customEmailPoolGenerator]);
   Array.from(selectEmailGenerator?.options || []).forEach((option) => {
     if (!option) return;
@@ -12463,6 +12524,9 @@ function updateMailProviderUI() {
   const useCustomEmail = isCustomMailProvider();
   const useCustomMailProviderPool = useCustomEmail && usesCustomMailProviderPool(selectMailProvider.value);
   const useIcloudProvider = isIcloudMailProvider();
+  const useYahooProvider = typeof isYahooMailProvider === 'function'
+    ? isYahooMailProvider()
+    : String(selectMailProvider.value || '').trim().toLowerCase() === yahooProvider;
   const useEmailGenerator = !useHotmail && !useLuckmail && !useYydsMail && !useCustomEmail && (!useGeneratedAlias || useGmail);
   const useCloudflareTempEmailProvider = selectMailProvider.value === 'cloudflare-temp-email';
   const useCloudMailProvider = selectMailProvider.value === 'cloudmail';
@@ -12480,6 +12544,12 @@ function updateMailProviderUI() {
   if (typeof rowCustomMailProviderPool !== 'undefined' && rowCustomMailProviderPool) {
     rowCustomMailProviderPool.style.display = useCustomEmail ? '' : 'none';
   }
+  if (rowYahooMailEmail) {
+    rowYahooMailEmail.style.display = (useYahooProvider || selectedGenerator === yahooGenerator) ? '' : 'none';
+  }
+  if (rowYahooMailPassword) {
+    rowYahooMailPassword.style.display = (useYahooProvider || selectedGenerator === yahooGenerator) ? '' : 'none';
+  }
   rowEmailPrefix.style.display = useGeneratedAlias && !useMail2925AccountPool ? '' : 'none';
   const hotmailServiceMode = getSelectedHotmailServiceMode();
   rowInbucketHost.style.display = useInbucket ? '' : 'none';
@@ -12487,6 +12557,7 @@ function updateMailProviderUI() {
   const useCustomEmailPool = useEmailGenerator && selectedGenerator === customEmailPoolGenerator;
   const useCloudflare = selectedGenerator === 'cloudflare';
   const useIcloud = selectedGenerator === 'icloud';
+  const useYahooGenerator = selectedGenerator === yahooGenerator;
   const useCloudflareTempEmailGenerator = selectedGenerator === 'cloudflare-temp-email';
   const useCloudMailGenerator = selectedGenerator === 'cloudmail';
   const showCloudflareDomain = useEmailGenerator && useCloudflare;
@@ -12661,6 +12732,9 @@ function updateMailProviderUI() {
   }
   if (autoHintText && useGeneratedAlias && aliasUiCopy?.hint) {
     autoHintText.textContent = aliasUiCopy.hint;
+  }
+  if (autoHintText && (useYahooProvider || (useEmailGenerator && useYahooGenerator))) {
+    autoHintText.textContent = 'Yahoo 需要先手动登录。创建临时邮箱时会直接创建新的临时邮箱；第 4/8 步会打开收件箱顶部邮件取码。';
   }
   if (autoHintText && useMail2925AccountPool && !useCustomEmailPool) {
     autoHintText.textContent = getMail2925Accounts().length
@@ -14410,7 +14484,19 @@ btnMailLogin?.addEventListener('click', async () => {
   }
 
   try {
-    await chrome.tabs.create({ url: loginUrl, active: true });
+    const response = await chrome.runtime.sendMessage({
+      type: 'OPEN_MAIL_PROVIDER_LOGIN',
+      source: 'sidepanel',
+      payload: {
+        provider: selectMailProvider?.value || latestState?.mailProvider || '',
+        url: loginUrl,
+        yahooMailEmail: inputYahooMailEmail?.value.trim() || '',
+        yahooMailPassword: inputYahooMailPassword?.value || '',
+      },
+    });
+    if (response?.error) {
+      throw new Error(response.error);
+    }
   } catch (err) {
     showToast(`打开${config.label}失败：${err.message}`, 'error');
   }
@@ -15319,6 +15405,19 @@ selectPlusAccountAccessStrategy?.addEventListener('change', () => {
     scheduleSettingsAutoSave();
   });
   input?.addEventListener('blur', () => {
+    saveSettings({ silent: true }).catch(() => { });
+  });
+});
+
+[inputYahooMailEmail, inputYahooMailPassword].forEach((input) => {
+  input?.addEventListener('input', () => {
+    markSettingsDirty(true);
+    scheduleSettingsAutoSave();
+  });
+  input?.addEventListener('blur', () => {
+    if (input === inputYahooMailEmail) {
+      inputYahooMailEmail.value = inputYahooMailEmail.value.trim();
+    }
     saveSettings({ silent: true }).catch(() => { });
   });
 });

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -4764,9 +4764,6 @@ function collectSettingsPayload() {
     yahooMailEmail: typeof inputYahooMailEmail !== 'undefined' && inputYahooMailEmail
       ? inputYahooMailEmail.value.trim()
       : String(latestState?.yahooMailEmail || '').trim(),
-    yahooMailPassword: typeof inputYahooMailPassword !== 'undefined' && inputYahooMailPassword
-      ? inputYahooMailPassword.value
-      : String(latestState?.yahooMailPassword || ''),
     emailGenerator: selectEmailGenerator.value,
     customMailProviderPool: typeof normalizeCustomEmailPoolEntries === 'function'
       ? normalizeCustomEmailPoolEntries(inputCustomMailProviderPool?.value)
@@ -10949,11 +10946,8 @@ function applySettingsState(state) {
   if (inputMail2925UseAccountPool) {
     inputMail2925UseAccountPool.checked = Boolean(state?.mail2925UseAccountPool);
   }
-  if (inputYahooMailEmail) {
+  if (typeof inputYahooMailEmail !== 'undefined' && inputYahooMailEmail) {
     inputYahooMailEmail.value = state?.yahooMailEmail || '';
-  }
-  if (inputYahooMailPassword) {
-    inputYahooMailPassword.value = state?.yahooMailPassword || '';
   }
   setManagedAliasBaseEmailInputForProvider(restoredMailProvider, state);
   inputInbucketHost.value = state?.inbucketHost || '';
@@ -12544,10 +12538,10 @@ function updateMailProviderUI() {
   if (typeof rowCustomMailProviderPool !== 'undefined' && rowCustomMailProviderPool) {
     rowCustomMailProviderPool.style.display = useCustomEmail ? '' : 'none';
   }
-  if (rowYahooMailEmail) {
+  if (typeof rowYahooMailEmail !== 'undefined' && rowYahooMailEmail) {
     rowYahooMailEmail.style.display = (useYahooProvider || selectedGenerator === yahooGenerator) ? '' : 'none';
   }
-  if (rowYahooMailPassword) {
+  if (typeof rowYahooMailPassword !== 'undefined' && rowYahooMailPassword) {
     rowYahooMailPassword.style.display = (useYahooProvider || selectedGenerator === yahooGenerator) ? '' : 'none';
   }
   rowEmailPrefix.style.display = useGeneratedAlias && !useMail2925AccountPool ? '' : 'none';
@@ -15409,17 +15403,13 @@ selectPlusAccountAccessStrategy?.addEventListener('change', () => {
   });
 });
 
-[inputYahooMailEmail, inputYahooMailPassword].forEach((input) => {
-  input?.addEventListener('input', () => {
-    markSettingsDirty(true);
-    scheduleSettingsAutoSave();
-  });
-  input?.addEventListener('blur', () => {
-    if (input === inputYahooMailEmail) {
-      inputYahooMailEmail.value = inputYahooMailEmail.value.trim();
-    }
-    saveSettings({ silent: true }).catch(() => { });
-  });
+inputYahooMailEmail?.addEventListener('input', () => {
+  markSettingsDirty(true);
+  scheduleSettingsAutoSave();
+});
+inputYahooMailEmail?.addEventListener('blur', () => {
+  inputYahooMailEmail.value = inputYahooMailEmail.value.trim();
+  saveSettings({ silent: true }).catch(() => { });
 });
 
 function syncCurrentIpProxyServiceProfileToLatestState() {

--- a/tests/background-step8-yahoo-polling.test.js
+++ b/tests/background-step8-yahoo-polling.test.js
@@ -1,0 +1,119 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const source = fs.readFileSync('background/steps/fetch-login-code.js', 'utf8');
+const globalScope = {};
+const api = new Function('self', `${source}; return self.MultiPageBackgroundStep8;`)(globalScope);
+
+test('step 8 uses yahoo refresh-then-resend polling cycle', async () => {
+  let capturedOptions = null;
+  const realDateNow = Date.now;
+  const realSetTimeout = global.setTimeout;
+  Date.now = () => 700000;
+  global.setTimeout = (callback) => {
+    if (typeof callback === 'function') callback();
+    return 0;
+  };
+
+  const executor = api.createStep8Executor({
+    addLog: async () => {},
+    chrome: {
+      tabs: {
+        update: async () => {},
+      },
+    },
+    CLOUDFLARE_TEMP_EMAIL_PROVIDER: 'cloudflare-temp-email',
+    confirmCustomVerificationStepBypass: async () => {},
+    ensureMail2925MailboxSession: async () => {},
+    ensureStep8VerificationPageReady: async () => ({ displayedEmail: 'user@example.com' }),
+    getMailConfig: () => ({
+      provider: 'yahoo',
+      label: 'Yahoo 邮箱',
+      source: 'yahoo-mail',
+      url: 'https://mail.yahoo.com/n/inbox/all',
+    }),
+    getState: async () => ({}),
+    getTabId: async () => 1,
+    HOTMAIL_PROVIDER: 'hotmail-api',
+    isTabAlive: async () => false,
+    isVerificationMailPollingError: () => false,
+    LUCKMAIL_PROVIDER: 'luckmail-api',
+    resolveVerificationStep: async (_step, _state, _mail, options) => {
+      capturedOptions = options;
+    },
+    rerunStep7ForStep8Recovery: async () => {},
+    reuseOrCreateTab: async () => {},
+    setState: async () => {},
+    shouldUseCustomRegistrationEmail: () => false,
+    STANDARD_MAIL_VERIFICATION_RESEND_INTERVAL_MS: 25000,
+    STEP7_MAIL_POLLING_RECOVERY_MAX_ATTEMPTS: 3,
+    throwIfStopped: () => {},
+  });
+
+  try {
+    await executor.executeStep8({
+      email: 'user@example.com',
+      oauthUrl: 'https://auth.openai.com/',
+    });
+  } finally {
+    Date.now = realDateNow;
+    global.setTimeout = realSetTimeout;
+  }
+
+  assert.equal(capturedOptions.requestFreshCodeFirst, false);
+  assert.equal(capturedOptions.lastResendAt, 700000);
+  assert.equal(capturedOptions.intervalMs, 5000);
+  assert.equal(capturedOptions.maxAttempts, 60);
+  assert.equal(capturedOptions.refreshesBeforeResend, 5);
+  assert.equal(capturedOptions.maxResendRequests, 0);
+  assert.equal(capturedOptions.keepRefreshingUntilCode, false);
+  assert.equal(capturedOptions.resendIntervalMs, 25000);
+});
+
+test('step 8 yahoo mail config is normalized from legacy inbox url to standard all inbox', async () => {
+  let capturedMail = null;
+
+  const executor = api.createStep8Executor({
+    addLog: async () => {},
+    chrome: {
+      tabs: {
+        update: async () => {},
+      },
+    },
+    CLOUDFLARE_TEMP_EMAIL_PROVIDER: 'cloudflare-temp-email',
+    confirmCustomVerificationStepBypass: async () => {},
+    ensureMail2925MailboxSession: async () => {},
+    ensureStep8VerificationPageReady: async () => ({ displayedEmail: 'user@example.com' }),
+    getMailConfig: () => ({
+      provider: 'yahoo',
+      label: 'Yahoo 邮箱',
+      source: 'yahoo-mail',
+      url: 'https://mail.yahoo.com/n/inbox/all',
+    }),
+    getState: async () => ({}),
+    getTabId: async () => 1,
+    HOTMAIL_PROVIDER: 'hotmail-api',
+    isTabAlive: async () => false,
+    isVerificationMailPollingError: () => false,
+    LUCKMAIL_PROVIDER: 'luckmail-api',
+    resolveVerificationStep: async (_step, _state, mail) => {
+      capturedMail = mail;
+    },
+    rerunStep7ForStep8Recovery: async () => {},
+    reuseOrCreateTab: async () => {},
+    setState: async () => {},
+    shouldUseCustomRegistrationEmail: () => false,
+    STANDARD_MAIL_VERIFICATION_RESEND_INTERVAL_MS: 25000,
+    STEP7_MAIL_POLLING_RECOVERY_MAX_ATTEMPTS: 3,
+    throwIfStopped: () => {},
+  });
+
+  await executor.executeStep8({
+    email: 'user@example.com',
+    oauthUrl: 'https://auth.openai.com/',
+  });
+
+  assert.ok(capturedMail);
+  assert.equal(capturedMail.url, 'https://mail.yahoo.com/n/inbox/all?listFilter=ALL_INBOX');
+});

--- a/tests/background-yahoo-provider.test.js
+++ b/tests/background-yahoo-provider.test.js
@@ -1,0 +1,243 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const backgroundSource = fs.readFileSync('background.js', 'utf8');
+
+function extractFunction(name) {
+  const markers = [`async function ${name}(`, `function ${name}(`];
+  const start = markers.map((marker) => backgroundSource.indexOf(marker)).find((index) => index >= 0);
+  if (start < 0) throw new Error(`missing function ${name}`);
+
+  let parenDepth = 0;
+  let signatureEnded = false;
+  let braceStart = -1;
+  for (let i = start; i < backgroundSource.length; i += 1) {
+    const ch = backgroundSource[i];
+    if (ch === '(') parenDepth += 1;
+    else if (ch === ')') {
+      parenDepth -= 1;
+      if (parenDepth === 0) signatureEnded = true;
+    } else if (ch === '{' && signatureEnded) {
+      braceStart = i;
+      break;
+    }
+  }
+
+  let depth = 0;
+  let end = braceStart;
+  for (; end < backgroundSource.length; end += 1) {
+    const ch = backgroundSource[end];
+    if (ch === '{') depth += 1;
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        end += 1;
+        break;
+      }
+    }
+  }
+  return backgroundSource.slice(start, end);
+}
+
+test('normalizeMailProvider keeps yahoo provider', () => {
+  const bundle = extractFunction('normalizeMailProvider');
+  const api = new Function(`
+const ICLOUD_PROVIDER = 'icloud';
+const GMAIL_PROVIDER = 'gmail';
+const YAHOO_PROVIDER = 'yahoo';
+const HOTMAIL_PROVIDER = 'hotmail-api';
+const LUCKMAIL_PROVIDER = 'luckmail-api';
+const CLOUDFLARE_TEMP_EMAIL_PROVIDER = 'cloudflare-temp-email';
+const CLOUD_MAIL_PROVIDER = 'cloudmail';
+const YYDS_MAIL_PROVIDER = 'yyds-mail';
+const PERSISTED_SETTING_DEFAULTS = { mailProvider: '163' };
+${bundle}
+return { normalizeMailProvider };
+`)();
+
+  assert.equal(api.normalizeMailProvider('yahoo'), 'yahoo');
+  assert.equal(api.normalizeMailProvider('YAHOO'), 'yahoo');
+});
+
+test('normalizeEmailGenerator keeps yahoo generator', () => {
+  const bundle = extractFunction('normalizeEmailGenerator');
+  const api = new Function(`
+const CUSTOM_EMAIL_POOL_GENERATOR = 'custom-pool';
+const GMAIL_ALIAS_GENERATOR = 'gmail-alias';
+const YYDS_MAIL_GENERATOR = 'yyds-mail';
+const CLOUDFLARE_TEMP_EMAIL_GENERATOR = 'cloudflare-temp-email';
+const YAHOO_GENERATOR = 'yahoo';
+${bundle}
+return { normalizeEmailGenerator };
+`)();
+
+  assert.equal(api.normalizeEmailGenerator('yahoo'), 'yahoo');
+  assert.equal(api.normalizeEmailGenerator('YAHOO'), 'yahoo');
+});
+
+test('getMailConfig returns yahoo mail config with full injection stack', () => {
+  const bundle = extractFunction('getMailConfig');
+  const api = new Function(`
+const ICLOUD_PROVIDER = 'icloud';
+const GMAIL_PROVIDER = 'gmail';
+const YAHOO_PROVIDER = 'yahoo';
+const HOTMAIL_PROVIDER = 'hotmail-api';
+const LUCKMAIL_PROVIDER = 'luckmail-api';
+const CLOUDFLARE_TEMP_EMAIL_PROVIDER = 'cloudflare-temp-email';
+const YYDS_MAIL_PROVIDER = 'yyds-mail';
+function normalizeInbucketOrigin(v = '') { return String(v || '').trim(); }
+${bundle}
+return { getMailConfig };
+`)();
+
+  assert.deepEqual(api.getMailConfig({ mailProvider: 'yahoo' }), {
+    provider: 'yahoo',
+    source: 'yahoo-mail',
+    url: 'https://mail.yahoo.com/n/inbox/all?listFilter=ALL_INBOX',
+    label: 'Yahoo 邮箱',
+    navigateOnReuse: true,
+    inject: ['content/activation-utils.js', 'shared/source-registry.js', 'content/utils.js', 'content/yahoo-mail.js'],
+    injectSource: 'yahoo-mail',
+  });
+});
+
+test('background exposes yahoo mail login through managed source tab opening', () => {
+  assert.match(backgroundSource, /async function openMailProviderLogin\(payload = \{\}\)/);
+  assert.match(backgroundSource, /const mail = getMailConfig\(\{\s*\.\.\.state,\s*mailProvider: provider,/);
+  assert.match(backgroundSource, /await reuseOrCreateTab\(mail\.source, targetUrl, \{/);
+  assert.match(backgroundSource, /injectSource: mail\.injectSource/);
+  assert.match(backgroundSource, /chrome\.tabs\.update\(tabId, \{ active: true \}\)/);
+  assert.match(backgroundSource, /type: 'YAHOO_LOGIN_WITH_CREDENTIALS'/);
+  assert.match(backgroundSource, /email: yahooMailEmail,/);
+  assert.match(backgroundSource, /password: yahooMailPassword,/);
+});
+
+test('background persists yahoo mailbox credentials', () => {
+  assert.match(backgroundSource, /yahooMailEmail: '',/);
+  assert.match(backgroundSource, /yahooMailPassword: '',/);
+  assert.match(backgroundSource, /case 'yahooMailEmail':\s*return String\(value \|\| ''\)\.trim\(\);/);
+  assert.match(backgroundSource, /case 'yahooMailPassword':\s*return String\(value \|\| ''\);/);
+});
+
+test('auto run persists the generated yahoo email before executing signup step 2', () => {
+  const ensureIndex = backgroundSource.indexOf('const readyEmail = await ensureAutoEmailReady(targetRun, totalRuns, attemptRuns);');
+  const persistIndex = backgroundSource.indexOf('await setEmailState(normalizedReadyEmail);', ensureIndex);
+  const executeIndex = backgroundSource.indexOf("await executeNodeAndWait('submit-signup-email'", ensureIndex);
+
+  assert.notEqual(ensureIndex, -1);
+  assert.notEqual(persistIndex, -1);
+  assert.notEqual(executeIndex, -1);
+  assert.equal(persistIndex < executeIndex, true);
+});
+
+test('signup email resolver refreshes latest state before deciding whether to generate yahoo again', () => {
+  const bundle = extractFunction('resolveSignupEmailForFlow');
+
+  assert.match(bundle, /latestState\s*=\s*await getState\(\)/);
+  assert.match(bundle, /\.\.\.\(state \|\| \{\}\),\s*\.\.\.\(latestState \|\| \{\}\),/);
+  assert.match(bundle, /signupFlowHelpers\.resolveSignupEmailForFlow/);
+});
+
+test('generated-email helper creates yahoo temporary alias through content script', async () => {
+  const source = fs.readFileSync('background/generated-email-helpers.js', 'utf8');
+  const globalScope = {};
+  const api = new Function('self', `${source}; return self.MultiPageGeneratedEmailHelpers;`)(globalScope);
+  const calls = [];
+  let savedEmail = '';
+  const helpers = api.createGeneratedEmailHelpers({
+    addLog: async () => {},
+    buildGeneratedAliasEmail: () => '',
+    buildCloudflareTempEmailHeaders: () => ({}),
+    CLOUDFLARE_TEMP_EMAIL_GENERATOR: 'cloudflare-temp-email',
+    CUSTOM_EMAIL_POOL_GENERATOR: 'custom-pool',
+    DUCK_AUTOFILL_URL: 'https://duckduckgo.com/email/settings/autofill',
+    fetch: async () => ({ ok: true, text: async () => '{}' }),
+    fetchIcloudHideMyEmail: async () => '',
+    getCloudflareTempEmailAddressFromResponse: () => '',
+    getCloudflareTempEmailConfig: () => ({}),
+    getCustomEmailPoolEmail: () => '',
+    getRegistrationEmailBaseline: () => '',
+    getState: async () => ({ emailGenerator: 'yahoo', emailPrefix: 'pref' }),
+    ensureMail2925AccountForFlow: async () => ({}),
+    joinCloudflareTempEmailUrl: (_base, path) => path,
+    normalizeCloudflareDomain: () => '',
+    normalizeCloudflareTempEmailAddress: () => '',
+    normalizeEmailGenerator: (value) => String(value || '').trim().toLowerCase() || 'duck',
+    isGeneratedAliasProvider: () => false,
+    persistRegistrationEmailState: async () => {
+      throw new Error('Yahoo should persist through setEmailState like the codex baseline');
+    },
+    reuseOrCreateTab: async (...args) => calls.push(['reuseOrCreateTab', ...args]),
+    sendToContentScript: async (...args) => {
+      calls.push(['sendToContentScript', ...args]);
+      return { email: 'pref-test@yahoo.com' };
+    },
+    setEmailState: async (email) => {
+      savedEmail = email;
+    },
+    throwIfStopped: () => {},
+  });
+
+  const email = await helpers.fetchGeneratedEmail({ emailGenerator: 'yahoo', emailPrefix: 'pref' }, {});
+
+  assert.equal(email, 'pref-test@yahoo.com');
+  assert.equal(calls[0][1], 'yahoo-mail');
+  assert.equal(calls[0][2], 'https://mail.yahoo.com/n/settings/2');
+  assert.deepEqual(calls[1][2].payload, { prefix: 'pref' });
+  assert.equal(calls[1][2].type, 'YAHOO_CREATE_TEMP_ALIAS');
+  assert.equal(savedEmail, 'pref-test@yahoo.com');
+});
+
+test('generated-email helper retries yahoo alias creation after foreground-required errors', async () => {
+  const source = fs.readFileSync('background/generated-email-helpers.js', 'utf8');
+  const globalScope = {};
+  const api = new Function('self', `${source}; return self.MultiPageGeneratedEmailHelpers;`)(globalScope);
+  const calls = [];
+  let sendCount = 0;
+  let savedEmail = '';
+  const helpers = api.createGeneratedEmailHelpers({
+    addLog: async (...args) => calls.push(['addLog', ...args]),
+    buildGeneratedAliasEmail: () => '',
+    buildCloudflareTempEmailHeaders: () => ({}),
+    CLOUDFLARE_TEMP_EMAIL_GENERATOR: 'cloudflare-temp-email',
+    CUSTOM_EMAIL_POOL_GENERATOR: 'custom-pool',
+    DUCK_AUTOFILL_URL: 'https://duckduckgo.com/email/settings/autofill',
+    fetch: async () => ({ ok: true, text: async () => '{}' }),
+    fetchIcloudHideMyEmail: async () => '',
+    getCloudflareTempEmailAddressFromResponse: () => '',
+    getCloudflareTempEmailConfig: () => ({}),
+    getCustomEmailPoolEmail: () => '',
+    getRegistrationEmailBaseline: () => '',
+    getState: async () => ({ emailGenerator: 'yahoo', emailPrefix: 'pref' }),
+    ensureMail2925AccountForFlow: async () => ({}),
+    joinCloudflareTempEmailUrl: (_base, path) => path,
+    normalizeCloudflareDomain: () => '',
+    normalizeCloudflareTempEmailAddress: () => '',
+    normalizeEmailGenerator: (value) => String(value || '').trim().toLowerCase() || 'duck',
+    isGeneratedAliasProvider: () => false,
+    persistRegistrationEmailState: async () => {
+      throw new Error('Yahoo should persist through setEmailState like the codex baseline');
+    },
+    reuseOrCreateTab: async (...args) => calls.push(['reuseOrCreateTab', ...args]),
+    sendToContentScript: async (...args) => {
+      calls.push(['sendToContentScript', ...args]);
+      sendCount += 1;
+      return sendCount === 1
+        ? { error: '创建 Yahoo 临时邮箱失败：点击“添加”后未出现创建面板。' }
+        : { email: 'pref-test@yahoo.com' };
+    },
+    setEmailState: async (email) => {
+      savedEmail = email;
+    },
+    throwIfStopped: () => {},
+  });
+
+  const email = await helpers.fetchGeneratedEmail({ emailGenerator: 'yahoo', emailPrefix: 'pref' }, {});
+
+  assert.equal(email, 'pref-test@yahoo.com');
+  assert.equal(calls.filter(([name]) => name === 'reuseOrCreateTab').length, 2);
+  assert.equal(calls.filter(([name]) => name === 'sendToContentScript').length, 2);
+  assert.equal(calls.some(([name, message]) => name === 'addLog' && /自动切换到 Yahoo 设置页后重试/.test(String(message))), true);
+  assert.equal(savedEmail, 'pref-test@yahoo.com');
+});

--- a/tests/background-yahoo-provider.test.js
+++ b/tests/background-yahoo-provider.test.js
@@ -104,6 +104,7 @@ return { getMailConfig };
 
 test('background exposes yahoo mail login through managed source tab opening', () => {
   assert.match(backgroundSource, /async function openMailProviderLogin\(payload = \{\}\)/);
+  assert.match(backgroundSource, /const provider = normalizeMailProvider\(payload\.provider \|\| state\.mailProvider \|\| ''\);/);
   assert.match(backgroundSource, /const mail = getMailConfig\(\{\s*\.\.\.state,\s*mailProvider: provider,/);
   assert.match(backgroundSource, /await reuseOrCreateTab\(mail\.source, targetUrl, \{/);
   assert.match(backgroundSource, /injectSource: mail\.injectSource/);
@@ -113,11 +114,12 @@ test('background exposes yahoo mail login through managed source tab opening', (
   assert.match(backgroundSource, /password: yahooMailPassword,/);
 });
 
-test('background persists yahoo mailbox credentials', () => {
+test('background persists yahoo mailbox email but not yahoo password', () => {
   assert.match(backgroundSource, /yahooMailEmail: '',/);
-  assert.match(backgroundSource, /yahooMailPassword: '',/);
   assert.match(backgroundSource, /case 'yahooMailEmail':\s*return String\(value \|\| ''\)\.trim\(\);/);
-  assert.match(backgroundSource, /case 'yahooMailPassword':\s*return String\(value \|\| ''\);/);
+  assert.doesNotMatch(backgroundSource, /yahooMailPassword: '',/);
+  assert.doesNotMatch(backgroundSource, /case 'yahooMailPassword':/);
+  assert.match(backgroundSource, /const yahooMailPassword = String\(payload\.yahooMailPassword \|\| ''\);/);
 });
 
 test('auto run persists the generated yahoo email before executing signup step 2', () => {

--- a/tests/kiro-yahoo-mail-command.test.js
+++ b/tests/kiro-yahoo-mail-command.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+test('kiro yahoo registration polling uses yahoo detail-capable command', () => {
+  const source = fs.readFileSync('background/kiro/register-runner.js', 'utf8');
+
+  assert.match(source, /async function pollYahooKiroVerificationCode\(/);
+  assert.match(source, /if \(mail\.provider === 'yahoo'\) \{\s*return pollYahooKiroVerificationCode/);
+  assert.match(source, /async function readKiroYahooTopMessageViaScripting\(/);
+  assert.match(source, /chrome\.scripting\.executeScript/);
+  assert.match(source, /后台 executeScript 直接读取 Yahoo 顶部 AWS\/Kiro 邮件行/);
+  assert.match(source, /type: 'YAHOO_OPEN_TOP_MESSAGE'/);
+  assert.match(source, /type: 'YAHOO_READ_CURRENT_MESSAGE_CODE'/);
+  assert.match(source, /reloadIfSameUrl: true/);
+});
+
+test('kiro yahoo registration polling resends from kiro page after one minute without code', () => {
+  const source = fs.readFileSync('background/kiro/register-runner.js', 'utf8');
+  const contentSource = fs.readFileSync('content/kiro/register-page.js', 'utf8');
+
+  assert.match(source, /KIRO_YAHOO_VERIFICATION_RESEND_INTERVAL_MS = 60 \* 1000/);
+  assert.match(source, /KIRO_YAHOO_VERIFICATION_MAX_ATTEMPTS = 45/);
+  assert.match(source, /async function resendKiroVerificationCodeFromRegisterPage\(/);
+  assert.match(source, /type: 'KIRO_RESEND_VERIFICATION_CODE'/);
+  assert.match(source, /Date\.now\(\) - lastKiroResendAt >= KIRO_YAHOO_VERIFICATION_RESEND_INTERVAL_MS/);
+  assert.match(source, /await focusOrOpenMailTab\(mail\)/);
+  assert.match(contentSource, /KIRO_RESEND_VERIFICATION_CODE/);
+  assert.match(contentSource, /async function resendKiroVerificationCode\(/);
+  assert.match(contentSource, /function findOtpResendButton\(/);
+});
+
+test('kiro yahoo desktop authorization polling uses yahoo detail-capable command', () => {
+  const source = fs.readFileSync('background/kiro/desktop-authorize-runner.js', 'utf8');
+
+  assert.match(source, /async function pollYahooKiroDesktopOtpCode\(/);
+  assert.match(source, /if \(mail\.provider === 'yahoo'\) \{\s*return pollYahooKiroDesktopOtpCode/);
+  assert.match(source, /type: 'YAHOO_CHECK_TOP_MESSAGE'/);
+  assert.match(source, /type: 'YAHOO_OPEN_TOP_MESSAGE'/);
+  assert.match(source, /type: 'YAHOO_READ_CURRENT_MESSAGE_CODE'/);
+  assert.match(source, /reloadIfSameUrl: true/);
+});

--- a/tests/mail-provider-utils.test.js
+++ b/tests/mail-provider-utils.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 
 const {
   HOTMAIL_PROVIDER,
+  inferMailProvider,
   YYDS_MAIL_PROVIDER,
   getIcloudForwardMailConfig,
   getIcloudForwardMailProviderOptions,
@@ -10,6 +11,7 @@ const {
   normalizeIcloudForwardMailProvider,
   normalizeIcloudTargetMailboxType,
   normalizeMailProvider,
+  withResolvedMailProvider,
 } = require('../mail-provider-utils.js');
 
 test('normalizeMailProvider accepts 126 and falls back to 163', () => {
@@ -47,6 +49,25 @@ test('getMailProviderConfig preserves the YYDS Mail provider sentinel', () => {
       provider: YYDS_MAIL_PROVIDER,
       label: 'YYDS Mail',
     }
+  );
+});
+
+test('mail provider utils infers effective provider from mail config shape', () => {
+  assert.equal(
+    inferMailProvider({ source: 'yahoo-mail', url: 'https://mail.yahoo.com/n/inbox/all' }, {}),
+    'yahoo'
+  );
+  assert.equal(
+    inferMailProvider({ label: 'Cloudflare Temp Email' }, {}),
+    'cloudflare-temp-email'
+  );
+  assert.equal(
+    inferMailProvider({}, { mailProvider: ' YAHOO ' }),
+    'yahoo'
+  );
+  assert.deepEqual(
+    withResolvedMailProvider({ source: 'yahoo-mail' }, {}),
+    { source: 'yahoo-mail', provider: 'yahoo' }
   );
 });
 

--- a/tests/sidepanel-yahoo-provider.test.js
+++ b/tests/sidepanel-yahoo-provider.test.js
@@ -1,0 +1,99 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const source = fs.readFileSync('sidepanel/sidepanel.js', 'utf8');
+const html = fs.readFileSync('sidepanel/sidepanel.html', 'utf8');
+
+function extractFunction(name) {
+  const markers = [`async function ${name}(`, `function ${name}(`];
+  const start = markers.map((marker) => source.indexOf(marker)).find((index) => index >= 0);
+  if (start < 0) throw new Error(`missing function ${name}`);
+
+  let parenDepth = 0;
+  let signatureEnded = false;
+  let braceStart = -1;
+  for (let i = start; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === '(') parenDepth += 1;
+    else if (ch === ')') {
+      parenDepth -= 1;
+      if (parenDepth === 0) signatureEnded = true;
+    } else if (ch === '{' && signatureEnded) {
+      braceStart = i;
+      break;
+    }
+  }
+
+  let depth = 0;
+  let end = braceStart;
+  for (; end < source.length; end += 1) {
+    const ch = source[end];
+    if (ch === '{') depth += 1;
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        end += 1;
+        break;
+      }
+    }
+  }
+  return source.slice(start, end);
+}
+
+test('sidepanel exposes yahoo provider and generator options', () => {
+  assert.match(html, /<option value="yahoo">Yahoo 邮箱 \(mail\.yahoo\.com\) 请把默认邮箱页面设置为ALL<\/option>/);
+  assert.match(html, /<option value="yahoo">Yahoo 临时邮箱<\/option>/);
+  assert.match(html, /<script src="\.\.\/yahoo-utils\.js"><\/script>/);
+});
+
+test('getSelectedEmailGenerator returns yahoo', () => {
+  const bundle = extractFunction('getSelectedEmailGenerator');
+  const api = new Function(`
+const selectEmailGenerator = { value: 'yahoo' };
+const GMAIL_ALIAS_GENERATOR = 'gmail-alias';
+const CUSTOM_EMAIL_POOL_GENERATOR = 'custom-pool';
+const YAHOO_GENERATOR = 'yahoo';
+${bundle}
+return { getSelectedEmailGenerator };
+`)();
+
+  assert.equal(api.getSelectedEmailGenerator(), 'yahoo');
+});
+
+test('getEmailGeneratorUiCopy returns yahoo copy', () => {
+  const bundle = extractFunction('getEmailGeneratorUiCopy');
+  const api = new Function(`
+const GMAIL_ALIAS_GENERATOR = 'gmail-alias';
+const CUSTOM_EMAIL_POOL_GENERATOR = 'custom-pool';
+const YAHOO_GENERATOR = 'yahoo';
+function getSelectedEmailGenerator() { return 'yahoo'; }
+function getCustomMailProviderUiCopy() { return null; }
+${bundle}
+return { getEmailGeneratorUiCopy };
+`)();
+
+  assert.deepEqual(api.getEmailGeneratorUiCopy(), {
+    buttonLabel: '创建别名',
+    placeholder: '点击创建 Yahoo 临时邮箱，或手动粘贴邮箱',
+    successVerb: '创建',
+    label: 'Yahoo 临时邮箱',
+  });
+});
+
+test('sidepanel contains yahoo login config and hint copy', () => {
+  assert.match(source, /\[YAHOO_PROVIDER\]: \{\s*label: 'Yahoo 邮箱',\s*url: 'https:\/\/mail\.yahoo\.com\/n\/inbox\/priority'/);
+  assert.match(source, /Yahoo 需要先手动登录/);
+  assert.match(source, /type: 'OPEN_MAIL_PROVIDER_LOGIN'/);
+  assert.match(source, /provider: selectMailProvider\?\.value \|\| latestState\?\.mailProvider/);
+});
+
+test('sidepanel shows yahoo mailbox credential rows in the mail provider block', () => {
+  assert.match(html, /id="row-yahoo-mail-email"/);
+  assert.match(html, /id="input-yahoo-mail-email"/);
+  assert.match(html, /id="row-yahoo-mail-password"/);
+  assert.match(html, /id="input-yahoo-mail-password"/);
+  assert.match(source, /yahooMailEmail: inputYahooMailEmail\?\.value\.trim\(\) \|\| ''/);
+  assert.match(source, /yahooMailPassword: inputYahooMailPassword\?\.value \|\| ''/);
+  assert.match(source, /rowYahooMailEmail\.style\.display = \(useYahooProvider \|\| selectedGenerator === yahooGenerator\) \? '' : 'none';/);
+});

--- a/tests/sidepanel-yahoo-provider.test.js
+++ b/tests/sidepanel-yahoo-provider.test.js
@@ -93,7 +93,8 @@ test('sidepanel shows yahoo mailbox credential rows in the mail provider block',
   assert.match(html, /id="input-yahoo-mail-email"/);
   assert.match(html, /id="row-yahoo-mail-password"/);
   assert.match(html, /id="input-yahoo-mail-password"/);
-  assert.match(source, /yahooMailEmail: inputYahooMailEmail\?\.value\.trim\(\) \|\| ''/);
+  assert.match(source, /yahooMailEmail: typeof inputYahooMailEmail !== 'undefined' && inputYahooMailEmail/);
+  assert.doesNotMatch(source, /yahooMailPassword: typeof inputYahooMailPassword !== 'undefined'/);
   assert.match(source, /yahooMailPassword: inputYahooMailPassword\?\.value \|\| ''/);
   assert.match(source, /rowYahooMailEmail\.style\.display = \(useYahooProvider \|\| selectedGenerator === yahooGenerator\) \? '' : 'none';/);
 });

--- a/tests/signup-page-yahoo-resend-guard.test.js
+++ b/tests/signup-page-yahoo-resend-guard.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+test('signup page keeps resend capability available for yahoo foreground refresh flow', () => {
+  const source = fs.readFileSync('content/signup-page.js', 'utf8');
+  assert.match(source, /async function resendVerificationCode\(step, timeout = 45000\)/);
+  assert.match(source, /simulateClick\(action\);/);
+  assert.doesNotMatch(source, /getCurrentMailProviderFromSession/);
+  assert.doesNotMatch(source, /Yahoo 模式禁止在认证页重新发送验证码/);
+});

--- a/tests/source-registry-yahoo.test.js
+++ b/tests/source-registry-yahoo.test.js
@@ -1,0 +1,32 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const source = fs.readFileSync('shared/source-registry.js', 'utf8');
+
+function loadRegistry() {
+  const globalScope = {};
+  const api = new Function('self', `${source}; return self.MultiPageSourceRegistry;`)(globalScope);
+  return api.createSourceRegistry();
+}
+
+test('source registry detects yahoo mail source and driver commands', () => {
+  const registry = loadRegistry();
+  assert.equal(registry.detectSourceFromLocation({
+    url: 'https://mail.yahoo.com/n/inbox/all?listFilter=ALL_INBOX',
+    hostname: 'mail.yahoo.com',
+  }), 'yahoo-mail');
+  assert.equal(registry.driverAcceptsCommand('yahoo-mail', 'YAHOO_CHECK_TOP_MESSAGE'), true);
+  assert.equal(registry.driverAcceptsCommand('yahoo-mail', 'YAHOO_CREATE_TEMP_ALIAS'), true);
+});
+
+test('source registry matches yahoo mail url family and blocks child-frame ready reports', () => {
+  const registry = loadRegistry();
+  assert.equal(registry.matchesSourceUrlFamily(
+    'yahoo-mail',
+    'https://mail.yahoo.com/n/inbox/all?listFilter=ALL_INBOX',
+    ''
+  ), true);
+  assert.equal(registry.shouldReportReadyForFrame('yahoo-mail', true), false);
+});
+

--- a/tests/source-registry-yahoo.test.js
+++ b/tests/source-registry-yahoo.test.js
@@ -18,6 +18,7 @@ test('source registry detects yahoo mail source and driver commands', () => {
   }), 'yahoo-mail');
   assert.equal(registry.driverAcceptsCommand('yahoo-mail', 'YAHOO_CHECK_TOP_MESSAGE'), true);
   assert.equal(registry.driverAcceptsCommand('yahoo-mail', 'YAHOO_CREATE_TEMP_ALIAS'), true);
+  assert.equal(registry.driverAcceptsCommand('yahoo-mail', 'YAHOO_LOGIN_WITH_CREDENTIALS'), true);
 });
 
 test('source registry matches yahoo mail url family and blocks child-frame ready reports', () => {
@@ -27,6 +28,10 @@ test('source registry matches yahoo mail url family and blocks child-frame ready
     'https://mail.yahoo.com/n/inbox/all?listFilter=ALL_INBOX',
     ''
   ), true);
+  assert.equal(registry.matchesSourceUrlFamily('yahoo-mail', 'https://login.yahoo.com/account/challenge/password', ''), true);
+  assert.equal(registry.detectSourceFromLocation({
+    url: 'https://guce.yahoo.com/consent',
+    hostname: 'guce.yahoo.com',
+  }), 'yahoo-mail');
   assert.equal(registry.shouldReportReadyForFrame('yahoo-mail', true), false);
 });
-

--- a/tests/verification-flow-yahoo.test.js
+++ b/tests/verification-flow-yahoo.test.js
@@ -1,0 +1,101 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const source = fs.readFileSync('background/verification-flow.js', 'utf8');
+const globalScope = {};
+const api = new Function('self', `${source}; return self.MultiPageBackgroundVerificationFlow;`)(globalScope);
+
+test('verification flow uses yahoo foreground top-message command', async () => {
+  const calls = [];
+  const helpers = api.createVerificationFlowHelpers({
+    addLog: async () => {},
+    buildVerificationPollPayload: (_step, state, overrides = {}) => ({
+      step: 4,
+      filterAfterTimestamp: 0,
+      targetEmail: state.email,
+      maxAttempts: 60,
+      intervalMs: 5000,
+      ...overrides,
+    }),
+    chrome: {
+      tabs: {
+        get: async () => ({ url: 'https://mail.yahoo.com/n/inbox/all?listFilter=ALL_INBOX' }),
+        remove: async () => {},
+        update: async () => {},
+      },
+    },
+    closeConflictingTabsForSource: async () => {},
+    CLOUDFLARE_TEMP_EMAIL_PROVIDER: 'cloudflare-temp-email',
+    CLOUD_MAIL_PROVIDER: 'cloudmail',
+    completeNodeFromBackground: async () => {},
+    confirmCustomVerificationStepBypassRequest: async () => ({}),
+    getNodeIdByStepForState: () => 'fetch-signup-code',
+    getHotmailVerificationPollConfig: () => ({}),
+    getHotmailVerificationRequestTimestamp: () => 0,
+    handleMail2925LimitReachedError: async (_step, err) => err,
+    getState: async () => ({ mailProvider: 'yahoo' }),
+    getTabId: async (sourceId) => (sourceId === 'signup-page' ? 1 : 2),
+    HOTMAIL_PROVIDER: 'hotmail-api',
+    isMail2925LimitReachedError: () => false,
+    isStopError: () => false,
+    isTabAlive: async () => true,
+    LUCKMAIL_PROVIDER: 'luckmail-api',
+    YYDS_MAIL_PROVIDER: 'yyds-mail',
+    MAIL_2925_VERIFICATION_INTERVAL_MS: 15000,
+    MAIL_2925_VERIFICATION_MAX_ATTEMPTS: 15,
+    pollCloudflareTempEmailVerificationCode: async () => ({}),
+    pollCloudMailVerificationCode: async () => ({}),
+    pollHotmailVerificationCode: async () => ({}),
+    pollLuckmailVerificationCode: async () => ({}),
+    pollYydsMailVerificationCode: async () => ({}),
+    reuseOrCreateTab: async () => 2,
+    sendToContentScript: async (_sourceId, message) => {
+      calls.push(['sendToContentScript', message]);
+      return {};
+    },
+    sendToContentScriptResilient: async () => ({}),
+    sendToMailContentScriptResilient: async (_mail, message) => {
+      calls.push(['sendToMailContentScriptResilient', message]);
+      return {
+        code: '123456',
+        emailTimestamp: 111,
+        freshnessMatched: true,
+        topMessageFingerprint: 'fp-1',
+      };
+    },
+    setNodeStatus: async () => {},
+    setState: async () => {},
+    sleepWithStop: async () => {},
+    throwIfStopped: () => {},
+    VERIFICATION_POLL_MAX_ROUNDS: 5,
+  });
+
+  const result = await helpers.pollFreshVerificationCode(
+    4,
+    { mailProvider: 'yahoo', email: 'user@yahoo.com' },
+    {
+      provider: 'yahoo',
+      source: 'yahoo-mail',
+      url: 'https://mail.yahoo.com/n/inbox/all?listFilter=ALL_INBOX',
+      label: 'Yahoo 邮箱',
+      inject: ['content/activation-utils.js', 'shared/source-registry.js', 'content/utils.js', 'content/yahoo-mail.js'],
+      injectSource: 'yahoo-mail',
+    },
+    {
+      intervalMs: 5000,
+      maxAttempts: 60,
+      refreshesBeforeResend: 5,
+      maxResendRequests: 0,
+      seedRejectedCodesFromState: false,
+    }
+  );
+
+  assert.equal(result.code, '123456');
+  assert.equal(calls.some(([, message]) => message.type === 'RESEND_VERIFICATION_CODE'), true);
+  const yahooCheck = calls.find(([, message]) => message.type === 'YAHOO_CHECK_TOP_MESSAGE');
+  assert.ok(yahooCheck);
+  assert.equal(yahooCheck[1].payload.yahooTopRowOnly, true);
+  assert.equal(yahooCheck[1].payload.filterAfterTimestamp, 0);
+});
+

--- a/tests/yahoo-mail-content.test.js
+++ b/tests/yahoo-mail-content.test.js
@@ -1,0 +1,349 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const source = fs.readFileSync('content/yahoo-mail.js', 'utf8');
+
+function loadYahooMailHelpers() {
+  class FakeHTMLElement {
+    constructor(attrs = {}, options = {}) {
+      this._attrs = { ...attrs };
+      this.dataset = { ...(options.dataset || {}) };
+      this._query = options.query || {};
+      this._queryAll = options.queryAll || [];
+      this.innerText = options.innerText || '';
+      this.textContent = options.textContent || this.innerText;
+      this._rect = options.rect || { width: 100, height: 20, top: 0, left: 0, right: 100, bottom: 20 };
+    }
+
+    getAttribute(name) {
+      return this._attrs[name] ?? null;
+    }
+
+    querySelector(selector) {
+      return this._query[selector] || null;
+    }
+
+    matches(selector) {
+      const testId = this.getAttribute('data-test-id') || '';
+      if (selector === '[data-test-id="message-list-item"]') {
+        return testId === 'message-list-item';
+      }
+      if (selector === '[data-test-id*="message-list-item"]') {
+        return testId.includes('message-list-item');
+      }
+      return false;
+    }
+
+    querySelectorAll() {
+      return this._queryAll;
+    }
+
+    getBoundingClientRect() {
+      return this._rect;
+    }
+  }
+
+  class FakeHTMLInputElement extends FakeHTMLElement {}
+  class FakeHTMLTextAreaElement extends FakeHTMLElement {}
+  class FakeSVGElement extends FakeHTMLElement {}
+  class FakeMouseEvent {}
+  class FakeInputEvent {}
+
+  const documentObject = {
+    body: { innerText: '', textContent: '' },
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    elementFromPoint: () => null,
+    documentElement: { clientWidth: 1920, clientHeight: 1080 },
+  };
+
+  const helpers = new Function(
+    'chrome', 'console', 'location', 'document', 'window', 'history', 'URL', 'log',
+    'HTMLElement', 'HTMLInputElement', 'HTMLTextAreaElement', 'SVGElement',
+    'MouseEvent', 'InputEvent', 'getComputedStyle',
+    `${source}; return { isYahooInboxPage, normalizeYahooFingerprintText, buildYahooTopMessageFingerprint, evaluateYahooTopMessageFreshness, extractVerificationCode, extractVerificationCodeWithPatterns, getRowText, getYahooRowFullText, extractSixDigitCodeFromLatestRow, getTopRowInlineCode, findTopMessageRow, isLikelyYahooMessageRow, findYahooMessageOpenTarget, getYahooMessageOpenClickPoint, isKiroYahooTopMessagePayload, handleKiroYahooTopMessageFastPath };`
+  )(
+    { runtime: { onMessage: { addListener: () => {} } } },
+    { log: () => {} },
+    { href: 'https://mail.yahoo.com/n/inbox/all', origin: 'https://mail.yahoo.com' },
+    documentObject,
+    { innerWidth: 1920, innerHeight: 1080 },
+    { length: 1, back: () => {} },
+    URL,
+    () => {},
+    FakeHTMLElement,
+    FakeHTMLInputElement,
+    FakeHTMLTextAreaElement,
+    FakeSVGElement,
+    FakeMouseEvent,
+    FakeInputEvent,
+    () => ({ display: 'block', visibility: 'visible' })
+  );
+
+  return {
+    ...helpers,
+    FakeHTMLElement,
+    documentObject,
+  };
+}
+
+test('yahoo mail content exposes dedicated top-message and alias commands', () => {
+  assert.match(source, /YAHOO_CHECK_TOP_MESSAGE/);
+  assert.match(source, /YAHOO_OPEN_TOP_MESSAGE/);
+  assert.match(source, /YAHOO_READ_CURRENT_MESSAGE_CODE/);
+  assert.match(source, /YAHOO_CREATE_TEMP_ALIAS/);
+  assert.match(source, /YAHOO_LEGACY_POLLING_DISABLED/);
+});
+
+test('yahoo mail content signals background when inbox or settings must be reopened', () => {
+  assert.match(source, /YAHOO_INBOX_REOPEN_REQUIRED::/);
+  assert.match(source, /YAHOO_SETTINGS_REOPEN_REQUIRED::/);
+  assert.doesNotMatch(source, /location\.href\s*=\s*YAHOO_INBOX_URL/);
+  assert.doesNotMatch(source, /location\.href\s*=\s*YAHOO_SETTINGS_URL/);
+});
+
+test('yahoo inbox detection accepts standard inbox urls with query strings', () => {
+  const { isYahooInboxPage } = loadYahooMailHelpers();
+  assert.equal(isYahooInboxPage('https://mail.yahoo.com/n/inbox/all?listFilter=ALL_INBOX'), true);
+  assert.equal(isYahooInboxPage('https://mail.yahoo.com/n/inbox/all?accountIds=abc'), true);
+  assert.equal(isYahooInboxPage('https://mail.yahoo.com/n/settings/2'), false);
+});
+
+test('yahoo fingerprint ignores volatile relative-time text changes on the same top mail', () => {
+  const { FakeHTMLElement, buildYahooTopMessageFingerprint } = loadYahooMailHelpers();
+  const row = new FakeHTMLElement(
+    { 'data-id': 'msg-1', 'data-test-id': 'row-1' },
+    {
+      query: {
+        'a[href]': { getAttribute: () => '/d/msg-1' },
+        'time, [datetime]': { getAttribute: () => '2026-04-26T01:23:45Z' },
+      },
+    }
+  );
+
+  const fp1 = buildYahooTopMessageFingerprint(row, 'OpenAI verification code 123456 1 minute ago', { code: '123456' }, 0);
+  const fp2 = buildYahooTopMessageFingerprint(row, 'OpenAI verification code 123456 2 minutes ago', { code: '123456' }, 0);
+  const fp3 = buildYahooTopMessageFingerprint(row, 'OpenAI verification code 123456 昨天 下午 3:21', { code: '123456' }, 0);
+
+  assert.equal(fp1, fp2);
+  assert.equal(fp2, fp3);
+});
+
+test('yahoo freshness rejects same top mail when only relative-time text changes', () => {
+  const { FakeHTMLElement, buildYahooTopMessageFingerprint, evaluateYahooTopMessageFreshness } = loadYahooMailHelpers();
+  const row = new FakeHTMLElement(
+    { 'data-id': 'msg-1', 'data-test-id': 'row-1' },
+    {
+      query: {
+        'a[href]': { getAttribute: () => '/d/msg-1' },
+        'time, [datetime]': { getAttribute: () => '2026-04-26T01:23:45Z' },
+      },
+    }
+  );
+
+  const previousTopMessageFingerprint = buildYahooTopMessageFingerprint(
+    row,
+    'OpenAI verification code 123456 1 minute ago',
+    { code: '123456' },
+    0
+  );
+
+  const freshness = evaluateYahooTopMessageFreshness(
+    row,
+    'OpenAI verification code 123456 2 minutes ago',
+    { code: '123456' },
+    1000,
+    {
+      previousTopMessageFingerprint,
+      previousAcceptedEmailTimestamp: 0,
+      requestedAt: 999999,
+      yahooTopRowOnly: true,
+    },
+    true
+  );
+
+  assert.equal(freshness.fingerprintChanged, false);
+  assert.equal(freshness.freshnessMatched, false);
+});
+
+test('yahoo freshness does not treat missing previous fingerprint as a fingerprint change', () => {
+  const { FakeHTMLElement, evaluateYahooTopMessageFreshness } = loadYahooMailHelpers();
+  const row = new FakeHTMLElement({ 'data-id': 'msg-3', 'data-test-id': 'row-3' });
+
+  const freshness = evaluateYahooTopMessageFreshness(
+    row,
+    'AWS Builder ID verification code 777888',
+    { code: '777888' },
+    0,
+    {
+      previousTopMessageFingerprint: '',
+      previousAcceptedEmailTimestamp: 0,
+      requestedAt: 0,
+      yahooTopRowOnly: true,
+    },
+    true
+  );
+
+  assert.equal(freshness.fingerprintChanged, false);
+  assert.equal(freshness.freshnessMatched, false);
+});
+
+test('yahoo top row detection ignores offscreen virtual rows and accepts Kiro AWS sender', () => {
+  const { FakeHTMLElement, findTopMessageRow, isLikelyYahooMessageRow } = loadYahooMailHelpers();
+  const offscreenOldRow = new FakeHTMLElement({}, {
+    innerText: 'ChatGPT 你的临时验证码 294070 6:42 PM',
+    rect: { width: 1000, height: 44, top: -180, left: 0, right: 1000, bottom: -136 },
+  });
+  const topKiroRow = new FakeHTMLElement({}, {
+    innerText: 'no-reply@signin.aws 验证您的 AWS 构建者 ID 电子邮件地址 11:20 PM',
+    rect: { width: 1000, height: 44, top: 72, left: 0, right: 1000, bottom: 116 },
+  });
+  const nextRow = new FakeHTMLElement({}, {
+    innerText: 'Amazon Web Services Response Required: Your Kiro Account 11:10 PM',
+    rect: { width: 1000, height: 44, top: 116, left: 0, right: 1000, bottom: 160 },
+  });
+
+  assert.equal(isLikelyYahooMessageRow(offscreenOldRow), false);
+  assert.equal(isLikelyYahooMessageRow(topKiroRow), true);
+  assert.equal(findTopMessageRow([offscreenOldRow, nextRow, topKiroRow]), topKiroRow);
+});
+
+test('yahoo row text extraction reads full hidden AWS snippet code before opening detail', () => {
+  const {
+    FakeHTMLElement,
+    getYahooRowFullText,
+    extractSixDigitCodeFromLatestRow,
+    getTopRowInlineCode,
+  } = loadYahooMailHelpers();
+  const snippet = new FakeHTMLElement({ id: 'email-snippet-2494' }, {
+    innerText: '',
+    textContent: '验证您的 AWS 构建者 ID 电子邮件地址 您好！ 请输入以下验证码。验证码： 762101 此验证码将在发送后 30 分钟过期。',
+  });
+  const subjectSnippet = new FakeHTMLElement({ id: 'email-subject-snippet-2494' }, {
+    innerText: '',
+    textContent: '验证您的 AWS 构建者 ID 电子邮件地址·验证您的 AWS 构建者 ID 电子邮件地址 您好！ 感谢您开始使用 AWS 构建者 ID！ AWS 构建者 ID 是...',
+  });
+  const row = new FakeHTMLElement({}, {
+    innerText: 'no-reply@signin.aws 验证您的 AWS 构建者 ID 电子邮件地址 11:47 PM',
+    textContent: 'no-reply@signin.aws 验证您的 AWS 构建者 ID 电子邮件地址 验证码： 762101 11:47 PM',
+    queryAll: [subjectSnippet, snippet],
+  });
+
+  const fullText = getYahooRowFullText(row);
+
+  assert.match(fullText, /验证码： 762101/);
+  assert.equal(extractSixDigitCodeFromLatestRow(row).code, '762101');
+  assert.equal(getTopRowInlineCode(row).code, '762101');
+});
+
+test('yahoo kiro top-message fast path extracts AWS code from visible row snippet', () => {
+  const {
+    FakeHTMLElement,
+    documentObject,
+    isKiroYahooTopMessagePayload,
+    handleKiroYahooTopMessageFastPath,
+  } = loadYahooMailHelpers();
+  const snippet = new FakeHTMLElement({ id: 'email-snippet-2494' }, {
+    textContent: '验证您的 AWS 构建者 ID 电子邮件地址 您好！ 请输入以下验证码。验证码： 762101 此验证码将在发送后 30 分钟过期。',
+  });
+  const row = new FakeHTMLElement({ 'data-test-id': 'message-list-item' }, {
+    innerText: 'no-reply@signin.aws 验证您的 AWS 构建者 ID 电子邮件地址 11:47 PM',
+    textContent: 'no-reply@signin.aws 验证您的 AWS 构建者 ID 电子邮件地址 验证码： 762101 11:47 PM',
+    rect: { width: 1000, height: 44, top: 80, left: 0, right: 1000, bottom: 124 },
+    queryAll: [snippet],
+  });
+  documentObject.querySelectorAll = () => [row];
+
+  const payload = {
+    flowId: 'kiro',
+    yahooTopRowOnly: true,
+    requestedAt: Date.now(),
+    yahooFreshnessSkewMs: 180000,
+    senderFilters: ['no-reply@signin.aws'],
+    subjectFilters: ['aws'],
+    codePatterns: [
+      { source: '(?:verification\\s*code|验证码|Your code is|code is)[：:\\s]*(\\d{6})', flags: 'gi' },
+    ],
+  };
+  const result = handleKiroYahooTopMessageFastPath(4, payload);
+
+  assert.equal(isKiroYahooTopMessagePayload(payload), true);
+  assert.equal(result.code, '762101');
+  assert.equal(result.preview.includes('验证码： 762101'), true);
+});
+
+test('yahoo content script creates disposable aliases without pre-cleaning old aliases', () => {
+  assert.doesNotMatch(source, /const deletedAliases = await deleteAllOldAliases\(\);/);
+  assert.match(source, /跳过旧一次性邮箱清理，直接创建新邮箱/);
+  assert.match(source, /const remainingAliases = collectAliasItems\(\)/);
+  assert.match(source, /deletedAliases:\s*\[\]/);
+});
+
+test('yahoo alias creation uses disposable count instead of scanning for new alias text', () => {
+  assert.match(source, /function getDisposableAliasUsageCount\(/);
+  assert.match(source, /function inferYahooAliasFromExistingAliases\(/);
+  assert.match(source, /等待一次性邮箱数量增加/);
+  assert.match(source, /afterUsage\?\.used > beforeUsage\.used/);
+  assert.doesNotMatch(source, /等待新别名出现在页面中/);
+  assert.doesNotMatch(source, /attempt < 15 && !createdAlias/);
+});
+
+test('yahoo top-message flow opens matching mail details when the row preview has no code', () => {
+  assert.match(source, /async function openTopRowAndReadVerificationCode\(/);
+  assert.match(source, /顶部目标邮件行未直接露出验证码，正在点进邮件详情读取正文/);
+  assert.match(source, /rowCode = await openTopRowAndReadVerificationCode\(topRow, rowText, payload\)/);
+  assert.match(source, /message-detail-required/);
+  assert.match(source, /顶部目标邮件需要打开详情读取正文/);
+  assert.match(source, /async function handleOpenTopMessage\(step, payload = \{\}\)/);
+  assert.match(source, /async function handleReadCurrentMessageCode\(step, payload = \{\}\)/);
+});
+
+test('yahoo message open click target prefers subject area and avoids left controls', () => {
+  const { FakeHTMLElement, findYahooMessageOpenTarget, getYahooMessageOpenClickPoint } = loadYahooMailHelpers();
+  const subject = new FakeHTMLElement({ 'data-test-id': 'message-list-item-subject' }, {
+    innerText: '验证您的 AWS 构建者 ID 电子邮件地址',
+    rect: { width: 650, height: 24, top: 80, left: 310, right: 960, bottom: 104 },
+  });
+  const row = new FakeHTMLElement({}, {
+    innerText: 'no-reply@signin.aws 验证您的 AWS 构建者 ID 电子邮件地址 11:27 PM',
+    rect: { width: 1120, height: 44, top: 68, left: 0, right: 1120, bottom: 112 },
+    query: {
+      '[data-test-id="message-list-item"]': null,
+      '[data-test-id*="message-list-item"]': subject,
+    },
+  });
+
+  const target = findYahooMessageOpenTarget(row);
+  const point = getYahooMessageOpenClickPoint(row, target);
+
+  assert.equal(target, subject);
+  assert.equal(point.x > 430, true);
+  assert.equal(point.y >= 86 && point.y <= 98, true);
+});
+
+test('yahoo verification extraction supports runtime Kiro code patterns', () => {
+  const { extractVerificationCodeWithPatterns } = loadYahooMailHelpers();
+  const code = extractVerificationCodeWithPatterns('Response Required: Your Kiro Account\nYour code is 847392', {
+    codePatterns: [
+      { source: '(?:verification\\s*code|验证码|Your code is|code is)[：:\\s]*(\\d{6})', flags: 'gi' },
+    ],
+  });
+
+  assert.equal(code, '847392');
+});
+
+test('yahoo content script diagnoses missing add button and alias limit separately', () => {
+  assert.match(source, /function buildYahooAliasCreateDiagnostics\(/);
+  assert.match(source, /新建一次性电子邮件地址/);
+  assert.match(source, /新增一次性电子邮件地址/);
+  assert.match(source, /Yahoo 页面提示已达到一次性邮箱\/别名上限/);
+  assert.match(source, /当前已按要求不自动清理旧别名/);
+});
+
+test('yahoo content script can fill login credentials from sidepanel card', () => {
+  assert.match(source, /YAHOO_LOGIN_WITH_CREDENTIALS/);
+  assert.match(source, /function findYahooLoginEmailInput\(\)/);
+  assert.match(source, /function findYahooLoginPasswordInput\(\)/);
+  assert.match(source, /async function handleYahooLoginWithCredentials\(payload = \{\}\)/);
+});

--- a/tests/yahoo-mail-delete-flow.test.js
+++ b/tests/yahoo-mail-delete-flow.test.js
@@ -1,0 +1,17 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const source = fs.readFileSync('content/yahoo-mail.js', 'utf8');
+
+test('yahoo alias delete flow still exists for disposable alias management', () => {
+  assert.match(source, /function clickDeleteForAliasItem\(/);
+  assert.match(source, /const beforeCount = aliases\.length/);
+  assert.match(source, /currentAliases\.length < beforeCount/);
+});
+
+test('yahoo verification flow no longer deletes inbox mails', () => {
+  assert.doesNotMatch(source, /async function deleteMailRow\(/);
+  assert.doesNotMatch(source, /async function deleteOldVerificationRows\(/);
+  assert.doesNotMatch(source, /删除已排除验证码/);
+});

--- a/yahoo-utils.js
+++ b/yahoo-utils.js
@@ -1,0 +1,121 @@
+(function yahooUtilsModule(root, factory) {
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = factory();
+    return;
+  }
+
+  root.YahooUtils = factory();
+})(typeof self !== 'undefined' ? self : globalThis, function createYahooUtils() {
+  const YAHOO_PROVIDER = 'yahoo';
+  const YAHOO_GENERATOR = 'yahoo';
+
+  function normalizeText(value) {
+    return String(value || '').replace(/\s+/g, ' ').trim().toLowerCase();
+  }
+
+  function normalizeTimestamp(value) {
+    if (!value) return 0;
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value > 0 ? value : 0;
+    }
+    const timestamp = Date.parse(String(value || ''));
+    return Number.isFinite(timestamp) ? timestamp : 0;
+  }
+
+  function extractYahooVerificationCode(text) {
+    const source = String(text || '');
+    const matchCn = source.match(/(?:代码为|验证码[^0-9]*?)[\s：:]*(\d{6})/i);
+    if (matchCn) return matchCn[1];
+
+    const matchOpenAi = source.match(/(?:your\s+chatgpt\s+code\s+is|verification\s+code|code(?:\s+is)?)[^0-9]{0,16}(\d{6})/i);
+    if (matchOpenAi) return matchOpenAi[1];
+
+    const matchStandalone = source.match(/\b(\d{6})\b/);
+    return matchStandalone ? matchStandalone[1] : null;
+  }
+
+  function normalizeYahooAlias(item = {}) {
+    const safeItem = item && typeof item === 'object' ? item : {};
+    const email = String(safeItem.email || safeItem.alias || safeItem.address || '').trim().toLowerCase();
+    if (!email || !email.includes('@')) {
+      return null;
+    }
+    return {
+      id: String(safeItem.id || safeItem.aliasId || email).trim(),
+      email,
+      label: String(safeItem.label || '').trim(),
+      note: String(safeItem.note || '').trim(),
+      active: safeItem.active !== false,
+      used: Boolean(safeItem.used),
+      preserved: Boolean(safeItem.preserved),
+      createdAt: safeItem.createdAt || safeItem.created_at || null,
+    };
+  }
+
+  function normalizeYahooAliasList(list = []) {
+    return (Array.isArray(list) ? list : [])
+      .map((item) => normalizeYahooAlias(item))
+      .filter(Boolean);
+  }
+
+  function pickReusableYahooAlias(list = []) {
+    return normalizeYahooAliasList(list).find((item) => item.active && !item.used) || null;
+  }
+
+  function messageMatchesYahooFilters(message = {}, filters = {}) {
+    const afterTimestamp = normalizeTimestamp(filters.afterTimestamp);
+    const senderFilters = (filters.senderFilters || []).map(normalizeText).filter(Boolean);
+    const subjectFilters = (filters.subjectFilters || []).map(normalizeText).filter(Boolean);
+    const excludedCodes = new Set((filters.excludeCodes || []).map((item) => String(item || '').trim()).filter(Boolean));
+
+    const sender = normalizeText(message.sender || message.from || '');
+    const subject = normalizeText(message.subject || '');
+    const body = normalizeText(message.bodyText || message.preview || message.body || '');
+    const receivedAt = normalizeTimestamp(message.receivedAt || message.receivedDateTime || message.timestamp);
+
+    if (afterTimestamp && receivedAt && receivedAt < afterTimestamp) {
+      return null;
+    }
+
+    const senderMatch = senderFilters.length === 0
+      ? true
+      : senderFilters.some((item) => sender.includes(item) || body.includes(item));
+    const subjectMatch = subjectFilters.length === 0
+      ? true
+      : subjectFilters.some((item) => subject.includes(item) || body.includes(item));
+
+    if (!senderMatch && !subjectMatch) {
+      return null;
+    }
+
+    const code = extractYahooVerificationCode([subject, body, sender].join(' '));
+    if (!code || excludedCodes.has(code)) {
+      return null;
+    }
+
+    return {
+      code,
+      message,
+      receivedAt,
+    };
+  }
+
+  function pickYahooVerificationMessage(messages = [], filters = {}) {
+    return (Array.isArray(messages) ? messages : [])
+      .map((message) => messageMatchesYahooFilters(message, filters))
+      .filter(Boolean)
+      .sort((left, right) => right.receivedAt - left.receivedAt)[0] || null;
+  }
+
+  return {
+    YAHOO_PROVIDER,
+    YAHOO_GENERATOR,
+    extractYahooVerificationCode,
+    normalizeText,
+    normalizeTimestamp,
+    normalizeYahooAlias,
+    normalizeYahooAliasList,
+    pickReusableYahooAlias,
+    pickYahooVerificationMessage,
+  };
+});


### PR DESCRIPTION
## 概述
本 PR 新增 Yahoo 邮箱服务，支持通过 Yahoo 邮箱自动创建临时别名邮箱，并将返回的最终邮箱地址回填到注册流程中，同时接入 OpenAI 与 Kiro 的验证码读取链路。

## 主要变更
新增 Yahoo Mail 工具与内容脚本：
- 新增 `yahoo-utils.js`
- 新增 `content/yahoo-mail.js`
- 支持 Yahoo 邮箱登录态检测和账号密码自动登录
- 支持创建 Yahoo 临时别名邮箱

侧边栏新增 Yahoo 邮箱服务选项：
- 新增 Yahoo 邮箱 provider
- 新增 Yahoo 临时邮箱 generator
- 新增 Yahoo 账号 / 密码配置卡片
- 登录按钮通过后台打开 Yahoo，并可自动填写账号密码
- Yahoo 选项提示默认邮箱页面需要设置为 ALL

注册/自动运行流程集成：
- 手动“获取邮箱”、步骤 2、自动运行均可创建 Yahoo 临时别名并回填
- 创建别名完成后恢复到 ChatGPT 注册页继续提交邮箱
- 步骤 4/8 验证码轮询支持 Yahoo 邮箱
- Yahoo 取码使用收件箱顶部邮件优先策略
- 顶部邮件未直接露出验证码时，会点进邮件正文读取
- Yahoo 验证码流程不删除收件箱邮件

Kiro 流程集成：
- Kiro 注册邮箱验证码接入 Yahoo 专用取码链路
- Kiro 桌面授权验证码接入 Yahoo 专用取码链路
- 如果 1 分钟内未收到 Kiro 验证码，会回到 Kiro 页面点击重新发送，再切回 Yahoo 收件箱读取新邮件
- 支持 Yahoo 顶部 AWS/Kiro 邮件识别与正文读码

兼容现有逻辑：
- 保留现有侧边栏、HeroSMS、source registry、operation delay 等行为
- 补充 Yahoo provider、verification、Kiro、sidepanel、source registry 相关测试覆盖

## 测试
- `node --check background.js`
- `node --check background/generated-email-helpers.js`
- `node --check background/verification-flow.js`
- `node --check background/kiro/register-runner.js`
- `node --check background/kiro/desktop-authorize-runner.js`
- `node --check content/yahoo-mail.js`
- `node --check content/kiro/register-page.js`
- `node --check sidepanel/sidepanel.js`
- Yahoo/Kiro 相关测试：69/69 通过
- 侧边栏/source registry/operation delay 回归测试：33/33 通过