### PR TITLE
Clear signup phone identity before starting the next auto-run round

### DIFF
--- a/background.js
+++ b/background.js
@@ -10934,6 +10934,72 @@ async function reportCompletedStepSideEffectError(step, error) {
   return reportCompletedNodeSideEffectError(getNodeIdByStepForState(step, state), error);
 }
 
+function getSignupPhoneIdentityValue(state = {}) {
+  const accountIdentifierType = String(state?.accountIdentifierType || '').trim().toLowerCase();
+  return String(
+    state?.signupPhoneNumber
+    || state?.signupPhoneCompletedActivation?.phoneNumber
+    || state?.signupPhoneActivation?.phoneNumber
+    || (accountIdentifierType === 'phone' ? state?.accountIdentifier : '')
+    || ''
+  ).trim();
+}
+
+function signupPhoneIdentityValuesMatch(left = '', right = '') {
+  const leftRaw = String(left || '').trim();
+  const rightRaw = String(right || '').trim();
+  if (!leftRaw || !rightRaw) {
+    return false;
+  }
+  if (leftRaw === rightRaw) {
+    return true;
+  }
+  const leftDigits = leftRaw.replace(/\D+/g, '');
+  const rightDigits = rightRaw.replace(/\D+/g, '');
+  return Boolean(leftDigits && rightDigits && leftDigits === rightDigits);
+}
+
+async function clearSignupPhoneIdentityAfterSuccessfulFlow(completionState = {}, options = {}) {
+  const completedPhone = getSignupPhoneIdentityValue(completionState);
+  const latestState = await getState();
+  const currentPhone = getSignupPhoneIdentityValue(latestState);
+  const currentIdentifierType = String(latestState?.accountIdentifierType || '').trim().toLowerCase();
+  const hasCurrentPhoneIdentity = Boolean(
+    currentPhone
+    || latestState?.signupPhoneActivation
+    || latestState?.signupPhoneCompletedActivation
+    || currentIdentifierType === 'phone'
+  );
+
+  if (!hasCurrentPhoneIdentity) {
+    return { cleared: false, reason: 'empty' };
+  }
+
+  if (completedPhone && currentPhone && !signupPhoneIdentityValuesMatch(completedPhone, currentPhone)) {
+    return { cleared: false, reason: 'changed' };
+  }
+
+  const updates = {
+    phoneNumber: '',
+    signupPhoneNumber: '',
+    signupPhoneActivation: null,
+    signupPhoneCompletedActivation: null,
+    signupPhoneVerificationRequestedAt: null,
+    signupPhoneVerificationPurpose: '',
+  };
+  if (currentIdentifierType === 'phone') {
+    updates.accountIdentifierType = null;
+    updates.accountIdentifier = '';
+  }
+
+  await setState(updates);
+  broadcastDataUpdate(updates);
+  await addLog('手机号注册：流程成功后已清空本轮注册手机号，避免下一轮复用。', 'ok', {
+    nodeId: options?.nodeId || 'platform-verify',
+  });
+  return { cleared: true, phoneNumber: currentPhone || completedPhone };
+}
+
 async function runCompletedNodeSideEffects(nodeId, payload, completionState, lastNodeId) {
   await handleNodeData(nodeId, payload);
   if (nodeId === lastNodeId) {
@@ -10966,6 +11032,11 @@ async function completeNodeFromBackground(nodeId, payload = {}) {
   await addLog('已完成', 'ok', { nodeId: normalizedNodeId });
 
   if (normalizedNodeId === lastNodeId) {
+    if (typeof clearSignupPhoneIdentityAfterSuccessfulFlow === 'function') {
+      await clearSignupPhoneIdentityAfterSuccessfulFlow(latestState, {
+        nodeId: normalizedNodeId,
+      });
+    }
     notifyNodeComplete(normalizedNodeId, payload);
     void runCompletedNodeSideEffects(normalizedNodeId, payload, completionState, lastNodeId)
       .catch((error) => reportCompletedNodeSideEffectError(normalizedNodeId, error));

--- a/tests/background-step-completion.test.js
+++ b/tests/background-step-completion.test.js
@@ -51,23 +51,31 @@ function extractFunction(name) {
   return source.slice(start, end);
 }
 
-function createApi(events, lastNodeId = 'platform-verify') {
-  return new Function('events', 'lastNodeId', `
+function createApi(events, lastNodeId = 'platform-verify', initialState = {}) {
+  return new Function('events', 'lastNodeId', 'initialState', `
 let stopRequested = false;
 const LOG_PREFIX = '[test]';
+let currentState = { nodeStatuses: {}, accountContributionEnabled: true, ...initialState };
 const STOP_ERROR_MESSAGE = '流程已被用户停止。';
 function getErrorMessage(error) {
   return error?.message || String(error || '');
 }
 async function getState() {
   events.push({ type: 'getState' });
-  return { nodeStatuses: {}, accountContributionEnabled: true };
+  return currentState;
 }
 function getLastNodeIdForState() {
   return lastNodeId;
 }
 async function setNodeStatus(nodeId, status) {
   events.push({ type: 'status', nodeId, status });
+}
+async function setState(updates) {
+  currentState = { ...currentState, ...updates };
+  events.push({ type: 'setState', updates });
+}
+function broadcastDataUpdate(updates) {
+  events.push({ type: 'broadcast', updates });
 }
 async function addLog(message, level, options = {}) {
   events.push({ type: 'log', message, level, options });
@@ -89,11 +97,14 @@ async function handleNodeData(nodeId, payload) {
 async function appendAndBroadcastAccountRunRecord(status, state) {
   events.push({ type: 'record', status, state });
 }
+${extractFunction('getSignupPhoneIdentityValue')}
+${extractFunction('signupPhoneIdentityValuesMatch')}
+${extractFunction('clearSignupPhoneIdentityAfterSuccessfulFlow')}
 ${extractFunction('runCompletedNodeSideEffects')}
 ${extractFunction('reportCompletedNodeSideEffectError')}
 ${extractFunction('completeNodeFromBackground')}
-return { completeNodeFromBackground };
-`)(events, lastNodeId);
+return { completeNodeFromBackground, getCurrentState: () => currentState };
+`)(events, lastNodeId, initialState);
 }
 
 test('completeNodeFromBackground releases final node before slow post-completion side effects', async () => {
@@ -123,4 +134,28 @@ test('completeNodeFromBackground keeps non-final node data handling before compl
   const types = events.map((event) => event.type);
   assert.equal(types.indexOf('handle-done') < types.indexOf('notify'), true);
   assert.equal(types.includes('record'), false);
+});
+
+test('completeNodeFromBackground clears signup phone identity before releasing final node', async () => {
+  const events = [];
+  const api = createApi(events, 'platform-verify', {
+    accountIdentifierType: 'phone',
+    accountIdentifier: '+56979206303',
+    signupPhoneNumber: '+56979206303',
+    signupPhoneActivation: { activationId: 'active', phoneNumber: '+56979206303' },
+    signupPhoneCompletedActivation: { activationId: 'done', phoneNumber: '+56979206303' },
+    signupPhoneVerificationRequestedAt: 123,
+    signupPhoneVerificationPurpose: 'login',
+  });
+
+  await api.completeNodeFromBackground('platform-verify', { localhostUrl: 'http://localhost:1455/auth/callback?code=ok' });
+
+  const types = events.map((event) => event.type);
+  assert.equal(types.indexOf('setState') < types.indexOf('notify'), true);
+  assert.equal(types.indexOf('broadcast') < types.indexOf('notify'), true);
+  assert.equal(api.getCurrentState().signupPhoneNumber, '');
+  assert.equal(api.getCurrentState().signupPhoneActivation, null);
+  assert.equal(api.getCurrentState().signupPhoneCompletedActivation, null);
+  assert.equal(api.getCurrentState().accountIdentifierType, null);
+  assert.equal(api.getCurrentState().accountIdentifier, '');
 });


### PR DESCRIPTION
## 问题背景

手机号注册链路在第 12 步 `platform-verify` 成功后，会马上把最终节点标记为完成并释放自动运行的完成信号。此时后续成功收尾逻辑仍然可能在后台异步执行，例如：

- 标记 / 删除 iCloud Hide My Email 别名
- 标记当前邮箱或邮箱池账号为已用
- 关闭 localhost callback 残留标签页
- 写入账号运行记录

实际运行日志中可以看到上一轮成功收尾和下一轮启动交错发生：第 12 步成功后，下一轮已经开始执行第 1 步，而上一轮的 iCloud 自动删除仍在几秒后继续输出日志。

在这种时间窗口里，手机号注册运行态可能还保留在 `chrome.storage.session` 中，包括：

- `signupPhoneNumber`
- `signupPhoneActivation`
- `signupPhoneCompletedActivation`
- `signupPhoneVerificationRequestedAt`
- `signupPhoneVerificationPurpose`
- `accountIdentifierType: "phone"`
- `accountIdentifier`

如果下一轮启动得很快，或者用户在成功后停止流程并手动从第 7 步继续，这些旧手机号状态就可能被后续 OAuth 手机号登录路径继续读取，导致下一轮复用上一轮已经完成注册的手机号。

## 根因分析

`completeNodeFromBackground()` 对最终节点采用的是“先释放完成信号，再异步执行收尾副作用”的设计：

1. 最终节点被标记为 `completed`
2. 立即调用 `notifyNodeComplete(...)`
3. 自动运行控制器收到完成信号后可以进入下一轮
4. `runCompletedNodeSideEffects(...)` 在后台继续处理成功后的收尾逻辑

这个设计可以避免最终节点被慢收尾阻塞，但也意味着“必须在下一轮可见之前清掉的运行态”不能放在异步收尾里处理。

手机号注册身份正好属于这种运行态：它只应该在同一轮内用于注册后 OAuth 登录和绑定邮箱，不应该跨成功轮次保留给下一轮使用。

## 解决方案

新增最终节点释放前的同步清理逻辑：`clearSignupPhoneIdentityAfterSuccessfulFlow()`。

当 `completeNodeFromBackground()` 判断当前节点是流程最后一个节点时，会在 `notifyNodeComplete(...)` 之前先清空本轮手机号注册身份：

- `phoneNumber`
- `signupPhoneNumber`
- `signupPhoneActivation`
- `signupPhoneCompletedActivation`
- `signupPhoneVerificationRequestedAt`
- `signupPhoneVerificationPurpose`

如果当前账号身份仍然是手机号身份，还会同步清空：

- `accountIdentifierType`
- `accountIdentifier`

清理完成后才释放最终节点完成信号，因此下一轮自动运行不会再读到上一轮手机号注册身份。

## 安全性细节

这个清理逻辑有几个保护点：

1. **保留成功记录所需的手机号快照**

   `completionState` 仍然是在清理前读取的快照，后续 `appendAndBroadcastAccountRunRecord('success', completionState)` 仍然可以记录本轮成功账号的手机号身份。也就是说，运行态被清掉，但账号历史不会丢失本轮手机号信息。

2. **避免误清新手机号**

   如果完成时快照里的手机号和当前 state 里的手机号都存在，但二者不一致，清理函数会跳过，避免在极端并发情况下清掉已经被其它流程写入的新手机号身份。

3. **支持格式差异匹配**

   手机号匹配同时支持原始字符串匹配和仅数字匹配，避免 `+56...`、空格、括号等格式差异导致同一个手机号被误判为不同。

4. **不等待慢收尾**

   iCloud 删除等慢操作仍然保留在异步收尾里，不会重新阻塞最终节点；本 PR 只把“必须在下一轮开始前完成”的手机号运行态清理前移。

5. **不修改发布版本号**

   本 PR 只修改运行态清理和测试，不调整 `manifest.json` 版本，避免把发布版本管理混入 bugfix。

## 用户可见变化

手机号注册流程成功后，日志会出现：

```text
手机号注册：流程成功后已清空本轮注册手机号，避免下一轮复用。
```

这表示当前轮手机号身份已经在下一轮开始前被清空。

## 测试

新增测试覆盖最终节点完成路径，验证：

- 最终节点在释放 `notifyNodeComplete` 前先清空手机号注册身份
- 清理会广播状态更新
- `signupPhoneNumber`、`signupPhoneActivation`、`signupPhoneCompletedActivation` 被清空
- 手机号类型的 `accountIdentifierType` / `accountIdentifier` 被清空
- 原有“最终节点慢收尾不阻塞完成信号”的行为仍然保留

已运行：

```powershell
node --test tests\background-step-completion.test.js
node --test tests\auto-run-fresh-attempt-reset.test.js
npm.cmd test
```

全量测试结果：

```text
1271 pass
```
