### PR TITLE
feat(email): 使用英文名日期时间生成邮箱前缀

### DIFF
--- a/background.js
+++ b/background.js
@@ -40,6 +40,7 @@ importScripts(
   'flows/kiro/background/desktop-client.js',
   'flows/kiro/background/desktop-authorize-runner.js',
   'flows/kiro/background/publisher-kiro-rs.js',
+  'background/email-local-part-helpers.js',
   'background/generated-email-helpers.js',
   'background/signup-flow-helpers.js',
   'background/mail-rule-registry.js',

--- a/background/cloudmail-provider.js
+++ b/background/cloudmail-provider.js
@@ -1,6 +1,6 @@
 (function cloudMailProviderModule(root, factory) {
-  root.MultiPageBackgroundCloudMailProvider = factory();
-})(typeof self !== 'undefined' ? self : globalThis, function createCloudMailProviderModule() {
+  root.MultiPageBackgroundCloudMailProvider = factory(root);
+})(typeof self !== 'undefined' ? self : globalThis, function createCloudMailProviderModule(root = globalThis) {
   function createCloudMailProvider(deps = {}) {
     const {
       addLog = async () => {},
@@ -18,6 +18,7 @@
       normalizeCloudMailDomains,
       normalizeCloudMailMailApiMessages,
       persistRegistrationEmailState = null,
+      buildRandomNameDateTimeLocalPart = root.MultiPageEmailLocalPartHelpers?.buildRandomNameDateTimeLocalPart,
       pickVerificationMessageWithTimeFallback,
       setEmailState = async () => {},
       setPersistentSettings = async () => {},
@@ -172,46 +173,10 @@
       return chars.join('');
     }
 
-    const ENGLISH_NAME_PREFIXES = [
-      'james', 'john', 'robert', 'michael', 'william', 'david', 'richard', 'joseph',
-      'thomas', 'charles', 'mary', 'patricia', 'jennifer', 'linda', 'elizabeth',
-      'barbara', 'susan', 'jessica', 'sarah', 'karen', 'daniel', 'matthew',
-      'anthony', 'mark', 'donald', 'steven', 'paul', 'andrew', 'joshua', 'kevin',
-      'brian', 'george', 'edward', 'ronald', 'timothy', 'jason', 'jeffrey', 'ryan',
-      'jacob', 'gary', 'nicholas', 'eric', 'jonathan', 'stephen', 'larry', 'justin',
-      'scott', 'brandon', 'benjamin', 'samuel', 'gregory', 'alexander', 'patrick',
-      'frank', 'raymond', 'jack', 'dennis', 'jerry', 'tyler', 'aaron', 'henry',
-      'douglas', 'peter', 'adam', 'zachary', 'nathan', 'walter', 'harold', 'kyle',
-      'carl', 'arthur', 'gerald', 'roger', 'alice', 'emma', 'olivia', 'sophia',
-      'isabella', 'mia', 'amelia', 'harper', 'evelyn', 'abigail', 'emily', 'ella',
-      'scarlett', 'grace', 'chloe', 'victoria', 'riley', 'aria', 'lily', 'nora',
-    ];
-
-    function pickRandomEnglishNamePrefix() {
-      return ENGLISH_NAME_PREFIXES[Math.floor(Math.random() * ENGLISH_NAME_PREFIXES.length)] || 'james';
-    }
-
-    function formatCloudMailDateTimeDigits(date = new Date()) {
-      const current = new Date(date);
-      if (Number.isNaN(current.getTime())) {
-        return '';
-      }
-      const year = String(current.getFullYear());
-      const month = String(current.getMonth() + 1).padStart(2, '0');
-      const day = String(current.getDate()).padStart(2, '0');
-      const hour = String(current.getHours()).padStart(2, '0');
-      const minute = String(current.getMinutes()).padStart(2, '0');
-      const second = String(current.getSeconds()).padStart(2, '0');
-      return `${year}${month}${day}${hour}${minute}${second}`;
-    }
-
     function buildCloudMailNameDateTimeLocalPart(date = new Date()) {
-      const normalizedName = pickRandomEnglishNamePrefix();
-      const dateTimeDigits = formatCloudMailDateTimeDigits(date);
-      if (!dateTimeDigits) {
-        return '';
-      }
-      return `${normalizedName}${dateTimeDigits}`;
+      return typeof buildRandomNameDateTimeLocalPart === 'function'
+        ? buildRandomNameDateTimeLocalPart(date)
+        : '';
     }
 
     async function fetchCloudMailAddress(state, options = {}) {

--- a/background/cloudmail-provider.js
+++ b/background/cloudmail-provider.js
@@ -172,6 +172,48 @@
       return chars.join('');
     }
 
+    const ENGLISH_NAME_PREFIXES = [
+      'james', 'john', 'robert', 'michael', 'william', 'david', 'richard', 'joseph',
+      'thomas', 'charles', 'mary', 'patricia', 'jennifer', 'linda', 'elizabeth',
+      'barbara', 'susan', 'jessica', 'sarah', 'karen', 'daniel', 'matthew',
+      'anthony', 'mark', 'donald', 'steven', 'paul', 'andrew', 'joshua', 'kevin',
+      'brian', 'george', 'edward', 'ronald', 'timothy', 'jason', 'jeffrey', 'ryan',
+      'jacob', 'gary', 'nicholas', 'eric', 'jonathan', 'stephen', 'larry', 'justin',
+      'scott', 'brandon', 'benjamin', 'samuel', 'gregory', 'alexander', 'patrick',
+      'frank', 'raymond', 'jack', 'dennis', 'jerry', 'tyler', 'aaron', 'henry',
+      'douglas', 'peter', 'adam', 'zachary', 'nathan', 'walter', 'harold', 'kyle',
+      'carl', 'arthur', 'gerald', 'roger', 'alice', 'emma', 'olivia', 'sophia',
+      'isabella', 'mia', 'amelia', 'harper', 'evelyn', 'abigail', 'emily', 'ella',
+      'scarlett', 'grace', 'chloe', 'victoria', 'riley', 'aria', 'lily', 'nora',
+    ];
+
+    function pickRandomEnglishNamePrefix() {
+      return ENGLISH_NAME_PREFIXES[Math.floor(Math.random() * ENGLISH_NAME_PREFIXES.length)] || 'james';
+    }
+
+    function formatCloudMailDateTimeDigits(date = new Date()) {
+      const current = new Date(date);
+      if (Number.isNaN(current.getTime())) {
+        return '';
+      }
+      const year = String(current.getFullYear());
+      const month = String(current.getMonth() + 1).padStart(2, '0');
+      const day = String(current.getDate()).padStart(2, '0');
+      const hour = String(current.getHours()).padStart(2, '0');
+      const minute = String(current.getMinutes()).padStart(2, '0');
+      const second = String(current.getSeconds()).padStart(2, '0');
+      return `${year}${month}${day}${hour}${minute}${second}`;
+    }
+
+    function buildCloudMailNameDateTimeLocalPart(date = new Date()) {
+      const normalizedName = pickRandomEnglishNamePrefix();
+      const dateTimeDigits = formatCloudMailDateTimeDigits(date);
+      if (!dateTimeDigits) {
+        return '';
+      }
+      return `${normalizedName}${dateTimeDigits}`;
+    }
+
     async function fetchCloudMailAddress(state, options = {}) {
       throwIfStopped();
       const latestState = state || await getState();
@@ -180,8 +222,9 @@
         requireToken: true,
         requireDomain: true,
       });
-      const requestedLocal = String(options.localPart || options.name || '').trim().toLowerCase()
-        || generateCloudMailAliasLocalPart();
+      const explicitLocalPart = String(options.localPart || '').trim().toLowerCase();
+      const nameDateTimeLocalPart = buildCloudMailNameDateTimeLocalPart(options.date);
+      const requestedLocal = explicitLocalPart || nameDateTimeLocalPart || generateCloudMailAliasLocalPart();
       const address = `${requestedLocal}@${ensuredConfig.domain}`.toLowerCase();
       const payload = { list: [{ email: address }] };
       try {
@@ -318,6 +361,7 @@
     }
 
     return {
+      buildCloudMailNameDateTimeLocalPart,
       ensureCloudMailConfig,
       ensureCloudMailToken,
       fetchCloudMailAddress,

--- a/background/cloudmail-provider.js
+++ b/background/cloudmail-provider.js
@@ -223,8 +223,9 @@
         requireDomain: true,
       });
       const explicitLocalPart = String(options.localPart || '').trim().toLowerCase();
+      const legacyNameLocalPart = String(options.name || '').trim().toLowerCase();
       const nameDateTimeLocalPart = buildCloudMailNameDateTimeLocalPart(options.date);
-      const requestedLocal = explicitLocalPart || nameDateTimeLocalPart || generateCloudMailAliasLocalPart();
+      const requestedLocal = explicitLocalPart || legacyNameLocalPart || nameDateTimeLocalPart || generateCloudMailAliasLocalPart();
       const address = `${requestedLocal}@${ensuredConfig.domain}`.toLowerCase();
       const payload = { list: [{ email: address }] };
       try {

--- a/background/email-local-part-helpers.js
+++ b/background/email-local-part-helpers.js
@@ -1,0 +1,51 @@
+(function attachEmailLocalPartHelpers(root, factory) {
+  root.MultiPageEmailLocalPartHelpers = factory();
+})(typeof self !== 'undefined' ? self : globalThis, function createEmailLocalPartHelpersModule() {
+  const ENGLISH_NAME_PREFIXES = [
+    'james', 'john', 'robert', 'michael', 'william', 'david', 'richard', 'joseph',
+    'thomas', 'charles', 'mary', 'patricia', 'jennifer', 'linda', 'elizabeth',
+    'barbara', 'susan', 'jessica', 'sarah', 'karen', 'daniel', 'matthew',
+    'anthony', 'mark', 'donald', 'steven', 'paul', 'andrew', 'joshua', 'kevin',
+    'brian', 'george', 'edward', 'ronald', 'timothy', 'jason', 'jeffrey', 'ryan',
+    'jacob', 'gary', 'nicholas', 'eric', 'jonathan', 'stephen', 'larry', 'justin',
+    'scott', 'brandon', 'benjamin', 'samuel', 'gregory', 'alexander', 'patrick',
+    'frank', 'raymond', 'jack', 'dennis', 'jerry', 'tyler', 'aaron', 'henry',
+    'douglas', 'peter', 'adam', 'zachary', 'nathan', 'walter', 'harold', 'kyle',
+    'carl', 'arthur', 'gerald', 'roger', 'alice', 'emma', 'olivia', 'sophia',
+    'isabella', 'mia', 'amelia', 'harper', 'evelyn', 'abigail', 'emily', 'ella',
+    'scarlett', 'grace', 'chloe', 'victoria', 'riley', 'aria', 'lily', 'nora',
+  ];
+
+  function pickRandomEnglishNamePrefix() {
+    return ENGLISH_NAME_PREFIXES[Math.floor(Math.random() * ENGLISH_NAME_PREFIXES.length)] || 'james';
+  }
+
+  function formatDateTimeDigits(date = new Date()) {
+    const current = new Date(date);
+    if (Number.isNaN(current.getTime())) {
+      return '';
+    }
+    const year = String(current.getFullYear());
+    const month = String(current.getMonth() + 1).padStart(2, '0');
+    const day = String(current.getDate()).padStart(2, '0');
+    const hour = String(current.getHours()).padStart(2, '0');
+    const minute = String(current.getMinutes()).padStart(2, '0');
+    const second = String(current.getSeconds()).padStart(2, '0');
+    const millisecond = String(current.getMilliseconds()).padStart(3, '0');
+    return `${year}${month}${day}${hour}${minute}${second}${millisecond}`;
+  }
+
+  function buildRandomNameDateTimeLocalPart(date = new Date()) {
+    const dateTimeDigits = formatDateTimeDigits(date);
+    if (!dateTimeDigits) {
+      return '';
+    }
+    return `${pickRandomEnglishNamePrefix()}${dateTimeDigits}`;
+  }
+
+  return {
+    buildRandomNameDateTimeLocalPart,
+    formatDateTimeDigits,
+    pickRandomEnglishNamePrefix,
+  };
+});

--- a/background/generated-email-helpers.js
+++ b/background/generated-email-helpers.js
@@ -1,6 +1,6 @@
 (function attachGeneratedEmailHelpers(root, factory) {
-  root.MultiPageGeneratedEmailHelpers = factory();
-})(typeof self !== 'undefined' ? self : globalThis, function createGeneratedEmailHelpersModule() {
+  root.MultiPageGeneratedEmailHelpers = factory(root);
+})(typeof self !== 'undefined' ? self : globalThis, function createGeneratedEmailHelpersModule(root = globalThis) {
   function createGeneratedEmailHelpers(deps = {}) {
     const {
       addLog,
@@ -23,6 +23,7 @@
       normalizeEmailGenerator,
       isGeneratedAliasProvider,
       persistRegistrationEmailState = null,
+      buildRandomNameDateTimeLocalPart = root.MultiPageEmailLocalPartHelpers?.buildRandomNameDateTimeLocalPart,
       reuseOrCreateTab,
       sendToContentScript,
       setEmailState,
@@ -56,48 +57,6 @@
       }
 
       return chars.join('');
-    }
-
-    const ENGLISH_NAME_PREFIXES = [
-      'james', 'john', 'robert', 'michael', 'william', 'david', 'richard', 'joseph',
-      'thomas', 'charles', 'mary', 'patricia', 'jennifer', 'linda', 'elizabeth',
-      'barbara', 'susan', 'jessica', 'sarah', 'karen', 'daniel', 'matthew',
-      'anthony', 'mark', 'donald', 'steven', 'paul', 'andrew', 'joshua', 'kevin',
-      'brian', 'george', 'edward', 'ronald', 'timothy', 'jason', 'jeffrey', 'ryan',
-      'jacob', 'gary', 'nicholas', 'eric', 'jonathan', 'stephen', 'larry', 'justin',
-      'scott', 'brandon', 'benjamin', 'samuel', 'gregory', 'alexander', 'patrick',
-      'frank', 'raymond', 'jack', 'dennis', 'jerry', 'tyler', 'aaron', 'henry',
-      'douglas', 'peter', 'adam', 'zachary', 'nathan', 'walter', 'harold', 'kyle',
-      'carl', 'arthur', 'gerald', 'roger', 'alice', 'emma', 'olivia', 'sophia',
-      'isabella', 'mia', 'amelia', 'harper', 'evelyn', 'abigail', 'emily', 'ella',
-      'scarlett', 'grace', 'chloe', 'victoria', 'riley', 'aria', 'lily', 'nora',
-    ];
-
-    function pickRandomEnglishNamePrefix() {
-      return ENGLISH_NAME_PREFIXES[Math.floor(Math.random() * ENGLISH_NAME_PREFIXES.length)] || 'james';
-    }
-
-    function formatLocalDateTimeDigits(date = new Date()) {
-      const current = new Date(date);
-      if (Number.isNaN(current.getTime())) {
-        return '';
-      }
-      const year = String(current.getFullYear());
-      const month = String(current.getMonth() + 1).padStart(2, '0');
-      const day = String(current.getDate()).padStart(2, '0');
-      const hour = String(current.getHours()).padStart(2, '0');
-      const minute = String(current.getMinutes()).padStart(2, '0');
-      const second = String(current.getSeconds()).padStart(2, '0');
-      return `${year}${month}${day}${hour}${minute}${second}`;
-    }
-
-    function buildRandomNameDateTimeLocalPart(date = new Date()) {
-      const normalizedPrefix = pickRandomEnglishNamePrefix();
-      const dateTimeDigits = formatLocalDateTimeDigits(date);
-      if (!dateTimeDigits) {
-        return '';
-      }
-      return `${normalizedPrefix}${dateTimeDigits}`;
     }
 
     async function fetchCloudflareEmail(state, options = {}) {

--- a/background/generated-email-helpers.js
+++ b/background/generated-email-helpers.js
@@ -58,6 +58,48 @@
       return chars.join('');
     }
 
+    const ENGLISH_NAME_PREFIXES = [
+      'james', 'john', 'robert', 'michael', 'william', 'david', 'richard', 'joseph',
+      'thomas', 'charles', 'mary', 'patricia', 'jennifer', 'linda', 'elizabeth',
+      'barbara', 'susan', 'jessica', 'sarah', 'karen', 'daniel', 'matthew',
+      'anthony', 'mark', 'donald', 'steven', 'paul', 'andrew', 'joshua', 'kevin',
+      'brian', 'george', 'edward', 'ronald', 'timothy', 'jason', 'jeffrey', 'ryan',
+      'jacob', 'gary', 'nicholas', 'eric', 'jonathan', 'stephen', 'larry', 'justin',
+      'scott', 'brandon', 'benjamin', 'samuel', 'gregory', 'alexander', 'patrick',
+      'frank', 'raymond', 'jack', 'dennis', 'jerry', 'tyler', 'aaron', 'henry',
+      'douglas', 'peter', 'adam', 'zachary', 'nathan', 'walter', 'harold', 'kyle',
+      'carl', 'arthur', 'gerald', 'roger', 'alice', 'emma', 'olivia', 'sophia',
+      'isabella', 'mia', 'amelia', 'harper', 'evelyn', 'abigail', 'emily', 'ella',
+      'scarlett', 'grace', 'chloe', 'victoria', 'riley', 'aria', 'lily', 'nora',
+    ];
+
+    function pickRandomEnglishNamePrefix() {
+      return ENGLISH_NAME_PREFIXES[Math.floor(Math.random() * ENGLISH_NAME_PREFIXES.length)] || 'james';
+    }
+
+    function formatLocalDateTimeDigits(date = new Date()) {
+      const current = new Date(date);
+      if (Number.isNaN(current.getTime())) {
+        return '';
+      }
+      const year = String(current.getFullYear());
+      const month = String(current.getMonth() + 1).padStart(2, '0');
+      const day = String(current.getDate()).padStart(2, '0');
+      const hour = String(current.getHours()).padStart(2, '0');
+      const minute = String(current.getMinutes()).padStart(2, '0');
+      const second = String(current.getSeconds()).padStart(2, '0');
+      return `${year}${month}${day}${hour}${minute}${second}`;
+    }
+
+    function buildRandomNameDateTimeLocalPart(date = new Date()) {
+      const normalizedPrefix = pickRandomEnglishNamePrefix();
+      const dateTimeDigits = formatLocalDateTimeDigits(date);
+      if (!dateTimeDigits) {
+        return '';
+      }
+      return `${normalizedPrefix}${dateTimeDigits}`;
+    }
+
     async function fetchCloudflareEmail(state, options = {}) {
       throwIfStopped();
       const latestState = state || await getState();
@@ -158,7 +200,9 @@
         requireAdminAuth: true,
         requireDomain: true,
       });
-      const requestedName = String(options.localPart || options.name || '').trim().toLowerCase() || generateCloudflareAliasLocalPart();
+      const requestedName = String(options.localPart || options.name || '').trim().toLowerCase()
+        || buildRandomNameDateTimeLocalPart(options.date)
+        || generateCloudflareAliasLocalPart();
       const payload = {
         enablePrefix: true,
         enableRandomSubdomain: Boolean(config.useRandomSubdomain),
@@ -365,6 +409,7 @@
       fetchCloudflareTempEmailAddress,
       fetchDuckEmail,
       fetchGeneratedEmail,
+      buildRandomNameDateTimeLocalPart,
       generateCloudflareAliasLocalPart,
       requestCloudflareTempEmailJson,
     };

--- a/tests/background-generated-email-module.test.js
+++ b/tests/background-generated-email-module.test.js
@@ -3,13 +3,15 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 
 function loadGeneratedEmailHelpersApi() {
+  const localPartHelpersSource = fs.readFileSync('background/email-local-part-helpers.js', 'utf8');
   const source = fs.readFileSync('background/generated-email-helpers.js', 'utf8');
   const globalScope = {};
-  return new Function('self', `${source}; return self.MultiPageGeneratedEmailHelpers;`)(globalScope);
+  return new Function('self', `${localPartHelpersSource}; ${source}; return self.MultiPageGeneratedEmailHelpers;`)(globalScope);
 }
 
 test('background imports generated email helper module', () => {
   const source = fs.readFileSync('background.js', 'utf8');
+  assert.match(source, /importScripts\([\s\S]*'background\/email-local-part-helpers\.js'/);
   assert.match(source, /importScripts\([\s\S]*'background\/generated-email-helpers\.js'/);
 });
 
@@ -481,7 +483,7 @@ test('generated email helper uses the regular temp email domain when random subd
     name: requests[0].body.name,
     domain: 'mail.example.com',
   });
-  assert.match(requests[0].body.name, /^[a-z]+[0-9]{14}$/);
+  assert.match(requests[0].body.name, /^[a-z]+[0-9]{17}$/);
 });
 
 test('generated email helper requests random subdomain creation while preserving the returned address', async () => {

--- a/tests/background-generated-email-module.test.js
+++ b/tests/background-generated-email-module.test.js
@@ -481,7 +481,7 @@ test('generated email helper uses the regular temp email domain when random subd
     name: requests[0].body.name,
     domain: 'mail.example.com',
   });
-  assert.match(requests[0].body.name, /^[a-z0-9]+$/);
+  assert.match(requests[0].body.name, /^[a-z]+[0-9]{14}$/);
 });
 
 test('generated email helper requests random subdomain creation while preserving the returned address', async () => {

--- a/tests/cloudmail-provider.test.js
+++ b/tests/cloudmail-provider.test.js
@@ -1,6 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
+require('../background/email-local-part-helpers.js');
 require('../background/cloudmail-provider.js');
 
 function createProviderApi(options = {}) {
@@ -276,8 +277,8 @@ test('fetchCloudMailAddress builds random english name plus current date-time lo
     cloudMailDomain: 'example.com',
   };
   const email = await api.fetchCloudMailAddress(state, {
-    date: '2026-05-17T08:09:10',
+    date: '2026-05-17T08:09:10.123',
   });
 
-  assert.match(email, /^[a-z]+20260517080910@example\.com$/);
+  assert.match(email, /^[a-z]+20260517080910123@example\.com$/);
 });

--- a/tests/cloudmail-provider.test.js
+++ b/tests/cloudmail-provider.test.js
@@ -228,3 +228,56 @@ test('fetchCloudMailAddress preserves phone identity through the shared persiste
     },
   ]);
 });
