### PR TITLE
feat: 新增 Plus 自助开通渠道与自定义 URL 接码服务商

### DIFF
--- a/background.js
+++ b/background.js
@@ -23,6 +23,7 @@ importScripts(
   'phone-sms/providers/five-sim.js',
   'phone-sms/providers/nexsms.js',
   'phone-sms/providers/madao.js',
+  'phone-sms/providers/custom-url.js',
   'phone-sms/providers/registry.js',
   'background/phone-verification-flow.js',
   'background/account-run-history.js',
@@ -728,7 +729,11 @@ const PLUS_PAYMENT_METHOD_PAYPAL = 'paypal';
 const PLUS_PAYMENT_METHOD_PAYPAL_HOSTED = 'paypal-hosted';
 const PLUS_PAYMENT_METHOD_NONE = 'none';
 const PLUS_PAYMENT_METHOD_GPC_HELPER = 'gpc-helper';
-const DEFAULT_PLUS_PAYMENT_METHOD = PLUS_PAYMENT_METHOD_GPC_HELPER;
+const PLUS_PAYMENT_METHOD_AUTO = 'plus-auto';
+const DEFAULT_PLUS_PAYMENT_METHOD = PLUS_PAYMENT_METHOD_AUTO;
+const DEFAULT_AUTO_BASE_URL = (typeof self !== 'undefined' && self.GpcUtils?.DEFAULT_AUTO_BASE_URL)
+  || 'https://auto.1iiu.com';
+const DEFAULT_AUTO_TIMEOUT_SECONDS = 900;
 const DEFAULT_PLUS_HOSTED_CHECKOUT_OAUTH_DELAY_SECONDS = 3;
 const DISPLAY_TIMEZONE = 'Asia/Shanghai';
 const MICROSOFT_TOKEN_DNR_RULE_ID = 1001;
@@ -841,6 +846,10 @@ function normalizePlusPaymentMethod(value = '') {
   }
   if (normalized === PLUS_PAYMENT_METHOD_GPC_HELPER) {
     return PLUS_PAYMENT_METHOD_GPC_HELPER;
+  }
+  const autoValue = typeof PLUS_PAYMENT_METHOD_AUTO !== 'undefined' ? PLUS_PAYMENT_METHOD_AUTO : 'plus-auto';
+  if (normalized === autoValue || normalized === 'pix' || normalized === 'pix_plus' || normalized === 'pixplus') {
+    return autoValue;
   }
   return PLUS_PAYMENT_METHOD_PAYPAL;
 }
@@ -1319,6 +1328,12 @@ const PERSISTED_SETTING_DEFAULTS = {
   gpcCardStatus: '',
   gpcPageStatus: '',
   gpcPageStatusText: '',
+  autoCdk: '',
+  autoTimeoutSeconds: DEFAULT_AUTO_TIMEOUT_SECONDS,
+  autoOrderId: '',
+  autoJobId: '',
+  autoOrderState: '',
+  autoPaymentStatus: '',
   autoRunSkipFailures: false,
   autoRunFallbackThreadIntervalMinutes: 0,
   operationDelayEnabled: true,
@@ -1429,6 +1444,8 @@ const PERSISTED_SETTING_DEFAULTS = {
   madaoReusePhone: true,
   madaoMinPrice: '',
   madaoMaxPrice: '',
+  customUrlSmsPool: '',
+  customUrlSmsPoolCursor: 0,
   phonePreferredActivation: null,
 };
 
@@ -2052,6 +2069,10 @@ function normalizePlusPaymentMethod(value = '') {
   }
   if (normalized === PLUS_PAYMENT_METHOD_GPC_HELPER) {
     return PLUS_PAYMENT_METHOD_GPC_HELPER;
+  }
+  if (typeof PLUS_PAYMENT_METHOD_AUTO !== 'undefined'
+    && (normalized === PLUS_PAYMENT_METHOD_AUTO || normalized === 'pix' || normalized === 'pix_plus' || normalized === 'pixplus')) {
+    return PLUS_PAYMENT_METHOD_AUTO;
   }
   return PLUS_PAYMENT_METHOD_PAYPAL;
 }
@@ -3373,6 +3394,21 @@ function normalizePersistentSettingValue(key, value) {
     case 'gpcBalanceUpdatedAt':
     case 'gpcRemainingUses':
       return Math.max(0, Number(value) || 0);
+    case 'autoCdk':
+      return self.GpcUtils?.normalizeAutoCdk
+        ? self.GpcUtils.normalizeAutoCdk(value)
+        : String(value || '').trim();
+    case 'autoTimeoutSeconds': {
+      const numeric = Math.floor(Number(value));
+      return Number.isFinite(numeric) && numeric > 0
+        ? Math.min(3600, Math.max(30, numeric))
+        : DEFAULT_AUTO_TIMEOUT_SECONDS;
+    }
+    case 'autoOrderId':
+    case 'autoJobId':
+    case 'autoOrderState':
+    case 'autoPaymentStatus':
+      return String(value || '').trim();
     case 'autoRunSkipFailures':
       return Boolean(value);
     case 'operationDelayEnabled':
@@ -3580,6 +3616,12 @@ function normalizePersistentSettingValue(key, value) {
     case 'madaoMinPrice':
     case 'madaoMaxPrice':
       return normalizeMaDaoPrice(value);
+    case 'customUrlSmsPool':
+      return String(value || '');
+    case 'customUrlSmsPoolCursor': {
+      const cursor = Math.floor(Number(value));
+      return Number.isFinite(cursor) && cursor > 0 ? cursor : 0;
+    }
     case 'phonePreferredActivation':
       return normalizePhonePreferredActivation(value);
     default:

--- a/background/message-router.js
+++ b/background/message-router.js
@@ -689,6 +689,9 @@
       if (normalized === 'gpc-helper') {
         return 'gpc-helper';
       }
+      if (normalized === 'plus-auto' || normalized === 'pix' || normalized === 'pix_plus' || normalized === 'pixplus') {
+        return 'plus-auto';
+      }
       return 'paypal';
     }
 
@@ -702,6 +705,9 @@
       }
       if (method === 'gpc-helper') {
         return 'GPC';
+      }
+      if (method === 'plus-auto') {
+        return 'Plus 自动充值';
       }
       return 'PayPal';
     }

--- a/background/phone-verification-flow.js
+++ b/background/phone-verification-flow.js
@@ -1395,6 +1395,8 @@
       'nexSmsBaseUrl',
       'nexSmsCountryOrder',
       'nexSmsServiceCode',
+      'customUrlSmsPool',
+      'customUrlSmsPoolCursor',
       'phoneVerificationReplacementLimit',
       'phoneCodeWaitSeconds',
       'phoneCodeTimeoutWindows',

--- a/core/flow-kernel/settings-schema.js
+++ b/core/flow-kernel/settings-schema.js
@@ -504,8 +504,8 @@
             input?.plusPaymentMethod
             ?? currentFlow.plus?.plusPaymentMethod
             ?? defaultOpenAiPlus.plusPaymentMethod
-            ?? 'paypal-hosted'
-          ).trim() || defaultOpenAiPlus.plusPaymentMethod || 'paypal-hosted',
+            ?? 'plus-auto'
+          ).trim() || defaultOpenAiPlus.plusPaymentMethod || 'plus-auto',
           plusAccountAccessStrategy: normalizePlusAccountAccessStrategy(
             input?.plusAccountAccessStrategy
             ?? currentFlow.plus?.plusAccountAccessStrategy
@@ -753,7 +753,7 @@
       next.phoneVerificationEnabled = Boolean(openaiState.signup?.phoneVerificationEnabled);
       next.phoneSignupReloginAfterBindEmailEnabled = Boolean(openaiState.signup?.phoneSignupReloginAfterBindEmailEnabled);
       next.plusModeEnabled = Boolean(openaiState.plus?.plusModeEnabled);
-      next.plusPaymentMethod = openaiState.plus?.plusPaymentMethod || 'paypal-hosted';
+      next.plusPaymentMethod = openaiState.plus?.plusPaymentMethod || 'plus-auto';
       next.plusAccountAccessStrategy = openaiState.plus?.plusAccountAccessStrategy || 'oauth';
       next.hostedCheckoutVerificationUrl = openaiState.plus?.hostedCheckoutVerificationUrl || '';
       next.hostedCheckoutPhoneNumber = openaiState.plus?.hostedCheckoutPhoneNumber || '';

--- a/flows/openai/background/steps/create-plus-checkout.js
+++ b/flows/openai/background/steps/create-plus-checkout.js
@@ -10,6 +10,10 @@
   const PLUS_PAYMENT_METHOD_PAYPAL_HOSTED = 'paypal-hosted';
 
   const PLUS_PAYMENT_METHOD_GPC_HELPER = 'gpc-helper';
+  const PLUS_PAYMENT_METHOD_AUTO = 'plus-auto';
+  const DEFAULT_AUTO_BASE_URL = 'https://auto.1iiu.com';
+  const AUTO_REDEEM_PATH = '/api/v1/redeem';
+  const AUTO_REQUEST_TIMEOUT_MS = 30000;
   const LOCAL_CHECKOUT_PROXY_HEALTH_URL = 'http://127.0.0.1:21988/health';
   const LOCAL_CHECKOUT_PROXY_URL = 'socks5://127.0.0.1:21987';
   const LOCAL_CHECKOUT_PROXY_SETTINGS_SCOPE = 'regular';
@@ -284,6 +288,9 @@ function FindProxyForURL(url, host) {
       if (normalized === PLUS_PAYMENT_METHOD_GPC_HELPER) {
         return PLUS_PAYMENT_METHOD_GPC_HELPER;
       }
+      if (normalized === PLUS_PAYMENT_METHOD_AUTO || normalized === 'pix' || normalized === 'pix_plus' || normalized === 'pixplus') {
+        return PLUS_PAYMENT_METHOD_AUTO;
+      }
       return PLUS_PAYMENT_METHOD_PAYPAL;
     }
 
@@ -291,6 +298,9 @@ function FindProxyForURL(url, host) {
       const paymentMethod = normalizePlusPaymentMethod(state?.plusPaymentMethod);
       if (paymentMethod === PLUS_PAYMENT_METHOD_GPC_HELPER) {
         return 'GPC 订阅页';
+      }
+      if (paymentMethod === PLUS_PAYMENT_METHOD_AUTO) {
+        return 'Plus 自动充值';
       }
       if (paymentMethod === PLUS_PAYMENT_METHOD_PAYPAL_HOSTED) {
         return 'PayPal 无卡直绑';
@@ -302,6 +312,9 @@ function FindProxyForURL(url, host) {
       const paymentMethod = normalizePlusPaymentMethod(method);
       if (paymentMethod === PLUS_PAYMENT_METHOD_GPC_HELPER) {
         return 'GPC';
+      }
+      if (paymentMethod === PLUS_PAYMENT_METHOD_AUTO) {
+        return 'Plus 自动充值';
       }
       if (paymentMethod === PLUS_PAYMENT_METHOD_PAYPAL_HOSTED) {
         return 'PayPal 无卡直绑';
@@ -1701,10 +1714,95 @@ function FindProxyForURL(url, host) {
       });
     }
 
+    function resolveAutoCdk(state = {}) {
+      const rootScope = typeof self !== 'undefined' ? self : globalThis;
+      const cardKey = rootScope.GpcUtils?.normalizeAutoCdk
+        ? rootScope.GpcUtils.normalizeAutoCdk(state?.autoCdk)
+        : String(state?.autoCdk || '').trim();
+      if (!cardKey) {
+        throw new Error('步骤 6：Plus 自动充值模式缺少卡密，请先在侧边栏填写 Plus 自动充值卡密。');
+      }
+      return cardKey;
+    }
+
+    async function readSessionForAutoCheckout() {
+      const sessionTabId = await openFreshChatGptTabForCheckoutCreate({ active: false });
+      try {
+        return await readSessionFromChatGptSessionTab(sessionTabId);
+      } finally {
+        if (chrome?.tabs?.remove && Number.isInteger(sessionTabId)) {
+          await chrome.tabs.remove(sessionTabId).catch(() => {});
+        }
+      }
+    }
+
+    async function executeAutoCheckoutCreate(state = {}) {
+      const cardKey = resolveAutoCdk(state);
+      // Plus 自动充值接口地址固定使用内置端点，不接受用户自定义。
+      const redeemUrl = `${DEFAULT_AUTO_BASE_URL}${AUTO_REDEEM_PATH}`;
+      await addLog('发起 Plus 自动充值：正在从 ChatGPT 获取完整 session...', 'info');
+      const session = await readSessionForAutoCheckout();
+      const accessToken = String(session?.accessToken || '').trim();
+      if (!session || !accessToken) {
+        throw new Error('发起 Plus 自动充值：获取 ChatGPT session 失败。');
+      }
+
+      await addLog('发起 Plus 自动充值：正在调用充值接口提交订单（/api/v1/redeem）...', 'info');
+      const { response, data } = await fetchJsonWithTimeout(redeemUrl, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          cdk: cardKey,
+          access_token: JSON.stringify(session),
+        }),
+      }, AUTO_REQUEST_TIMEOUT_MS);
+
+      if (!response?.ok) {
+        const detail = String(data?.error || data?.message || data?.detail || `HTTP ${response?.status || 0}`).trim();
+        throw new Error(`发起 Plus 自动充值失败：${detail}`);
+      }
+      const orderId = String(data?.order_id ?? data?.orderId ?? '').trim();
+      if (!orderId) {
+        throw new Error(`发起 Plus 自动充值返回不可用响应：${JSON.stringify(data || {})}`);
+      }
+      const jobId = String(data?.job_id ?? data?.jobId ?? '').trim();
+      const orderState = String(data?.state || '').trim();
+      const remaining = Number(data?.remaining);
+
+      await setState({
+        plusCheckoutSource: PLUS_PAYMENT_METHOD_AUTO,
+        plusCheckoutCountry: 'US',
+        plusCheckoutCurrency: 'USD',
+        autoOrderId: orderId,
+        autoJobId: jobId,
+        autoOrderState: orderState || 'queued',
+        autoPaymentStatus: '',
+      });
+      // 注意：此处仅代表订单已提交（通常为 queued/排队中），充值尚未完成；
+      // 真正的成功判定在下一步「等待 Plus 自动充值完成」轮询订单状态后给出。
+      await addLog(
+        `发起 Plus 自动充值：订单已提交（order_id=${orderId}${jobId ? `, job_id=${jobId}` : ''}${orderState ? `, 状态=${orderState}` : ''}${Number.isFinite(remaining) ? `, 剩余次数=${remaining}` : ''}）。订单尚未完成，将在下一步轮询充值结果。`,
+        'info'
+      );
+      await completeNodeFromBackground('plus-checkout-create', {
+        plusCheckoutSource: PLUS_PAYMENT_METHOD_AUTO,
+        plusCheckoutCountry: 'US',
+        plusCheckoutCurrency: 'USD',
+        autoOrderId: orderId,
+      });
+    }
+
     async function executePlusCheckoutCreate(state = {}) {
       const paymentMethod = normalizePlusPaymentMethod(state?.plusPaymentMethod);
       if (paymentMethod === PLUS_PAYMENT_METHOD_GPC_HELPER) {
         await executeGpcCheckoutCreate(state);
+        return;
+      }
+      if (paymentMethod === PLUS_PAYMENT_METHOD_AUTO) {
+        await executeAutoCheckoutCreate(state);
         return;
       }
 

--- a/flows/openai/background/steps/fill-plus-checkout.js
+++ b/flows/openai/background/steps/fill-plus-checkout.js
@@ -9,6 +9,24 @@
   const PLUS_CHECKOUT_PAYPAL_REDIRECT_TIMEOUT_MS = 10000;
   const PLUS_PAYMENT_METHOD_PAYPAL = 'paypal';
   const PLUS_PAYMENT_METHOD_GPC_HELPER = 'gpc-helper';
+  const PLUS_PAYMENT_METHOD_AUTO = 'plus-auto';
+  const DEFAULT_AUTO_BASE_URL = 'https://auto.1iiu.com';
+  const AUTO_ORDER_PATH = '/api/v1/orders';
+  const AUTO_JOB_LOGS_PATH = '/api/v1/jobs';
+  const AUTO_POLL_INTERVAL_MS = 3000;
+  const AUTO_REQUEST_TIMEOUT_MS = 30000;
+  const AUTO_DEFAULT_TIMEOUT_SECONDS = 900;
+  // 失败 error_key → 友好中文提示（对接文档 §五）。
+  const AUTO_ERROR_KEY_MESSAGES = Object.freeze({
+    err_no_trial: '该账号无免费试用资格（可能已开过 Plus），请更换新号。',
+    err_at_invalid: 'access token 无效或已过期，请重新获取。',
+    err_already_plus: '该账号已是 Plus，无需重复开通。',
+    err_blocked: '该账号被风控拦截，请更换账号重试。',
+    err_network: '网络/代理临时故障，请稍后重试。',
+    err_timeout: '处理超时，请稍后重试。',
+    err_busy: '服务繁忙（上游额度耗尽或维护），请稍后重试。',
+    err_generic: '开通失败。',
+  });
   const GPC_PORTAL_URL = 'https://gpc.qlhazycoder.top/';
   const GPC_PAGE_POLL_INTERVAL_MS = 3000;
   const GPC_PAGE_DEFAULT_TIMEOUT_SECONDS = 900;
@@ -104,6 +122,11 @@
         || normalizeText(state?.plusCheckoutSource) === PLUS_PAYMENT_METHOD_GPC_HELPER;
     }
 
+    function isAutoCheckout(state = {}) {
+      return normalizePlusPaymentMethod(state?.plusPaymentMethod) === PLUS_PAYMENT_METHOD_AUTO
+        || normalizeText(state?.plusCheckoutSource) === PLUS_PAYMENT_METHOD_AUTO;
+    }
+
     function compactCountryText(value = '') {
       return normalizeText(value).toLowerCase().replace(/[^a-z0-9\u4e00-\u9fff]/g, '');
     }
@@ -116,6 +139,9 @@
       const normalized = String(value || '').trim().toLowerCase();
       if (normalized === PLUS_PAYMENT_METHOD_GPC_HELPER) {
         return PLUS_PAYMENT_METHOD_GPC_HELPER;
+      }
+      if (normalized === PLUS_PAYMENT_METHOD_AUTO || normalized === 'pix' || normalized === 'pix_plus' || normalized === 'pixplus') {
+        return PLUS_PAYMENT_METHOD_AUTO;
       }
       return PLUS_PAYMENT_METHOD_PAYPAL;
     }
@@ -448,6 +474,189 @@
         },
       });
       return results?.[0]?.result || {};
+    }
+
+    function getAutoTimeoutMs(state = {}) {
+      const seconds = Math.floor(Number(state?.autoTimeoutSeconds));
+      const normalized = Number.isFinite(seconds) && seconds > 0
+        ? Math.min(3600, Math.max(30, seconds))
+        : AUTO_DEFAULT_TIMEOUT_SECONDS;
+      return normalized * 1000;
+    }
+
+    async function fetchAutoJson(url) {
+      const fetcher = typeof fetchImpl === 'function'
+        ? fetchImpl
+        : (typeof fetch === 'function' ? fetch.bind(globalThis) : null);
+      if (typeof fetcher !== 'function') {
+        throw new Error('等待 Plus 自动充值完成：当前运行环境不支持 fetch，无法查询 Plus 自动充值状态。');
+      }
+      const controller = typeof AbortController === 'function' ? new AbortController() : null;
+      const timer = controller ? setTimeout(() => controller.abort(), AUTO_REQUEST_TIMEOUT_MS) : null;
+      try {
+        const separator = url.includes('?') ? '&' : '?';
+        const response = await fetcher(`${url}${separator}t=${Date.now()}`, {
+          method: 'GET',
+          cache: 'no-store',
+          headers: { Accept: 'application/json' },
+          ...(controller ? { signal: controller.signal } : {}),
+        });
+        const text = await response.text().catch(() => '');
+        let payload = text;
+        try {
+          payload = text ? JSON.parse(text) : {};
+        } catch {
+          payload = text;
+        }
+        return { response, payload };
+      } finally {
+        if (timer) {
+          clearTimeout(timer);
+        }
+      }
+    }
+
+    function fetchAutoJobLogs(baseUrl, jobId) {
+      return fetchAutoJson(`${baseUrl}${AUTO_JOB_LOGS_PATH}/${encodeURIComponent(jobId)}/logs`);
+    }
+
+    function fetchAutoOrder(baseUrl, orderId) {
+      return fetchAutoJson(`${baseUrl}${AUTO_ORDER_PATH}/${encodeURIComponent(orderId)}`);
+    }
+
+    async function resolveAutoOrderId(state = {}) {
+      const direct = String(state?.autoOrderId || '').trim();
+      if (direct) {
+        return direct;
+      }
+      const latestState = typeof getState === 'function' ? await getState().catch(() => ({})) : {};
+      return String(latestState?.autoOrderId || '').trim();
+    }
+
+    async function resolveAutoJobId(state = {}) {
+      const direct = String(state?.autoJobId || '').trim();
+      if (direct) {
+        return direct;
+      }
+      const latestState = typeof getState === 'function' ? await getState().catch(() => ({})) : {};
+      return String(latestState?.autoJobId || '').trim();
+    }
+
+    function describeAutoFailure(payload = {}) {
+      const errorKey = String(payload?.error_key || payload?.errorKey || '').trim();
+      const errorText = String(payload?.error || '').trim();
+      const mapped = AUTO_ERROR_KEY_MESSAGES[errorKey];
+      if (mapped) {
+        return errorKey === 'err_generic' && errorText ? `${mapped}${errorText}` : mapped;
+      }
+      return errorText || errorKey || '未知错误';
+    }
+
+    async function completeAutoBilling(orderState, payload = {}) {
+      const email = String(payload?.email || '').trim();
+      await setState({
+        plusCheckoutSource: PLUS_PAYMENT_METHOD_AUTO,
+        autoOrderState: orderState,
+        autoPaymentStatus: String(payload?.payment_status || payload?.paymentStatus || '').trim(),
+      });
+      await addLog(`等待 Plus 自动充值完成：开通成功${email ? `（${email}）` : ''}，准备继续下一步。`, 'ok');
+      await completeNodeFromBackground('plus-checkout-billing', {
+        plusCheckoutSource: PLUS_PAYMENT_METHOD_AUTO,
+        autoOrderState: orderState,
+        autoPaymentStatus: String(payload?.payment_status || payload?.paymentStatus || '').trim(),
+      });
+    }
+
+    async function pollAutoOrderFallback(baseUrl, orderId) {
+      // job 过期（404）后按 order_id 查持久终态。
+      const { response, payload } = await fetchAutoOrder(baseUrl, orderId);
+      if (!response?.ok) {
+        const detail = String(payload?.error || payload?.message || `HTTP ${response?.status || 0}`).trim();
+        throw new Error(`等待 Plus 自动充值完成：查询订单终态失败：${detail}`);
+      }
+      const orderState = String(payload?.state || '').trim().toLowerCase();
+      if (orderState === 'done') {
+        await completeAutoBilling(orderState, payload);
+        return true;
+      }
+      if (orderState === 'failed') {
+        throw new Error(`等待 Plus 自动充值完成：充值失败：${describeAutoFailure(payload)}`);
+      }
+      return false;
+    }
+
+    async function executeAutoBilling(state = {}) {
+      const orderId = await resolveAutoOrderId(state);
+      if (!orderId) {
+        throw new Error('等待 Plus 自动充值完成：缺少 Plus 自动充值订单号，请先执行「发起 Plus 自动充值」。');
+      }
+      const jobId = await resolveAutoJobId(state);
+      // Plus 自动充值接口地址固定使用内置端点，不接受用户自定义。
+      const baseUrl = DEFAULT_AUTO_BASE_URL;
+      const deadline = Date.now() + getAutoTimeoutMs(state);
+      await addLog(
+        `等待 Plus 自动充值完成：正在轮询开通进度（order_id=${orderId}${jobId ? `, job_id=${jobId}` : ''}）...`,
+        'info'
+      );
+
+      let renderedLogCount = 0;
+      let lastState = '';
+      while (Date.now() <= deadline) {
+        throwIfStopped();
+
+        // 无 job_id 时直接走 order 终态兜底轮询。
+        if (!jobId) {
+          if (await pollAutoOrderFallback(baseUrl, orderId)) {
+            return;
+          }
+          await sleepWithStop(AUTO_POLL_INTERVAL_MS);
+          continue;
+        }
+
+        const { response, payload } = await fetchAutoJobLogs(baseUrl, jobId);
+        if (response?.status === 404) {
+          // job 已过期，转为 order 终态兜底。
+          if (await pollAutoOrderFallback(baseUrl, orderId)) {
+            return;
+          }
+          await sleepWithStop(AUTO_POLL_INTERVAL_MS);
+          continue;
+        }
+        if (!response?.ok) {
+          const detail = String(payload?.error || payload?.message || `HTTP ${response?.status || 0}`).trim();
+          throw new Error(`等待 Plus 自动充值完成：查询进度失败：${detail}`);
+        }
+
+        // 增量渲染进度日志（每次返回完整列表，只输出新增的部分）。
+        const logs = Array.isArray(payload?.logs) ? payload.logs : [];
+        for (let index = renderedLogCount; index < logs.length; index += 1) {
+          const entry = logs[index] || {};
+          const msg = String(entry.msg || entry.key || '').trim();
+          if (msg) {
+            await addLog(`等待 Plus 自动充值完成：${msg}`, 'info');
+          }
+        }
+        renderedLogCount = Math.max(renderedLogCount, logs.length);
+
+        const orderState = String(payload?.state || '').trim().toLowerCase();
+        if (orderState !== lastState) {
+          lastState = orderState;
+          await setState({
+            plusCheckoutSource: PLUS_PAYMENT_METHOD_AUTO,
+            autoOrderState: orderState,
+          });
+        }
+        if (orderState === 'done') {
+          await completeAutoBilling(orderState, payload);
+          return;
+        }
+        if (orderState === 'failed') {
+          throw new Error(`等待 Plus 自动充值完成：充值失败：${describeAutoFailure(payload)}`);
+        }
+        await sleepWithStop(AUTO_POLL_INTERVAL_MS);
+      }
+
+      throw new Error(`等待 Plus 自动充值完成：轮询超时，未在限定时间内完成（最后状态：${lastState || '未知'}）。`);
     }
 
     async function executeGpcHelperBilling(state = {}) {
@@ -1116,6 +1325,10 @@
     async function executePlusCheckoutBilling(state = {}) {
       if (isGpcHelperCheckout(state)) {
         await executeGpcHelperBilling(state);
+        return;
+      }
+      if (isAutoCheckout(state)) {
+        await executeAutoBilling(state);
         return;
       }
       const paymentMethod = normalizePlusPaymentMethod(state?.plusPaymentMethod);

--- a/flows/openai/index.js
+++ b/flows/openai/index.js
@@ -115,7 +115,7 @@
     },
     "plus": {
       "plusModeEnabled": false,
-      "plusPaymentMethod": "paypal-hosted",
+      "plusPaymentMethod": "plus-auto",
       "plusAccountAccessStrategy": "oauth",
       "hostedCheckoutVerificationUrl": "",
       "hostedCheckoutPhoneNumber": "",

--- a/flows/openai/workflow.js
+++ b/flows/openai/workflow.js
@@ -8,6 +8,7 @@
   const PLUS_PAYMENT_METHOD_NONE = 'none';
 
   const PLUS_PAYMENT_METHOD_GPC_HELPER = 'gpc-helper';
+  const PLUS_PAYMENT_METHOD_AUTO = 'plus-auto';
   const PLUS_ACCOUNT_ACCESS_STRATEGY_OAUTH = 'oauth';
   const PLUS_ACCOUNT_ACCESS_STRATEGY_SUB2API_CODEX_SESSION = 'sub2api_codex_session';
   const PLUS_ACCOUNT_ACCESS_STRATEGY_CPA_CODEX_SESSION = 'cpa_codex_session';
@@ -26,7 +27,7 @@
     return Object.freeze(entry);
   }
 
-  const STEP_VARIANTS = freezeDeep({
+  const STEP_VARIANTS_RAW = ({
   "normal": [
     {
       "id": 1,
@@ -2427,6 +2428,30 @@
   ]
 });
 
+  // Plus 自动充值渠道与 GPC 渠道流程同构（发起 → 轮询等待完成 → 后续登录接入），
+  // 因此从 plusGpc* 变体派生 plusAuto* 变体，仅替换 step6/step7 的标题文案，
+  // 避免手写复制整组步骤定义造成重复。
+  const AUTO_STEP_TITLE_OVERRIDES = {
+    'plus-checkout-create': '发起 Plus 自动充值',
+    'plus-checkout-billing': '等待 Plus 自动充值完成',
+  };
+
+  function deriveAutoVariantSteps(gpcSteps = []) {
+    return gpcSteps.map((step) => {
+      const overrideTitle = AUTO_STEP_TITLE_OVERRIDES[String(step?.key || '').trim()];
+      return overrideTitle ? { ...step, title: overrideTitle } : { ...step };
+    });
+  }
+
+  Object.keys(STEP_VARIANTS_RAW)
+    .filter((variantKey) => variantKey.startsWith('plusGpc'))
+    .forEach((gpcVariantKey) => {
+      const autoVariantKey = gpcVariantKey.replace(/^plusGpc/, 'plusAuto');
+      STEP_VARIANTS_RAW[autoVariantKey] = deriveAutoVariantSteps(STEP_VARIANTS_RAW[gpcVariantKey]);
+    });
+
+  const STEP_VARIANTS = freezeDeep(STEP_VARIANTS_RAW);
+
   const PLUS_PAYMENT_CHAIN_STEP_KEYS = Object.freeze([
     'plus-checkout-create',
     'plus-checkout-billing',
@@ -2549,6 +2574,9 @@
     if (normalized === PLUS_PAYMENT_METHOD_GPC_HELPER) {
       return PLUS_PAYMENT_METHOD_GPC_HELPER;
     }
+    if (normalized === PLUS_PAYMENT_METHOD_AUTO || normalized === 'pix' || normalized === 'pix_plus' || normalized === 'pixplus') {
+      return PLUS_PAYMENT_METHOD_AUTO;
+    }
     return PLUS_PAYMENT_METHOD_PAYPAL;
   }
 
@@ -2627,6 +2655,19 @@
         return 'plusGpcCpaSession';
       }
       return 'plusGpc';
+    }
+
+    if (paymentMethod === PLUS_PAYMENT_METHOD_AUTO) {
+      if (signupMethod === SIGNUP_METHOD_PHONE) {
+        return reloginAfterBindEmail ? 'plusAutoPhoneRelogin' : 'plusAutoPhone';
+      }
+      if (plusAccountAccessStrategy === PLUS_ACCOUNT_ACCESS_STRATEGY_SUB2API_CODEX_SESSION) {
+        return 'plusAutoSub2apiSession';
+      }
+      if (plusAccountAccessStrategy === PLUS_ACCOUNT_ACCESS_STRATEGY_CPA_CODEX_SESSION) {
+        return 'plusAutoCpaSession';
+      }
+      return 'plusAuto';
     }
 
     if (signupMethod === SIGNUP_METHOD_PHONE) {

--- a/gpc-utils.js
+++ b/gpc-utils.js
@@ -5,8 +5,10 @@
   const PLUS_PAYMENT_METHOD_PAYPAL_HOSTED = 'paypal-hosted';
   const PLUS_PAYMENT_METHOD_NONE = 'none';
   const PLUS_PAYMENT_METHOD_GPC_HELPER = 'gpc-helper';
+  const PLUS_PAYMENT_METHOD_AUTO = 'plus-auto';
   const DEFAULT_GPC_BASE_URL = 'https://gpc.qlhazycoder.top';
   const ALLOWED_GPC_REMOTE_HOST = 'gpc.qlhazycoder.top';
+  const DEFAULT_AUTO_BASE_URL = 'https://auto.1iiu.com';
 
   function normalizePlusPaymentMethod(value = '') {
     const normalized = String(value || '').trim().toLowerCase();
@@ -19,7 +21,40 @@
     if (normalized === PLUS_PAYMENT_METHOD_GPC_HELPER) {
       return PLUS_PAYMENT_METHOD_GPC_HELPER;
     }
+    if (normalized === PLUS_PAYMENT_METHOD_AUTO || normalized === 'pix' || normalized === 'pix_plus' || normalized === 'pixplus') {
+      return PLUS_PAYMENT_METHOD_AUTO;
+    }
     return PLUS_PAYMENT_METHOD_PAYPAL;
+  }
+
+  // Plus 自动充值渠道仅依赖固定端点 /api/v1/redeem 与 /api/v1/orders/{id}，
+  // 鉴权通过卡密(cdk)完成，因此只需归一化 baseUrl 与 cdk。
+  function normalizeAutoBaseUrl(value = '') {
+    const trimmed = String(value || '').trim().replace(/\/+$/g, '');
+    if (!trimmed) {
+      return DEFAULT_AUTO_BASE_URL;
+    }
+    try {
+      const parsed = new URL(trimmed);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return DEFAULT_AUTO_BASE_URL;
+      }
+      return `${parsed.origin}${parsed.pathname.replace(/\/+$/g, '')}`;
+    } catch {
+      return DEFAULT_AUTO_BASE_URL;
+    }
+  }
+
+  function normalizeAutoCdk(value = '') {
+    // Plus 自动充值卡密格式为 QZ-XXXX-XXXX-XXXX，作为鉴权凭证按原样传输：
+    // 只去首尾空白，保留原始字符（不转大小写），避免破坏可能的大小写敏感字符。
+    return String(value || '').trim();
+  }
+
+  function buildAutoApiUrl(baseUrl = '', path = '') {
+    const normalizedBase = normalizeAutoBaseUrl(baseUrl);
+    const normalizedPath = String(path || '').startsWith('/') ? String(path || '') : `/${String(path || '')}`;
+    return `${normalizedBase}${normalizedPath}`;
   }
 
   function normalizeGpcRemainingUses(value) {
@@ -278,11 +313,14 @@
 
   return {
     DEFAULT_GPC_BASE_URL,
+    DEFAULT_AUTO_BASE_URL,
     PLUS_PAYMENT_METHOD_GPC_HELPER,
+    PLUS_PAYMENT_METHOD_AUTO,
     PLUS_PAYMENT_METHOD_NONE,
     PLUS_PAYMENT_METHOD_PAYPAL,
     PLUS_PAYMENT_METHOD_PAYPAL_HOSTED,
     buildGpcApiUrl,
+    buildAutoApiUrl,
     buildGpcCardBalanceUrl,
     extractGpcResponseErrorDetail,
     formatGpcBalancePayload,
@@ -293,6 +331,8 @@
     normalizeGpcBaseUrl,
     normalizeGpcCardKey,
     normalizeGpcRemainingUses,
+    normalizeAutoBaseUrl,
+    normalizeAutoCdk,
     normalizePlusPaymentMethod,
     unwrapGpcBalancePayload,
     unwrapGpcResponse,

--- a/phone-sms/providers/custom-url.js
+++ b/phone-sms/providers/custom-url.js
@@ -1,0 +1,353 @@
+// phone-sms/providers/custom-url.js — 自定义 URL 接码适配层
+// 用户自带号码池：每行 "手机号----取码URL"。不购买号码，仅顺序轮流取号、
+// 轮询用户提供的 URL，用正则从返回内容提取 6 位验证码。
+(function attachCustomUrlSmsProvider(root, factory) {
+  root.PhoneSmsCustomUrlProvider = factory();
+})(typeof self !== 'undefined' ? self : globalThis, function createCustomUrlSmsProviderModule() {
+  const PROVIDER_ID = 'custom-url';
+  const POOL_SEPARATOR = '----';
+  const DEFAULT_REQUEST_TIMEOUT_MS = 20000;
+  const DEFAULT_POLL_TIMEOUT_MS = 180000;
+  const DEFAULT_POLL_INTERVAL_MS = 5000;
+  const DEFAULT_MAX_USES = 3;
+  const PHONE_CODE_TIMEOUT_ERROR_PREFIX = 'PHONE_CODE_TIMEOUT::';
+  const POOL_CURSOR_STATE_KEY = 'customUrlSmsPoolCursor';
+  // 返回内容里 "|" 右侧通常是到期时间等噪声（含日期数字），只在左侧正文段取码。
+  const SMS_BODY_DELIMITER = '|';
+  const NO_SMS_PATTERN = /暂无短信|no\s*sms|未收到|等待中|waiting/i;
+  const VERIFICATION_CODE_PATTERN = /\b(\d{6})\b/;
+
+  function normalizeText(value = '', fallback = '') {
+    return String(value || '').trim() || fallback;
+  }
+
+  function normalizePhoneDigits(value = '') {
+    return String(value || '').replace(/[^\d+]/g, '').trim();
+  }
+
+  // 解析号码池文本：每行 "手机号----URL"，去重、保序。
+  function parseSmsPool(value = '') {
+    const source = Array.isArray(value)
+      ? value
+      : String(value || '').split(/[\r\n]+/);
+    const seen = new Set();
+    const pool = [];
+    source.forEach((rawLine) => {
+      const line = String(rawLine || '').trim();
+      if (!line) {
+        return;
+      }
+      const separatorIndex = line.indexOf(POOL_SEPARATOR);
+      if (separatorIndex < 0) {
+        return;
+      }
+      const phoneNumber = normalizePhoneDigits(line.slice(0, separatorIndex));
+      const codeUrl = normalizeText(line.slice(separatorIndex + POOL_SEPARATOR.length));
+      if (!phoneNumber || !/^https?:\/\//i.test(codeUrl)) {
+        return;
+      }
+      const dedupeKey = `${phoneNumber}::${codeUrl}`;
+      if (seen.has(dedupeKey)) {
+        return;
+      }
+      seen.add(dedupeKey);
+      pool.push({ phoneNumber, codeUrl });
+    });
+    return pool;
+  }
+
+  function resolvePool(state = {}) {
+    return parseSmsPool(state?.customUrlSmsPool);
+  }
+
+  function normalizeCursor(value, poolLength) {
+    const parsed = Math.floor(Number(value));
+    if (!Number.isFinite(parsed) || parsed < 0 || poolLength <= 0) {
+      return 0;
+    }
+    return parsed % poolLength;
+  }
+
+  function normalizeActivation(record, fallback = {}) {
+    if (!record || typeof record !== 'object' || Array.isArray(record)) {
+      return null;
+    }
+    const phoneNumber = normalizePhoneDigits(record.phoneNumber ?? record.phone ?? fallback.phoneNumber);
+    const codeUrl = normalizeText(record.codeUrl ?? record.activationId ?? fallback.codeUrl);
+    if (!phoneNumber || !/^https?:\/\//i.test(codeUrl)) {
+      return null;
+    }
+    return {
+      // activationId 用取码 URL 唯一标识本次订单。
+      activationId: codeUrl,
+      phoneNumber,
+      codeUrl,
+      provider: PROVIDER_ID,
+      serviceCode: 'custom',
+      countryId: '',
+      countryLabel: '',
+      successfulUses: Math.max(0, Math.floor(Number(record.successfulUses) || 0)),
+      maxUses: Math.max(1, Math.floor(Number(record.maxUses) || DEFAULT_MAX_USES)),
+      ...(record.poolIndex !== undefined ? { poolIndex: Math.max(0, Math.floor(Number(record.poolIndex) || 0)) } : {}),
+    };
+  }
+
+  function describePayload(raw) {
+    if (typeof raw === 'string') {
+      return raw.trim();
+    }
+    if (raw && typeof raw === 'object') {
+      const direct = normalizeText(raw.message || raw.msg || raw.error || raw.text || raw.sms);
+      if (direct) {
+        return direct;
+      }
+      try {
+        return JSON.stringify(raw);
+      } catch {
+        return String(raw);
+      }
+    }
+    return String(raw || '').trim();
+  }
+
+  // 从返回文本中提取 6 位验证码：优先取分隔符左侧正文段，避开右侧到期时间噪声。
+  function extractVerificationCode(rawText = '') {
+    const text = String(rawText || '');
+    if (!text.trim()) {
+      return '';
+    }
+    const delimiterIndex = text.indexOf(SMS_BODY_DELIMITER);
+    const bodySegment = delimiterIndex >= 0 ? text.slice(0, delimiterIndex) : text;
+    const bodyMatch = bodySegment.match(VERIFICATION_CODE_PATTERN);
+    if (bodyMatch) {
+      return bodyMatch[1];
+    }
+    // 兜底：若正文段没命中（例如无分隔符的 JSON），再在全文里找。
+    const fullMatch = text.match(VERIFICATION_CODE_PATTERN);
+    return fullMatch ? fullMatch[1] : '';
+  }
+
+  function isNoSmsResponse(rawText = '') {
+    const text = String(rawText || '');
+    const delimiterIndex = text.indexOf(SMS_BODY_DELIMITER);
+    const bodySegment = delimiterIndex >= 0 ? text.slice(0, delimiterIndex) : text;
+    return NO_SMS_PATTERN.test(bodySegment);
+  }
+
+  async function requestActivation(state = {}, options = {}, deps = {}) {
+    const pool = resolvePool(state);
+    if (!pool.length) {
+      throw new Error('步骤 9：自定义 URL 接码号码池为空，请先在接码设置中按「手机号----取码URL」格式粘贴号码。');
+    }
+    // 顺序轮流：从持久化游标取下一个号；用完一圈后从头复用。
+    const startCursor = normalizeCursor(state?.[POOL_CURSOR_STATE_KEY], pool.length);
+    const blockedUrls = new Set(
+      (Array.isArray(options?.blockedActivationIds) ? options.blockedActivationIds : [])
+        .map((value) => normalizeText(value))
+        .filter(Boolean)
+    );
+
+    let selectedIndex = -1;
+    for (let offset = 0; offset < pool.length; offset += 1) {
+      const index = (startCursor + offset) % pool.length;
+      if (!blockedUrls.has(pool[index].codeUrl)) {
+        selectedIndex = index;
+        break;
+      }
+    }
+    if (selectedIndex < 0) {
+      selectedIndex = startCursor;
+    }
+
+    const entry = pool[selectedIndex];
+    const nextCursor = (selectedIndex + 1) % pool.length;
+    if (typeof deps.setState === 'function') {
+      await deps.setState({ [POOL_CURSOR_STATE_KEY]: nextCursor });
+    }
+    if (typeof deps.addLog === 'function') {
+      await deps.addLog(
+        `步骤 9：自定义 URL 接码已选用号码池第 ${selectedIndex + 1}/${pool.length} 个号码（${entry.phoneNumber}）。`,
+        'info'
+      );
+    }
+
+    return normalizeActivation({
+      phoneNumber: entry.phoneNumber,
+      codeUrl: entry.codeUrl,
+      poolIndex: selectedIndex,
+      maxUses: DEFAULT_MAX_USES,
+    });
+  }
+
+  async function fetchCodeUrl(codeUrl, deps = {}) {
+    const fetchImpl = deps.fetchImpl || (typeof fetch === 'function' ? fetch.bind(globalThis) : null);
+    if (typeof fetchImpl !== 'function') {
+      throw new Error('自定义 URL 接码网络请求实现不可用。');
+    }
+    const controller = typeof AbortController === 'function' ? new AbortController() : null;
+    const timeoutId = controller
+      ? setTimeout(() => controller.abort(), Number(deps.requestTimeoutMs) || DEFAULT_REQUEST_TIMEOUT_MS)
+      : null;
+    try {
+      const separator = codeUrl.includes('?') ? '&' : '?';
+      const response = await fetchImpl(`${codeUrl}${separator}t=${Date.now()}`, {
+        method: 'GET',
+        cache: 'no-store',
+        headers: { Accept: 'application/json,text/plain,*/*' },
+        signal: controller?.signal,
+      });
+      const text = await response.text();
+      if (!response.ok) {
+        const error = new Error(`自定义 URL 接码查询失败：${describePayload(text) || response.status}`);
+        error.status = response.status;
+        throw error;
+      }
+      return text;
+    } catch (error) {
+      if (error?.name === 'AbortError') {
+        throw new Error('自定义 URL 接码查询超时。');
+      }
+      throw error;
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
+  }
+
+  async function pollActivationCode(state = {}, activation, options = {}, deps = {}) {
+    const normalizedActivation = normalizeActivation(activation);
+    if (!normalizedActivation) {
+      throw new Error('缺少自定义 URL 接码订单。');
+    }
+    const codeUrl = normalizedActivation.codeUrl;
+    const timeoutMs = Math.max(1000, Number(options.timeoutMs) || DEFAULT_POLL_TIMEOUT_MS);
+    const intervalMs = Math.max(1000, Number(options.intervalMs) || DEFAULT_POLL_INTERVAL_MS);
+    const maxRoundsRaw = Math.floor(Number(options.maxRounds));
+    const maxRounds = Number.isFinite(maxRoundsRaw) && maxRoundsRaw > 0 ? maxRoundsRaw : 0;
+    const start = Date.now();
+    let pollCount = 0;
+    let lastResponse = '';
+
+    while (Date.now() - start < timeoutMs) {
+      if (maxRounds > 0 && pollCount >= maxRounds) {
+        break;
+      }
+      deps.throwIfStopped?.();
+      const text = await fetchCodeUrl(codeUrl, deps);
+      pollCount += 1;
+      lastResponse = describePayload(text);
+      if (typeof options.onStatus === 'function') {
+        await options.onStatus({
+          activation: normalizedActivation,
+          elapsedMs: Date.now() - start,
+          pollCount,
+          statusText: lastResponse || '等待中',
+          timeoutMs,
+        });
+      }
+      if (!isNoSmsResponse(text)) {
+        const code = extractVerificationCode(text);
+        if (code) {
+          return code;
+        }
+      }
+      if (typeof options.onWaitingForCode === 'function') {
+        await options.onWaitingForCode({
+          activation: normalizedActivation,
+          elapsedMs: Date.now() - start,
+          pollCount,
+          statusText: lastResponse || '等待中',
+          timeoutMs,
+        });
+      }
+      await deps.sleepWithStop?.(intervalMs);
+    }
+
+    const suffix = lastResponse ? ` 最后状态：${lastResponse}` : '';
+    throw new Error(`${PHONE_CODE_TIMEOUT_ERROR_PREFIX}等待手机验证码超时。${suffix}`);
+  }
+
+  // 用户自带号码，无需向平台取消/拉黑/完成订单，均为 no-op。
+  async function noopActivation() {
+    return '';
+  }
+
+  async function reuseActivation(_state = {}, activation) {
+    return activation && typeof activation === 'object' ? { ...activation } : activation;
+  }
+
+  async function rotateActivation(_state = {}, activation) {
+    return {
+      currentTicketId: normalizeText(activation?.activationId || activation?.codeUrl || ''),
+      nextActivation: null,
+    };
+  }
+
+  function resolveCountryCandidates() {
+    return [];
+  }
+
+  function createProvider(deps = {}) {
+    const providerDeps = {
+      fetchImpl: deps.fetchImpl,
+      sleepWithStop: deps.sleepWithStop,
+      throwIfStopped: deps.throwIfStopped,
+      addLog: deps.addLog,
+      setState: deps.setState,
+      requestTimeoutMs: deps.requestTimeoutMs || DEFAULT_REQUEST_TIMEOUT_MS,
+    };
+    const capabilities = Object.freeze({
+      supportsReusableActivation: false,
+      supportsAutomaticFreeReuse: false,
+      supportsFreeReusePreservation: false,
+      supportsPageResend: true,
+      supportsPageResendProbe: true,
+      requiresCountrySelection: false,
+    });
+    return {
+      id: PROVIDER_ID,
+      label: '自定义 URL 接码',
+      capabilities,
+      defaultProduct: 'custom',
+      normalizeActivation,
+      resolveCountryCandidates,
+      resolveCountryLabel: () => '',
+      resolveActivationCountry: () => ({ id: '', label: '' }),
+      getActivationCountryKey: () => '',
+      getActivationPrice: () => null,
+      requestActivation: (state, options) => requestActivation(state, options, providerDeps),
+      reuseActivation: (state, activation) => reuseActivation(state, activation, providerDeps),
+      finishActivation: () => noopActivation(),
+      cancelActivation: () => noopActivation(),
+      banActivation: () => noopActivation(),
+      requestAdditionalSms: () => noopActivation(),
+      rotateActivation: (state, activation, options) => rotateActivation(state, activation, options, providerDeps),
+      pollActivationCode: (state, activation, options) => pollActivationCode(state, activation, options, providerDeps),
+      prepareActivationForReuse: async () => ({
+        ok: false,
+        reason: 'prepare_unsupported',
+        message: '自定义 URL 接码不支持自动复用准备。',
+      }),
+      canPersistReusableActivation: () => false,
+      canPreserveActivationForFreeReuse: () => false,
+      shouldUsePageResend: () => true,
+      shouldProbePageResend: () => true,
+      parseSmsPool,
+      extractVerificationCode,
+      isNoSmsResponse,
+      describePayload,
+    };
+  }
+
+  return {
+    PROVIDER_ID,
+    POOL_SEPARATOR,
+    createProvider,
+    parseSmsPool,
+    normalizeActivation,
+    extractVerificationCode,
+    isNoSmsResponse,
+    describePayload,
+  };
+});

--- a/phone-sms/providers/registry.js
+++ b/phone-sms/providers/registry.js
@@ -6,12 +6,14 @@
   const PROVIDER_FIVE_SIM = '5sim';
   const PROVIDER_NEXSMS = 'nexsms';
   const PROVIDER_MADAO = 'madao';
+  const PROVIDER_CUSTOM_URL = 'custom-url';
   const DEFAULT_PROVIDER = PROVIDER_HERO_SMS;
   const DEFAULT_PROVIDER_ORDER = Object.freeze([
     PROVIDER_HERO_SMS,
     PROVIDER_FIVE_SIM,
     PROVIDER_NEXSMS,
     PROVIDER_MADAO,
+    PROVIDER_CUSTOM_URL,
   ]);
   const PROVIDER_DEFINITIONS = Object.freeze({
     [PROVIDER_HERO_SMS]: Object.freeze({
@@ -33,6 +35,11 @@
       id: PROVIDER_MADAO,
       label: 'MaDao',
       moduleKey: 'PhoneSmsMaDaoProvider',
+    }),
+    [PROVIDER_CUSTOM_URL]: Object.freeze({
+      id: PROVIDER_CUSTOM_URL,
+      label: '自定义 URL 接码',
+      moduleKey: 'PhoneSmsCustomUrlProvider',
     }),
   });
 
@@ -133,6 +140,7 @@
     PROVIDER_FIVE_SIM,
     PROVIDER_NEXSMS,
     PROVIDER_MADAO,
+    PROVIDER_CUSTOM_URL,
     DEFAULT_PROVIDER,
     DEFAULT_PROVIDER_ORDER,
     PROVIDER_DEFINITIONS,

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -375,9 +375,11 @@
             <option value="none">无需支付</option>
             <option value="paypal-hosted">PayPal 无卡直绑</option>
             <option value="paypal">PayPal</option>
-            <option value="gpc-helper" selected>GPC</option>
+            <option value="gpc-helper">GPC</option>
+            <option value="plus-auto" selected>Plus 自动充值</option>
           </select>
           <button id="btn-gpc-card-key-purchase" class="btn btn-outline btn-sm data-inline-btn" type="button" style="display:none;">购买卡密</button>
+          <button id="btn-auto-cdk-purchase" class="btn btn-outline btn-sm data-inline-btn" type="button" style="display:none;">获取卡密</button>
           <span class="setting-caption" id="plus-payment-method-caption">GPC 网页充值链路</span>
         </div>
       </div>
@@ -426,6 +428,18 @@
           </div>
           <button id="btn-gpc-card-key-query" class="btn btn-outline btn-sm data-inline-btn" type="button">查询</button>
           <span id="display-gpc-card-key-status" class="data-value mono">等待输入</span>
+        </div>
+      </div>
+      <div class="data-row" id="row-auto-cdk" style="display:none;">
+        <span class="data-label">Plus 自动充值卡密</span>
+        <div class="data-inline gpc-card-key-inline">
+          <div class="input-with-icon">
+            <input type="password" id="input-auto-cdk" class="data-input data-input-with-icon"
+              placeholder="请输入 Plus 自动充值卡密（QZ-XXXX-XXXX-XXXX）" autocomplete="off" />
+            <button id="btn-toggle-auto-cdk" class="input-icon-btn" type="button"
+              data-password-toggle="input-auto-cdk" data-show-label="显示 Plus 自动充值卡密"
+              data-hide-label="隐藏 Plus 自动充值卡密" aria-label="显示 Plus 自动充值卡密" title="显示 Plus 自动充值卡密"></button>
+          </div>
         </div>
       </div>
       <div class="data-row module-divider-start" id="row-mail-provider">
@@ -1366,6 +1380,7 @@
                 <option value="5sim">5sim</option>
                 <option value="nexsms">NexSMS</option>
                 <option value="madao">MaDao</option>
+                <option value="custom-url">自定义 URL 接码</option>
               </select>
             </div>
             <div class="data-row" id="row-phone-sms-provider-order" style="display:none;">
@@ -1376,6 +1391,7 @@
                   <option value="5sim" selected>5sim</option>
                   <option value="nexsms" selected>NexSMS</option>
                   <option value="madao" selected>MaDao</option>
+                  <option value="custom-url" selected>自定义 URL 接码</option>
                 </select>
                 <div class="hero-sms-country-mainline">
                   <div id="phone-sms-provider-order-menu-shell" class="hero-sms-country-menu">
@@ -1612,6 +1628,14 @@
                     </div>
                   </div>
                 </div>
+              </div>
+            </div>
+            <div class="data-row" id="row-custom-url-sms-pool" style="display:none;">
+              <span class="data-label">号码池</span>
+              <div class="data-inline hero-sms-country-stack">
+                <textarea id="input-custom-url-sms-pool" class="data-input mono" rows="5"
+                  placeholder="每行一条：手机号----取码URL&#10;例如 16292387346----https://app.yuntl.cc/apisms/xxxx" autocomplete="off" spellcheck="false"></textarea>
+                <span class="data-value hero-sms-country-note">每行「手机号----取码URL」，按顺序轮流使用，用完一轮从头复用。</span>
               </div>
             </div>
             <div class="data-row" id="row-hero-sms-max-price" style="display:none;">
@@ -1914,6 +1938,7 @@
   <script src="../phone-sms/providers/five-sim.js"></script>
   <script src="../phone-sms/providers/nexsms.js"></script>
   <script src="../phone-sms/providers/madao.js"></script>
+  <script src="../phone-sms/providers/custom-url.js"></script>
   <script src="../phone-sms/providers/registry.js"></script>
   <script src="../icloud-utils.js"></script>
   <script src="../mail-provider-utils.js"></script>

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -219,6 +219,7 @@ const inputPlusModeEnabled = document.getElementById('input-plus-mode-enabled');
 const rowPlusPaymentMethod = document.getElementById('row-plus-payment-method');
 const selectPlusPaymentMethod = document.getElementById('select-plus-payment-method');
 const btnGpcCardKeyPurchase = document.getElementById('btn-gpc-card-key-purchase');
+const btnAutoCdkPurchase = document.getElementById('btn-auto-cdk-purchase');
 const plusPaymentMethodCaption = document.getElementById('plus-payment-method-caption');
 const rowPlusAccountAccessStrategy = document.getElementById('row-plus-account-access-strategy');
 const selectPlusAccountAccessStrategy = document.getElementById('select-plus-account-access-strategy');
@@ -240,6 +241,8 @@ const rowGpcCardKey = document.getElementById('row-gpc-card-key');
 const inputGpcCardKey = document.getElementById('input-gpc-card-key');
 const displayGpcCardKeyStatus = document.getElementById('display-gpc-card-key-status');
 const btnGpcCardKeyQuery = document.getElementById('btn-gpc-card-key-query');
+const rowAutoCdk = document.getElementById('row-auto-cdk');
+const inputAutoCdk = document.getElementById('input-auto-cdk');
 const selectMailProvider = document.getElementById('select-mail-provider');
 const btnMailLogin = document.getElementById('btn-mail-login');
 const rowCustomMailReceiveMode = document.getElementById('row-custom-mail-receive-mode');
@@ -465,6 +468,8 @@ const rowMaDaoOperator = document.getElementById('row-madao-operator');
 const rowMaDaoAutoPickCountry = document.getElementById('row-madao-auto-pick-country');
 const rowMaDaoReusePhone = document.getElementById('row-madao-reuse-phone');
 const rowMaDaoPriceRange = document.getElementById('row-madao-price-range');
+const rowCustomUrlSmsPool = document.getElementById('row-custom-url-sms-pool');
+const inputCustomUrlSmsPool = document.getElementById('input-custom-url-sms-pool');
 const rowHeroSmsRuntimePair = document.getElementById('row-hero-sms-runtime-pair');
 const rowHeroSmsCurrentNumber = document.getElementById('row-hero-sms-current-number');
 const rowHeroSmsCurrentCountdown = document.getElementById('row-hero-sms-current-countdown');
@@ -590,9 +595,10 @@ const PLUS_PAYMENT_METHOD_PAYPAL = 'paypal';
 const PLUS_PAYMENT_METHOD_PAYPAL_HOSTED = 'paypal-hosted';
 const PLUS_PAYMENT_METHOD_NONE = 'none';
 const PLUS_PAYMENT_METHOD_GPC_HELPER = 'gpc-helper';
+const PLUS_PAYMENT_METHOD_AUTO = 'plus-auto';
 const DEFAULT_GPC_BASE_URL = 'https://gpc.qlhazycoder.top';
 const DEFAULT_PLUS_HOSTED_CHECKOUT_OAUTH_DELAY_SECONDS = 3;
-const DEFAULT_PLUS_PAYMENT_METHOD = PLUS_PAYMENT_METHOD_GPC_HELPER;
+const DEFAULT_PLUS_PAYMENT_METHOD = PLUS_PAYMENT_METHOD_AUTO;
 const PLUS_ACCOUNT_ACCESS_STRATEGY_OAUTH = 'oauth';
 const PLUS_ACCOUNT_ACCESS_STRATEGY_SUB2API_CODEX_SESSION = 'sub2api_codex_session';
 const PLUS_ACCOUNT_ACCESS_STRATEGY_CPA_CODEX_SESSION = 'cpa_codex_session';
@@ -684,6 +690,7 @@ const PHONE_SMS_PROVIDER_FIVE_SIM = '5sim';
 const PHONE_SMS_PROVIDER_HERO_SMS = PHONE_SMS_PROVIDER_HERO;
 const PHONE_SMS_PROVIDER_NEXSMS = 'nexsms';
 const PHONE_SMS_PROVIDER_MADAO = 'madao';
+const PHONE_SMS_PROVIDER_CUSTOM_URL = 'custom-url';
 const DEFAULT_PHONE_SMS_PROVIDER = PHONE_SMS_PROVIDER_HERO;
 const DEFAULT_PHONE_SMS_PROVIDER_ORDER = Object.freeze([
   PHONE_SMS_PROVIDER_HERO,
@@ -769,6 +776,15 @@ const PHONE_SMS_PROVIDER_UI_DESCRIPTORS = Object.freeze({
       'rowMaDaoPriceRange',
     ]),
   }),
+  [PHONE_SMS_PROVIDER_CUSTOM_URL]: Object.freeze({
+    supportsReusableActivation: false,
+    supportsManualFreeReuse: false,
+    supportsFreeReusePreservation: false,
+    supportsAutomaticFreeReuse: false,
+    rowKeys: Object.freeze([
+      'rowCustomUrlSmsPool',
+    ]),
+  }),
 });
 const HERO_SMS_COUNTRY_SELECTION_MAX = 3;
 
@@ -813,6 +829,7 @@ function getPhoneSmsProviderUiRowMap() {
     rowMaDaoAutoPickCountry,
     rowMaDaoReusePhone,
     rowMaDaoPriceRange,
+    rowCustomUrlSmsPool,
     rowPhoneSmsPreferredPriceControl,
     rowPhoneSmsReuseControl,
   };
@@ -3438,6 +3455,7 @@ function normalizePlusPaymentMethod(value = '') {
   }
 
   const gpcValue = typeof PLUS_PAYMENT_METHOD_GPC_HELPER !== 'undefined' ? PLUS_PAYMENT_METHOD_GPC_HELPER : 'gpc-helper';
+  const autoValue = typeof PLUS_PAYMENT_METHOD_AUTO !== 'undefined' ? PLUS_PAYMENT_METHOD_AUTO : 'plus-auto';
   const paypalValue = typeof PLUS_PAYMENT_METHOD_PAYPAL !== 'undefined' ? PLUS_PAYMENT_METHOD_PAYPAL : 'paypal';
   const paypalHostedValue = typeof PLUS_PAYMENT_METHOD_PAYPAL_HOSTED !== 'undefined' ? PLUS_PAYMENT_METHOD_PAYPAL_HOSTED : 'paypal-hosted';
   const noneValue = typeof PLUS_PAYMENT_METHOD_NONE !== 'undefined' ? PLUS_PAYMENT_METHOD_NONE : 'none';
@@ -3450,6 +3468,9 @@ function normalizePlusPaymentMethod(value = '') {
   }
   if (normalized === gpcValue) {
     return gpcValue;
+  }
+  if (normalized === autoValue || normalized === 'pix' || normalized === 'pix_plus' || normalized === 'pixplus') {
+    return autoValue;
   }
   return paypalValue;
 }
@@ -4668,6 +4689,9 @@ function collectSettingsPayload() {
   const nexSmsApiKeyValue = typeof inputNexSmsApiKey !== 'undefined' && inputNexSmsApiKey
     ? String(inputNexSmsApiKey.value || '')
     : String(latestState?.nexSmsApiKey || '');
+  const customUrlSmsPoolValue = typeof inputCustomUrlSmsPool !== 'undefined' && inputCustomUrlSmsPool
+    ? String(inputCustomUrlSmsPool.value || '')
+    : String(latestState?.customUrlSmsPool || '');
   const maDaoBaseUrlValue = typeof inputMaDaoBaseUrl !== 'undefined' && inputMaDaoBaseUrl
     ? normalizeMaDaoBaseUrlSafe(inputMaDaoBaseUrl.value || latestState?.madaoBaseUrl)
     : normalizeMaDaoBaseUrlSafe(latestState?.madaoBaseUrl);
@@ -5241,6 +5265,9 @@ function collectSettingsPayload() {
     gpcCardKey: typeof inputGpcCardKey !== 'undefined' && inputGpcCardKey
       ? normalizeGpcCardKeyInput(inputGpcCardKey.value || '')
       : normalizeGpcCardKeyInput(latestState?.gpcCardKey || ''),
+    autoCdk: typeof inputAutoCdk !== 'undefined' && inputAutoCdk
+      ? String(inputAutoCdk.value || '').trim()
+      : String(latestState?.autoCdk || '').trim(),
     ...(accountContributionEnabled ? {} : {
       customPassword: inputPassword.value,
     }),
@@ -5336,6 +5363,7 @@ function collectSettingsPayload() {
     nexSmsApiKey: nexSmsApiKeyValue,
     nexSmsCountryOrder: nexSmsCountryOrderValue,
     nexSmsServiceCode: nexSmsServiceCodeValue,
+    customUrlSmsPool: customUrlSmsPoolValue,
     madaoBaseUrl: maDaoBaseUrlValue,
     madaoHttpSecret: maDaoHttpSecretValue,
     madaoMode: maDaoModeValue,
@@ -10806,6 +10834,7 @@ function updatePlusModeUI() {
   const noneValue = typeof PLUS_PAYMENT_METHOD_NONE !== 'undefined' ? PLUS_PAYMENT_METHOD_NONE : 'none';
 
   const gpcValue = typeof PLUS_PAYMENT_METHOD_GPC_HELPER !== 'undefined' ? PLUS_PAYMENT_METHOD_GPC_HELPER : 'gpc-helper';
+  const autoValue = typeof PLUS_PAYMENT_METHOD_AUTO !== 'undefined' ? PLUS_PAYMENT_METHOD_AUTO : 'plus-auto';
   const oauthStrategyValue = typeof PLUS_ACCOUNT_ACCESS_STRATEGY_OAUTH !== 'undefined'
     ? PLUS_ACCOUNT_ACCESS_STRATEGY_OAUTH
     : 'oauth';
@@ -10922,6 +10951,7 @@ function updatePlusModeUI() {
     : method;
   const hostedRowsVisible = enabled && selectedMethod === paypalHostedValue;
   const gpcRowsVisible = enabled && selectedMethod === gpcValue;
+  const autoRowsVisible = enabled && selectedMethod === autoValue;
   if (typeof rowPlusMode !== 'undefined' && rowPlusMode) {
     rowPlusMode.style.display = supportsPlusMode ? '' : 'none';
   }
@@ -10935,6 +10965,8 @@ function updatePlusModeUI() {
     plusPaymentMethodCaption.textContent = method === gpcValue
       ? 'GPC 网页充值链路'
 
+      : method === autoValue
+      ? ''
       : method === noneValue
       ? '已有 Plus，无需配置支付链路'
       : method === paypalHostedValue
@@ -11049,6 +11081,12 @@ function updatePlusModeUI() {
   }
   if (typeof btnGpcCardKeyPurchase !== 'undefined' && btnGpcCardKeyPurchase) {
     btnGpcCardKeyPurchase.style.display = gpcRowsVisible ? '' : 'none';
+  }
+  if (typeof rowAutoCdk !== 'undefined' && rowAutoCdk) {
+    rowAutoCdk.style.display = autoRowsVisible ? '' : 'none';
+  }
+  if (typeof btnAutoCdkPurchase !== 'undefined' && btnAutoCdkPurchase) {
+    btnAutoCdkPurchase.style.display = autoRowsVisible ? '' : 'none';
   }
 
 }
@@ -11961,6 +11999,9 @@ function applySettingsState(state) {
       setGpcCardKeyStatus(inputGpcCardKey.value ? '等待检测' : '等待输入', '');
     }
   }
+  if (typeof inputAutoCdk !== 'undefined' && inputAutoCdk) {
+    inputAutoCdk.value = state?.autoCdk || '';
+  }
   if (typeof inputHostedCheckoutVerificationUrl !== 'undefined' && inputHostedCheckoutVerificationUrl) {
     inputHostedCheckoutVerificationUrl.value = String(state?.hostedCheckoutVerificationUrl || '').trim();
   }
@@ -12321,6 +12362,9 @@ function applySettingsState(state) {
     inputNexSmsServiceCode.value = typeof normalizeNexSmsServiceCodeValue === 'function'
       ? normalizeNexSmsServiceCodeValue(state?.nexSmsServiceCode || defaultNexSmsServiceCode)
       : String(state?.nexSmsServiceCode || defaultNexSmsServiceCode).trim().toLowerCase().replace(/[^a-z0-9_-]+/g, '') || defaultNexSmsServiceCode;
+  }
+  if (typeof inputCustomUrlSmsPool !== 'undefined' && inputCustomUrlSmsPool) {
+    inputCustomUrlSmsPool.value = String(state?.customUrlSmsPool || '');
   }
   if (typeof inputMaDaoBaseUrl !== 'undefined' && inputMaDaoBaseUrl) {
     inputMaDaoBaseUrl.value = normalizeMaDaoBaseUrlValue(state?.madaoBaseUrl);
@@ -16277,6 +16321,13 @@ inputPassword.addEventListener('blur', () => {
 });
 
 inputPlusModeEnabled?.addEventListener('change', () => {
+  // 每次开启 Plus 模式时，支付方式强制重置为默认值（不沿用上次选择）。
+  if (inputPlusModeEnabled.checked
+    && typeof selectPlusPaymentMethod !== 'undefined' && selectPlusPaymentMethod
+    && typeof DEFAULT_PLUS_PAYMENT_METHOD !== 'undefined') {
+    selectPlusPaymentMethod.value = DEFAULT_PLUS_PAYMENT_METHOD;
+    currentPlusPaymentMethod = DEFAULT_PLUS_PAYMENT_METHOD;
+  }
   updatePlusModeUI();
   updateSignupMethodUI({ notify: true });
   const stepDefinitionState = typeof resolveStepDefinitionCapabilityState === 'function'
@@ -16301,6 +16352,10 @@ inputPlusModeEnabled?.addEventListener('change', () => {
 
 btnGpcCardKeyPurchase?.addEventListener('click', () => {
   openExternalUrl('https://pay.ldxp.cn/shop/gpc');
+});
+
+btnAutoCdkPurchase?.addEventListener('click', () => {
+  openExternalUrl('https://shop.qlhazycoder.top/');
 });
 
 btnOpenTargetRepository?.addEventListener('click', () => {
@@ -16378,6 +16433,7 @@ selectPlusPaymentMethod?.addEventListener('change', () => {
   inputHostedCheckoutVerificationUrl,
   inputHostedCheckoutPhone,
   inputPlusHostedCheckoutOauthDelaySeconds,
+  inputAutoCdk,
 ].forEach((input) => {
   input?.addEventListener('input', () => {
     markSettingsDirty(true);
@@ -17678,6 +17734,17 @@ function buildPhoneSmsProviderStatePatch(provider = getSelectedPhoneSmsProvider(
     };
   }
 
+  const customUrlProviderValue = typeof PHONE_SMS_PROVIDER_CUSTOM_URL !== 'undefined'
+    ? PHONE_SMS_PROVIDER_CUSTOM_URL
+    : 'custom-url';
+  if (normalizedProvider === customUrlProviderValue) {
+    return {
+      customUrlSmsPool: typeof inputCustomUrlSmsPool !== 'undefined' && inputCustomUrlSmsPool
+        ? String(inputCustomUrlSmsPool.value || '')
+        : String(latestState?.customUrlSmsPool || ''),
+    };
+  }
+
   const currentSelection = typeof getPhoneSmsCountrySelectionForProvider === 'function'
     ? getPhoneSmsCountrySelectionForProvider(PHONE_SMS_PROVIDER_HERO_SMS, { ensureDefault: true })
     : [];
@@ -17985,6 +18052,14 @@ inputNexSmsApiKey?.addEventListener('input', () => {
   scheduleSettingsAutoSave();
 });
 inputNexSmsApiKey?.addEventListener('blur', () => {
+  saveSettings({ silent: true }).catch(() => { });
+});
+
+inputCustomUrlSmsPool?.addEventListener('input', () => {
+  markSettingsDirty(true);
+  scheduleSettingsAutoSave();
+});
+inputCustomUrlSmsPool?.addEventListener('blur', () => {
   saveSettings({ silent: true }).catch(() => { });
 });
 
@@ -18959,6 +19034,9 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
       }
       if (message.payload.gpcCardKey !== undefined && inputGpcCardKey) {
         inputGpcCardKey.value = message.payload.gpcCardKey || '';
+      }
+      if (message.payload.autoCdk !== undefined && typeof inputAutoCdk !== 'undefined' && inputAutoCdk) {
+        inputAutoCdk.value = message.payload.autoCdk || '';
       }
       if (
         message.payload.gpcBalance !== undefined

--- a/tests/background-account-history-settings.test.js
+++ b/tests/background-account-history-settings.test.js
@@ -50,8 +50,8 @@ function extractFunction(name) {
   return source.slice(start, end);
 }
 
-test('background defaults Plus payment method to GPC', () => {
-  assert.match(source, /const DEFAULT_PLUS_PAYMENT_METHOD = PLUS_PAYMENT_METHOD_GPC_HELPER;/);
+test('background defaults Plus payment method to Auto', () => {
+  assert.match(source, /const DEFAULT_PLUS_PAYMENT_METHOD = PLUS_PAYMENT_METHOD_AUTO;/);
   assert.match(source, /plusPaymentMethod: DEFAULT_PLUS_PAYMENT_METHOD/);
 });
 

--- a/tests/custom-url-provider.test.js
+++ b/tests/custom-url-provider.test.js
@@ -1,0 +1,119 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const source = fs.readFileSync('phone-sms/providers/custom-url.js', 'utf8');
+const api = new Function('self', `${source}; return self.PhoneSmsCustomUrlProvider;`)({});
+
+function createTextResponse(payload, ok = true, status = ok ? 200 : 400) {
+  return {
+    ok,
+    status,
+    text: async () => (typeof payload === 'string' ? payload : JSON.stringify(payload)),
+  };
+}
+
+test('custom-url parses the phone----url pool, skipping malformed lines', () => {
+  const pool = api.parseSmsPool([
+    '16292387346----https://app.yuntl.cc/apisms/abc',
+    '  16292387347 ---- https://app.yuntl.cc/apisms/def  ',
+    'missing-separator-line',
+    '12345----not-a-url',
+    '16292387346----https://app.yuntl.cc/apisms/abc',
+  ].join('\n'));
+  assert.equal(pool.length, 2);
+  assert.deepEqual(pool[0], { phoneNumber: '16292387346', codeUrl: 'https://app.yuntl.cc/apisms/abc' });
+  assert.equal(pool[1].phoneNumber, '16292387347');
+});
+
+test('custom-url extracts 6-digit code from body, ignoring expiry date noise', () => {
+  // 实测「暂无短信」格式
+  assert.equal(api.extractVerificationCode('暂无短信|链接到期时间2026-07-01 23:59:59，续费请提前联系客服'), '');
+  assert.equal(api.isNoSmsResponse('暂无短信|链接到期时间2026-07-01 23:59:59'), true);
+  // 含验证码
+  assert.equal(api.extractVerificationCode('您的验证码是 123456，请勿泄露|到期2026-07-01'), '123456');
+  assert.equal(api.isNoSmsResponse('您的验证码是 123456|到期2026-07-01'), false);
+  // JSON 兜底
+  assert.equal(api.extractVerificationCode('{"code":"654321","msg":"ok"}'), '654321');
+});
+
+test('custom-url requestActivation walks the pool in order and advances the cursor', async () => {
+  const setStateCalls = [];
+  const provider = api.createProvider({
+    setState: async (patch) => { setStateCalls.push(patch); },
+    addLog: async () => {},
+  });
+  const state = {
+    customUrlSmsPool: '111----https://a.test/1\n222----https://a.test/2\n333----https://a.test/3',
+    customUrlSmsPoolCursor: 0,
+  };
+
+  const first = await provider.requestActivation(state, {});
+  assert.equal(first.phoneNumber, '111');
+  assert.equal(first.codeUrl, 'https://a.test/1');
+  assert.equal(first.provider, 'custom-url');
+  assert.equal(setStateCalls[0].customUrlSmsPoolCursor, 1);
+
+  // 模拟游标推进
+  const second = await provider.requestActivation({ ...state, customUrlSmsPoolCursor: 1 }, {});
+  assert.equal(second.phoneNumber, '222');
+  assert.equal(setStateCalls[1].customUrlSmsPoolCursor, 2);
+
+  // 用完一圈后从头复用
+  const wrap = await provider.requestActivation({ ...state, customUrlSmsPoolCursor: 3 }, {});
+  assert.equal(wrap.phoneNumber, '111', '游标超出长度应回到第一个');
+});
+
+test('custom-url requestActivation throws when the pool is empty', async () => {
+  const provider = api.createProvider({ setState: async () => {} });
+  await assert.rejects(
+    () => provider.requestActivation({ customUrlSmsPool: '' }, {}),
+    /号码池为空/,
+  );
+});
+
+test('custom-url pollActivationCode returns the code once SMS arrives', async () => {
+  const responses = [
+    '暂无短信|到期2026-07-01',
+    '暂无短信|到期2026-07-01',
+    '【ChatGPT】验证码 246810，10分钟内有效|到期2026-07-01',
+  ];
+  let index = 0;
+  const provider = api.createProvider({
+    fetchImpl: async () => createTextResponse(responses[Math.min(index++, responses.length - 1)]),
+    sleepWithStop: async () => {},
+    throwIfStopped: () => {},
+  });
+  const code = await provider.pollActivationCode(
+    {},
+    { phoneNumber: '111', codeUrl: 'https://a.test/1' },
+    { timeoutMs: 60000, intervalMs: 1 },
+  );
+  assert.equal(code, '246810');
+  assert.equal(index, 3, '应轮询到第 3 次才拿到码');
+});
+
+test('custom-url pollActivationCode times out when no code arrives', async () => {
+  const provider = api.createProvider({
+    fetchImpl: async () => createTextResponse('暂无短信|到期2026-07-01'),
+    sleepWithStop: async () => {},
+    throwIfStopped: () => {},
+  });
+  await assert.rejects(
+    () => provider.pollActivationCode(
+      {},
+      { phoneNumber: '111', codeUrl: 'https://a.test/1' },
+      { timeoutMs: 10, intervalMs: 1, maxRounds: 2 },
+    ),
+    /PHONE_CODE_TIMEOUT::/,
+  );
+});
+
+test('custom-url lifecycle hooks are no-ops and require no country selection', async () => {
+  const provider = api.createProvider({});
+  assert.equal(provider.capabilities.requiresCountrySelection, false);
+  assert.equal(await provider.cancelActivation({}, {}), '');
+  assert.equal(await provider.banActivation({}, {}), '');
+  assert.equal(await provider.finishActivation({}, {}), '');
+  assert.deepEqual(provider.resolveCountryCandidates(), []);
+});

--- a/tests/gpc-utils.test.js
+++ b/tests/gpc-utils.test.js
@@ -15,8 +15,30 @@ test('GPC utils keeps supported Plus payment methods distinct and normalizes leg
   assert.equal(api.normalizePlusPaymentMethod('none'), 'none');
   assert.equal(api.normalizePlusPaymentMethod('no-payment'), 'none');
   assert.equal(api.normalizePlusPaymentMethod('gpc-helper'), 'gpc-helper');
+  assert.equal(api.normalizePlusPaymentMethod('plus-auto'), 'plus-auto');
+  assert.equal(api.normalizePlusPaymentMethod('pix'), 'plus-auto');
+  assert.equal(api.normalizePlusPaymentMethod('pixplus'), 'plus-auto');
   assert.equal(api.normalizePlusPaymentMethod('gopay'), 'paypal');
   assert.equal(api.normalizePlusPaymentMethod('unknown'), 'paypal');
+});
+
+test('GPC utils normalizes Auto base URL and cdk, and builds Auto API URLs', () => {
+  const api = loadGpcUtils();
+  assert.equal(api.DEFAULT_AUTO_BASE_URL, 'https://auto.1iiu.com');
+  assert.equal(api.PLUS_PAYMENT_METHOD_AUTO, 'plus-auto');
+  assert.equal(api.normalizeAutoBaseUrl(''), 'https://auto.1iiu.com');
+  assert.equal(api.normalizeAutoBaseUrl('https://auto.1iiu.com/'), 'https://auto.1iiu.com');
+  assert.equal(api.normalizeAutoBaseUrl('not a url'), 'https://auto.1iiu.com');
+  assert.equal(api.normalizeAutoBaseUrl('https://custom.example.com/base/'), 'https://custom.example.com/base');
+  assert.equal(api.normalizeAutoCdk(' QZ-aB12-Cd34-Ef56 '), 'QZ-aB12-Cd34-Ef56');
+  assert.equal(
+    api.buildAutoApiUrl('https://auto.1iiu.com', '/api/v1/redeem'),
+    'https://auto.1iiu.com/api/v1/redeem'
+  );
+  assert.equal(
+    api.buildAutoApiUrl('', 'api/v1/orders/12'),
+    'https://auto.1iiu.com/api/v1/orders/12'
+  );
 });
 
 test('GPC utils builds card balance URLs from portal endpoints', () => {

--- a/tests/phone-sms-provider-registry.test.js
+++ b/tests/phone-sms-provider-registry.test.js
@@ -24,16 +24,22 @@ test('phone sms provider registry normalizes ids, order and labels consistently'
     PhoneSmsMaDaoProvider: {
       createProvider: (deps = {}) => ({ provider: 'madao', deps }),
     },
+    PhoneSmsCustomUrlProvider: {
+      createProvider: (deps = {}) => ({ provider: 'custom-url', deps }),
+    },
   });
 
-  assert.deepStrictEqual(registry.getProviderIds(), ['hero-sms', '5sim', 'nexsms', 'madao']);
+  assert.deepStrictEqual(registry.getProviderIds(), ['hero-sms', '5sim', 'nexsms', 'madao', 'custom-url']);
   assert.equal(registry.normalizeProviderId(' NEXSMS '), 'nexsms');
   assert.equal(registry.normalizeProviderId(' MaDao '), 'madao');
+  assert.equal(registry.normalizeProviderId(' Custom-URL '), 'custom-url');
   assert.equal(registry.normalizeProviderId('unknown-provider'), 'hero-sms');
   assert.equal(registry.getProviderLabel('nexsms'), 'NexSMS');
   assert.equal(registry.getProviderLabel('madao'), 'MaDao');
+  assert.equal(registry.getProviderLabel('custom-url'), '自定义 URL 接码');
   assert.equal(registry.getProviderDefinition('nexsms').moduleKey, 'PhoneSmsNexSmsProvider');
   assert.equal(registry.getProviderDefinition('madao').moduleKey, 'PhoneSmsMaDaoProvider');
+  assert.equal(registry.getProviderDefinition('custom-url').moduleKey, 'PhoneSmsCustomUrlProvider');
   assert.deepStrictEqual(
     registry.normalizeProviderOrder([
       { provider: 'madao' },

--- a/tests/plus-auto-billing.test.js
+++ b/tests/plus-auto-billing.test.js
@@ -1,0 +1,137 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+// 加载 gpc-utils（提供 Plus 自动充值归一化）与 fill-plus-checkout 模块。
+const gpcUtilsSource = fs.readFileSync('gpc-utils.js', 'utf8');
+const source = fs.readFileSync('flows/openai/background/steps/fill-plus-checkout.js', 'utf8');
+const globalScope = {};
+new Function('self', `${gpcUtilsSource};`)(globalScope);
+const api = new Function('self', `${source}; return self.MultiPageBackgroundPlusCheckoutBilling;`)(globalScope);
+
+// responses：按轮询次数依次返回 { status, payload }（最后一个重复）。
+// 默认 status=200。fetch 会按请求 URL 区分 jobs/logs 与 orders。
+function createBillingHarness({ responses = [] } = {}) {
+  const logs = [];
+  const stateUpdates = [];
+  const completedNodes = [];
+  const fetchedUrls = [];
+  let pollIndex = 0;
+
+  const deps = {
+    addLog: async (message, level = 'info') => { logs.push({ message, level }); },
+    chrome: { tabs: { update: async () => ({}) } },
+    completeNodeFromBackground: async (key, payload = {}) => { completedNodes.push({ key, payload }); },
+    ensureContentScriptReadyOnTabUntilStopped: async () => {},
+    fetch: async (url) => {
+      fetchedUrls.push(String(url));
+      const idx = Math.min(pollIndex, responses.length - 1);
+      pollIndex += 1;
+      const entry = responses[idx] || { payload: {} };
+      const status = entry.status || 200;
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        text: async () => JSON.stringify(entry.payload ?? {}),
+      };
+    },
+    getState: async () => ({}),
+    getTabId: async () => 0,
+    isTabAlive: async () => false,
+    setState: async (patch) => { stateUpdates.push(patch); },
+    sleepWithStop: async () => {},
+    waitForTabCompleteUntilStopped: async () => {},
+    throwIfStopped: () => {},
+  };
+
+  const executor = api.createPlusCheckoutBillingExecutor(deps);
+  return { executor, logs, stateUpdates, completedNodes, fetchedUrls, getPollCount: () => pollIndex };
+}
+
+const AUTO_STATE = { plusPaymentMethod: 'plus-auto', autoOrderId: '12', autoJobId: 'job-abc', autoTimeoutSeconds: 60 };
+
+test('Plus 自动充值轮询 jobs/logs：queued → running → done 判成功并渲染进度日志', async () => {
+  const { executor, completedNodes, fetchedUrls, logs, getPollCount } = createBillingHarness({
+    responses: [
+      { payload: { state: 'queued', logs: [{ t: '14:22:01', msg: '🔑 已解析账号', key: 'parsed' }] } },
+      { payload: { state: 'running', logs: [
+        { t: '14:22:01', msg: '🔑 已解析账号', key: 'parsed' },
+        { t: '14:22:25', msg: '⏳ 结账中…（已等 20s）', key: 'checkout' },
+      ] } },
+      { payload: { state: 'done', email: 'user@example.com', logs: [
+        { t: '14:22:01', msg: '🔑 已解析账号', key: 'parsed' },
+        { t: '14:22:25', msg: '⏳ 结账中…（已等 20s）', key: 'checkout' },
+        { t: '14:23:16', msg: '🚀 开通 Plus 成功', key: 'done_ok' },
+      ] } },
+    ],
+  });
+
+  await executor.executePlusCheckoutBilling(AUTO_STATE);
+
+  assert.equal(getPollCount(), 3, '应轮询 3 次');
+  assert.ok(fetchedUrls.every((u) => u.includes('/api/v1/jobs/job-abc/logs')), '应轮询 jobs/logs 接口');
+  const completion = completedNodes.find((node) => node.key === 'plus-checkout-billing');
+  assert.ok(completion, '应完成 plus-checkout-billing 节点');
+  // 进度日志增量渲染：每条 msg 只输出一次
+  assert.ok(logs.some((l) => l.message.includes('🚀 开通 Plus 成功')), '应渲染成功进度');
+  const parsedCount = logs.filter((l) => l.message.includes('🔑 已解析账号')).length;
+  assert.equal(parsedCount, 1, '同一条进度日志不应重复渲染');
+});
+
+test('Plus 自动充值轮询：done_already（账号已是 Plus）也判成功', async () => {
+  const { executor, completedNodes } = createBillingHarness({
+    responses: [{ payload: { state: 'done', logs: [{ t: '14:22:05', msg: '✅ 该账号已是 Plus', key: 'done_already' }] } }],
+  });
+  await executor.executePlusCheckoutBilling(AUTO_STATE);
+  assert.ok(completedNodes.some((node) => node.key === 'plus-checkout-billing'));
+});
+
+test('Plus 自动充值轮询：state=failed 时按 error_key 给出友好提示', async () => {
+  const { executor } = createBillingHarness({
+    responses: [{ payload: { state: 'failed', error_key: 'err_no_trial', error: '❌ 该账号无免费试用资格' } }],
+  });
+  await assert.rejects(
+    () => executor.executePlusCheckoutBilling(AUTO_STATE),
+    /无免费试用资格/,
+  );
+});
+
+test('Plus 自动充值轮询：job 404 时回退到 orders 终态查询并成功', async () => {
+  const { executor, completedNodes, fetchedUrls } = createBillingHarness({
+    responses: [
+      { status: 404, payload: { error: 'job not found or expired' } },
+      { payload: { state: 'done', payment_status: 'paid', email: 'u@e.com' } },
+    ],
+  });
+  await executor.executePlusCheckoutBilling(AUTO_STATE);
+  assert.ok(fetchedUrls.some((u) => u.includes('/api/v1/jobs/')), '先查 jobs/logs');
+  assert.ok(fetchedUrls.some((u) => u.includes('/api/v1/orders/12')), '404 后回退 orders');
+  assert.ok(completedNodes.some((node) => node.key === 'plus-checkout-billing'));
+});
+
+test('Plus 自动充值轮询：无 job_id 时直接走 orders 终态轮询', async () => {
+  const { executor, completedNodes, fetchedUrls } = createBillingHarness({
+    responses: [{ payload: { state: 'done', payment_status: 'paid' } }],
+  });
+  await executor.executePlusCheckoutBilling({ plusPaymentMethod: 'plus-auto', autoOrderId: '12', autoTimeoutSeconds: 60 });
+  assert.ok(fetchedUrls.every((u) => u.includes('/api/v1/orders/12')), '应仅查 orders 接口');
+  assert.ok(completedNodes.some((node) => node.key === 'plus-checkout-billing'));
+});
+
+test('Plus 自动充值轮询：缺少订单号时抛错', async () => {
+  const { executor } = createBillingHarness({ responses: [{ payload: { state: 'done' } }] });
+  await assert.rejects(
+    () => executor.executePlusCheckoutBilling({ plusPaymentMethod: 'plus-auto', autoOrderId: '' }),
+    /缺少 Plus 自动充值订单号/,
+  );
+});
+
+test('Plus 自动充值轮询：jobs/logs 非 404 错误时抛错', async () => {
+  const { executor } = createBillingHarness({
+    responses: [{ status: 500, payload: { error: '服务器错误' } }],
+  });
+  await assert.rejects(
+    () => executor.executePlusCheckoutBilling(AUTO_STATE),
+    /查询进度失败/,
+  );
+});

--- a/tests/plus-auto-create.test.js
+++ b/tests/plus-auto-create.test.js
@@ -1,0 +1,124 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+// 加载 gpc-utils（提供 Plus 自动充值归一化）与 create-plus-checkout 模块。
+const gpcUtilsSource = fs.readFileSync('gpc-utils.js', 'utf8');
+const source = fs.readFileSync('flows/openai/background/steps/create-plus-checkout.js', 'utf8');
+const globalScope = {};
+new Function('self', `${gpcUtilsSource};`)(globalScope);
+const api = new Function('self', `${source}; return self.MultiPageBackgroundPlusCheckoutCreate;`)(globalScope);
+
+function createExecutorHarness({ redeemResponse, redeemStatus = 200, session = { accessToken: 'eyJ-token' } } = {}) {
+  const logs = [];
+  const stateUpdates = [];
+  const completedNodes = [];
+  const fetchCalls = [];
+  let nextTabId = 9001;
+
+  const deps = {
+    addLog: async (message, level = 'info') => { logs.push({ message, level }); },
+    chrome: {
+      tabs: {
+        create: async () => ({ id: nextTabId }),
+        update: async () => ({}),
+        remove: async () => ({}),
+        get: async (id) => ({ id, url: 'https://chatgpt.com/' }),
+      },
+    },
+    completeNodeFromBackground: async (key, payload = {}) => { completedNodes.push({ key, payload }); },
+    createAutomationTab: async () => ({ id: nextTabId }),
+    ensureContentScriptReadyOnTabUntilStopped: async () => {},
+    fetch: async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      return {
+        ok: redeemStatus >= 200 && redeemStatus < 300,
+        status: redeemStatus,
+        json: async () => redeemResponse,
+        text: async () => JSON.stringify(redeemResponse),
+      };
+    },
+    registerTab: async () => {},
+    sendTabMessageUntilStopped: async (_tabId, _source, message) => {
+      // PLUS_CHECKOUT_GET_STATE 用于读取 session。
+      if (message?.type === 'PLUS_CHECKOUT_GET_STATE') {
+        return { session, accessToken: session?.accessToken || '' };
+      }
+      return {};
+    },
+    setState: async (patch) => { stateUpdates.push(patch); },
+    sleepWithStop: async () => {},
+    waitForTabCompleteUntilStopped: async () => {},
+    throwIfStopped: () => {},
+  };
+
+  const executor = api.createPlusCheckoutCreateExecutor(deps);
+  return { executor, logs, stateUpdates, completedNodes, fetchCalls };
+}
+
+test('Plus 自动充值发起：成功返回 order_id 时存储订单并完成节点', async () => {
+  const { executor, stateUpdates, completedNodes, fetchCalls } = createExecutorHarness({
+    redeemResponse: { order_id: 12, job_id: 'job-abc', state: 'queued', remaining: 2 },
+  });
+
+  await executor.executePlusCheckoutCreate({
+    plusPaymentMethod: 'plus-auto',
+    autoCdk: '  QZ-aB12-Cd34-Ef56  ',
+  });
+
+  // 调用了固定内置端点的 redeem 接口（不接受用户自定义地址）
+  const redeemCall = fetchCalls.find((call) => String(call.url).includes('/api/v1/redeem'));
+  assert.ok(redeemCall, '应调用 /api/v1/redeem');
+  assert.ok(String(redeemCall.url).startsWith('https://auto.1iiu.com/api/v1/redeem'), '应使用内置 Plus 自动充值端点');
+  const body = JSON.parse(redeemCall.options.body);
+  assert.equal(body.cdk, 'QZ-aB12-Cd34-Ef56', 'cdk 应去首尾空白但保留原始大小写');
+  assert.ok(body.access_token.includes('eyJ-token'), 'access_token 应包含 session');
+
+  // 订单号写入 state
+  const orderState = stateUpdates.find((patch) => patch.autoOrderId);
+  assert.equal(orderState.autoOrderId, '12');
+  assert.equal(orderState.plusCheckoutSource, 'plus-auto');
+
+  // 完成节点
+  const completion = completedNodes.find((node) => node.key === 'plus-checkout-create');
+  assert.ok(completion, '应完成 plus-checkout-create 节点');
+  assert.equal(completion.payload.autoOrderId, '12');
+});
+
+test('Plus 自动充值发起：卡密无效返回 400 时抛错', async () => {
+  const { executor } = createExecutorHarness({
+    redeemResponse: { error: '卡密已用完' },
+    redeemStatus: 400,
+  });
+
+  await assert.rejects(
+    () => executor.executePlusCheckoutCreate({
+      plusPaymentMethod: 'plus-auto',
+      autoCdk: 'QZ-USED0000000',
+    }),
+    /卡密已用完/,
+  );
+});
+
+test('Plus 自动充值发起：缺少卡密时抛错', async () => {
+  const { executor } = createExecutorHarness({ redeemResponse: {} });
+
+  await assert.rejects(
+    () => executor.executePlusCheckoutCreate({ plusPaymentMethod: 'plus-auto', autoCdk: '' }),
+    /缺少卡密/,
+  );
+});
+
+test('Plus 自动充值发起：返回缺少 order_id 时抛错', async () => {
+  const { executor } = createExecutorHarness({
+    redeemResponse: { state: 'queued' },
+  });
+
+  await assert.rejects(
+    () => executor.executePlusCheckoutCreate({
+      plusPaymentMethod: 'plus-auto',
+      autoCdk: 'QZ-NOORDER0000',
+    }),
+    /不可用响应/,
+  );
+});

--- a/tests/sidepanel-phone-verification-settings.test.js
+++ b/tests/sidepanel-phone-verification-settings.test.js
@@ -963,6 +963,7 @@ const rowMaDaoOperator = { style: { display: 'none' } };
 const rowMaDaoAutoPickCountry = { style: { display: 'none' } };
 const rowMaDaoReusePhone = { style: { display: 'none' } };
 const rowMaDaoPriceRange = { style: { display: 'none' } };
+const rowCustomUrlSmsPool = { style: { display: 'none' } };
 const rowHeroSmsRuntimePair = { style: { display: 'none' } };
 const rowHeroSmsCurrentNumber = { style: { display: 'none' } };
 const rowHeroSmsCurrentCountdown = { style: { display: 'none' } };
@@ -1165,6 +1166,7 @@ return {
   rowMaDaoAutoPickCountry,
   rowMaDaoReusePhone,
   rowMaDaoPriceRange,
+  rowCustomUrlSmsPool,
   rowPhoneSmsPreferredPriceControl,
   rowPhoneSmsReuseControl,
   rowPhoneCodeFailureTopic,

--- a/tests/sidepanel-plus-payment-method.test.js
+++ b/tests/sidepanel-plus-payment-method.test.js
@@ -62,12 +62,11 @@ function extractLastFunction(name) {
   return sidepanelSource.slice(start, end);
 }
 
-test('sidepanel defaults Plus payment method to GPC', () => {
-  assert.match(sidepanelSource, /const DEFAULT_PLUS_PAYMENT_METHOD = PLUS_PAYMENT_METHOD_GPC_HELPER;/);
+test('sidepanel defaults Plus payment method to Auto', () => {
+  assert.match(sidepanelSource, /const DEFAULT_PLUS_PAYMENT_METHOD = PLUS_PAYMENT_METHOD_AUTO;/);
   assert.match(sidepanelSource, /currentPlusPaymentMethod = DEFAULT_PLUS_PAYMENT_METHOD/);
   assert.match(sidepanelSource, /state\?\.plusPaymentMethod \|\| DEFAULT_PLUS_PAYMENT_METHOD/);
-  assert.match(sidepanelHtml, /<option value="gpc-helper" selected>GPC<\/option>/);
-  assert.match(sidepanelHtml, /id="plus-payment-method-caption">GPC 网页充值链路<\/span>/);
+  assert.match(sidepanelHtml, /<option value="plus-auto" selected>Plus 自动充值<\/option>/);
 });
 
 test('sidepanel step definitions normalize legacy gopay payment method to PayPal', () => {
@@ -469,6 +468,66 @@ return {
   assert.equal(api.btnGpcCardKeyPurchase.style.display, 'none');
   assert.equal(api.rows.rowGpcCardKey.style.display, 'none');
   assert.equal(api.rowPayPalAccount.style.display, '');
+});
+
+test('sidepanel Plus UI shows auto-charge fields only for the auto payment method', () => {
+  const bundle = [
+    extractFunction('normalizePlusPaymentMethod'),
+    extractFunction('normalizePlusAccountAccessStrategy'),
+    extractFunction('getSelectedPlusPaymentMethod'),
+    extractFunction('getRequestedPlusAccountAccessStrategy'),
+    extractFunction('updatePlusModeUI'),
+  ].join('\n');
+
+  const api = new Function(`
+let latestState = { plusPaymentMethod: 'plus-auto' };
+let currentPlusPaymentMethod = 'paypal';
+let currentPlusAccountAccessStrategy = 'oauth';
+const inputPlusModeEnabled = { checked: true };
+const selectPlusPaymentMethod = { value: 'plus-auto', style: { display: 'none' } };
+const PLUS_PAYMENT_METHOD_AUTO = 'plus-auto';
+const PLUS_ACCOUNT_ACCESS_STRATEGY_OAUTH = 'oauth';
+const PLUS_ACCOUNT_ACCESS_STRATEGY_SUB2API_CODEX_SESSION = 'sub2api_codex_session';
+const PLUS_ACCOUNT_ACCESS_STRATEGY_CPA_CODEX_SESSION = 'cpa_codex_session';
+const DEFAULT_PLUS_ACCOUNT_ACCESS_STRATEGY = PLUS_ACCOUNT_ACCESS_STRATEGY_OAUTH;
+const plusPaymentMethodCaption = { textContent: '' };
+const rowPayPalAccount = { style: { display: '' } };
+const rowGpcCardKey = { style: { display: '' } };
+const rowAutoCdk = { style: { display: 'none' } };
+const btnAutoCdkPurchase = { style: { display: 'none' } };
+${bundle}
+return {
+  updatePlusModeUI,
+  selectPlusPaymentMethod,
+  plusPaymentMethodCaption,
+  rows: { rowGpcCardKey, rowAutoCdk, rowPayPalAccount },
+  btnAutoCdkPurchase,
+};
+`)();
+
+  api.updatePlusModeUI();
+
+  assert.equal(api.rows.rowAutoCdk.style.display, '');
+  assert.equal(api.rows.rowGpcCardKey.style.display, 'none');
+  assert.equal(api.rows.rowPayPalAccount.style.display, 'none');
+  assert.equal(api.plusPaymentMethodCaption.textContent, '', 'Plus 自动充值不显示说明文字');
+  assert.equal(api.btnAutoCdkPurchase.style.display, '', 'Plus 自动充值显示获取卡密按钮');
+
+  api.selectPlusPaymentMethod.value = 'gpc-helper';
+  api.updatePlusModeUI();
+  assert.equal(api.rows.rowAutoCdk.style.display, 'none');
+  assert.equal(api.btnAutoCdkPurchase.style.display, 'none', '非 Plus 自动充值隐藏获取卡密按钮');
+  assert.equal(api.rows.rowGpcCardKey.style.display, '');
+});
+
+test('sidepanel HTML exposes the auto payment option and config rows', () => {
+  assert.match(sidepanelHtml, /<option value="plus-auto" selected>Plus 自动充值<\/option>/);
+  assert.match(sidepanelHtml, /id="row-auto-cdk"/);
+  assert.match(sidepanelHtml, /id="input-auto-cdk"/);
+  // Plus 自动充值接口地址固定内置，不在 UI 暴露。
+  assert.doesNotMatch(sidepanelHtml, /id="input-auto-base-url"/);
+  // 「获取卡密」按钮
+  assert.match(sidepanelHtml, /id="btn-auto-cdk-purchase"[^>]*>获取卡密</);
 });
 
 test('sidepanel start check only requires a GPC card key', async () => {

--- a/tests/step-definitions-module.test.js
+++ b/tests/step-definitions-module.test.js
@@ -679,11 +679,11 @@ test('sidepanel html exposes Plus mode, PayPal, no-payment, and GPC settings', (
   const plusPaymentSelect = getSelectMarkup(visibleHtml, 'select-plus-payment-method');
   assert.match(html, /id="input-plus-mode-enabled"/);
   assert.match(html, /id="select-plus-payment-method"/);
-  assert.match(plusPaymentSelect, /<option value="gpc-helper" selected>GPC<\/option>/);
+  assert.match(plusPaymentSelect, /<option value="plus-auto" selected>Plus 自动充值<\/option>/);
   assert.match(html, /<option value="none">无需支付<\/option>/);
   assert.match(html, /id="select-paypal-account"/);
   assert.match(html, /id="btn-add-paypal-account"/);
-  assert.match(html, /<option value="gpc-helper" selected>GPC<\/option>/);
+  assert.match(html, /<option value="plus-auto" selected>Plus 自动充值<\/option>/);
   assert.match(html, /id="btn-gpc-card-key-purchase"/);
   assert.match(html, /id="btn-gpc-card-key-query"/);
   assert.match(html, />购买卡密</);


### PR DESCRIPTION
## 概述

本 PR 新增两项独立服务能力，均复用现有的渠道注册 / 步骤编排 / 设置持久化 / 侧边栏 UI 架构，未改动既有支付方式与接码平台的行为：

1. **Plus 自助开通渠道**（`plus-auto`）—— OpenAI Plus 自动开通的新方式
2. **自定义 URL 接码服务商**（`custom-url`）—— 用户自带号码池的收码方式

---

## 一、Plus 自助开通渠道（`plus-auto`）

为 Plus 模式新增支付方式「Plus 自动充值」并设为默认。流程与现有渠道同构（发起 → 轮询等待完成 → 后续登录接入），仅新增渠道专属两步，复用其余所有步骤。

### 工作流程
- **发起开通**：自动读取当前 ChatGPT 账号的完整 session，调用开通接口 `POST /api/v1/redeem`（卡密 + access_token）提交订单，返回订单号 / 任务号。此步仅表示订单已提交（排队中），不代表开通成功。
- **等待完成**：主轮询 `GET /api/v1/jobs/{job_id}/logs` 实时渲染开通进度（校验 → 上传 → 出码 → 付款 → 成功）；任务过期（404）后回退查 `GET /api/v1/orders/{order_id}` 终态。`state=done` 判成功（含账号本就是 Plus 的情况），`state=failed` 按稳定 `error_key` 给出友好提示。
- 接口域名固定内置，不暴露给用户；用户仅需填写卡密（`QZ-XXXX-XXXX-XXXX`，原样传输、不改大小写）。

### 交互
- 支付方式下拉新增「Plus 自动充值」并设为默认；每次开启 Plus 模式时强制重置为默认值，不沿用上次选择。
- 选中时提供「获取卡密」按钮，跳转购卡页面。

### 主要改动
- `flows/openai/background/steps/create-plus-checkout.js`：发起开通逻辑
- `flows/openai/background/steps/fill-plus-checkout.js`：轮询进度 / 终态判定
- `flows/openai/workflow.js`：渠道步骤变体编排与路由
- `gpc-utils.js`：渠道常量、卡密 / baseURL 归一化、URL 构造
- `background.js` / `core/flow-kernel/settings-schema.js` / `flows/openai/index.js`：默认值与设置持久化
- `background/message-router.js`：切换日志的支付方式标签
- `sidepanel/sidepanel.html` `sidepanel/sidepanel.js`：下拉、卡密输入、获取卡密按钮、显隐与持久化

---

## 二、自定义 URL 接码服务商（`custom-url`）

新增「自定义 URL 接码」服务商。区别于现有买号型平台——**用户自带号码池**，扩展不购买号码，仅负责填号、轮询用户提供的取码 URL、用正则提取验证码。

### 工作方式
- 用户在号码池文本框按 `手机号----取码URL` 格式逐行粘贴；按顺序轮流使用，用完一轮从头循环复用（游标持久化，避免同号短时间内重复使用）。
- 收码时直接 GET 用户提供的 URL，取分隔符左侧短信正文段，用正则提取 6 位验证码（避开返回内容里的到期时间等干扰），无短信则继续轮询。
- 无购买 / 复用 / 取消等平台操作，生命周期 hook 均为空操作；不需要选择国家。

### 主要改动
- `phone-sms/providers/custom-url.js`：新增 provider 实现
- `phone-sms/providers/registry.js`：注册服务商
- `background.js`（importScripts、默认值与归一化）、`background/phone-verification-flow.js`（设置字段）
- `sidepanel/sidepanel.html` `sidepanel/sidepanel.js`：服务商下拉、号码池输入、显隐与持久化

---

## 测试
- 新增：`tests/plus-auto-create.test.js`、`tests/plus-auto-billing.test.js`、`tests/custom-url-provider.test.js`
- 扩展：`tests/gpc-utils.test.js`、`tests/sidepanel-plus-payment-method.test.js`、`tests/phone-sms-provider-registry.test.js` 等
- 全量 `node --test tests/*.test.js` 通过，无新增回归。

## 兼容性
- 纯新增 + 配套调整，未改动既有支付方式 / 接码平台行为。
- 保留旧标识符别名用于设置迁移，旧保存值可正确映射到新渠道。
- 扩展为手写 Service Worker（`importScripts` 加载），无构建步骤。