+
+test('fetchCloudMailAddress builds random english name plus current date-time local part by default', async () => {
+  const api = globalThis.MultiPageBackgroundCloudMailProvider.createCloudMailProvider({
+    addLog: async () => {},
+    buildCloudMailHeaders: () => ({}),
+    CLOUD_MAIL_DEFAULT_PAGE_SIZE: 20,
+    CLOUD_MAIL_GENERATOR: 'cloudmail',
+    CLOUD_MAIL_PROVIDER: 'cloudmail',
+    fetchImpl: async (url) => {
+      if (String(url).includes('/api/public/addUser')) {
+        return {
+          ok: true,
+          text: async () => JSON.stringify({ code: 200 }),
+        };
+      }
+      return {
+        ok: true,
+        text: async () => JSON.stringify({ code: 200, data: { token: 'token' } }),
+      };
+    },
+    getCloudMailTokenFromResponse: () => 'token',
+    getState: async () => ({}),
+    joinCloudMailUrl: (baseUrl, path) => `${baseUrl}${path}`,
+    normalizeCloudMailAddress: (value) => String(value || '').trim().toLowerCase(),
+    normalizeCloudMailBaseUrl: (value) => String(value || '').trim(),
+    normalizeCloudMailDomain: (value) => String(value || '').trim(),
+    normalizeCloudMailDomains: (values) => values || [],
+    normalizeCloudMailMailApiMessages: () => [],
+    persistRegistrationEmailState: async () => {},
+    pickVerificationMessageWithTimeFallback: () => ({
+      match: null,
+      usedRelaxedFilters: false,
+      usedTimeFallback: false,
+    }),
+    setEmailState: async () => {},
+    setPersistentSettings: async () => {},
+    sleepWithStop: async () => {},
+    throwIfStopped: () => {},
+  });
+
+  const state = {
+    cloudMailBaseUrl: 'https://mail.example.com',
+    cloudMailAdminEmail: 'admin@example.com',
+    cloudMailAdminPassword: 'secret',
+    cloudMailToken: 'token',
+    cloudMailDomain: 'example.com',
+  };
+  const email = await api.fetchCloudMailAddress(state, {
+    date: '2026-05-17T08:09:10',
+  });
+
+  assert.match(email, /^[a-z]+20260517080910@example\.com$/);
+});


### PR DESCRIPTION
- 将 CloudMail 默认邮箱前缀改为随机英文名加日期时间

- 将 Cloudflare Temp Email 默认 name 同步改为英文名日期时间格式

- 补充并更新相关测试，覆盖 14 位日期时间前缀断言